### PR TITLE
chore: updated code to accomodate for latest nimbus

### DIFF
--- a/core/identity-hub/src/main/java/org/eclipse/edc/identityhub/processor/CollectionsWriteProcessor.java
+++ b/core/identity-hub/src/main/java/org/eclipse/edc/identityhub/processor/CollectionsWriteProcessor.java
@@ -93,7 +93,7 @@ public class CollectionsWriteProcessor implements MessageProcessor {
             var jwt = SignedJWT.parse(new String(data));
             var vcClaim = Optional.ofNullable(jwt.getJWTClaimsSet().getClaim(VERIFIABLE_CREDENTIALS_KEY))
                     .orElseThrow(() -> new EdcException("Missing `vc` claim in signed JWT"));
-            mapper.readValue(vcClaim.toString(), VerifiableCredential.class);
+            mapper.convertValue(vcClaim, VerifiableCredential.class);
         } catch (Exception e) {
             return Result.failure("Failed to parse Verifiable Credential: " + e.getMessage());
         }


### PR DESCRIPTION
## What this PR changes/adds

Adds a small code change to accomodate for changes done upstream due to the upgrade to Nimbus 9.


## Why it does that

compatibility

## Further notes

- Nimbus 9 gets shipped with the latest SNAPSHOT of the VersionCatalog, which was merged in https://github.com/eclipse-edc/GradlePlugins/pull/62

## Linked Issue(s)

Closes #https://github.com/eclipse-edc/Connector/issues/2302
