### PR TITLE
build(deps): remove unnecessary bouncycastle dependencies

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -3,8 +3,6 @@ name: Test Code (Style, Tests)
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/client-cli/build.gradle.kts
+++ b/client-cli/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.okhttp)
     implementation(libs.nimbus.jwt)
-    implementation(libs.bouncyCastle.bcpkix)
 }
 repositories {
     mavenCentral()

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -29,6 +29,5 @@ dependencies {
     testImplementation(libs.jackson.databind)
     testImplementation(libs.okhttp)
     testImplementation(libs.nimbus.jwt)
-    testImplementation(libs.bouncyCastle.bcpkix)
 }
 


### PR DESCRIPTION
## What this PR changes/adds

Wanted to bump bouncycastle version, but I found out that these dependencies are not necessary, so I got rid of them.

## Why it does that

cleanup

## Further notes

Made the CI run on every push on every branch, as it is in the `Connector` repository

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
