### PR TITLE
refactor(SqlIdentityHubStore): apply AbstractSqlStore class and PostgresqlStoreSetupExtension in test

### DIFF
--- a/extensions/store/sql/identity-hub-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/SqlIdentityHubStore.java
+++ b/extensions/store/sql/identity-hub-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/SqlIdentityHubStore.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Amadeus
+ *  Copyright (c) 2020 - 2023 Amadeus
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -14,41 +14,34 @@
 
 package org.eclipse.edc.identityhub.store.sql;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.identityhub.store.spi.IdentityHubRecord;
 import org.eclipse.edc.identityhub.store.spi.IdentityHubStore;
 import org.eclipse.edc.identityhub.store.sql.schema.IdentityHubStatements;
 import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.sql.store.AbstractSqlStore;
 import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Objects;
 import java.util.stream.Stream;
-import javax.sql.DataSource;
 
-import static java.lang.String.format;
 import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuery;
 
 /**
  * SQL implementation for {@link IdentityHubStore}.
  */
-public class SqlIdentityHubStore implements IdentityHubStore {
-
-    private final DataSourceRegistry dataSourceRegistry;
-    private final String dataSourceName;
-    private final TransactionContext transactionContext;
+public class SqlIdentityHubStore extends AbstractSqlStore implements IdentityHubStore {
     private final IdentityHubStatements statements;
 
     public SqlIdentityHubStore(DataSourceRegistry dataSourceRegistry,
                                String dataSourceName,
                                TransactionContext transactionContext,
-                               IdentityHubStatements identityHubStatements) {
-        this.dataSourceRegistry = Objects.requireNonNull(dataSourceRegistry);
-        this.dataSourceName = Objects.requireNonNull(dataSourceName);
-        this.transactionContext = Objects.requireNonNull(transactionContext);
+                               IdentityHubStatements identityHubStatements, ObjectMapper mapper) {
+        super(dataSourceRegistry, dataSourceName, transactionContext, mapper);
         statements = Objects.requireNonNull(identityHubStatements);
     }
 
@@ -81,13 +74,5 @@ public class SqlIdentityHubStore implements IdentityHubStore {
                 .payload(resultSet.getString(statements.getPayloadColumn()).getBytes())
                 .createdAt(resultSet.getLong(statements.getCreatedAtColumn()))
                 .build();
-    }
-
-    private DataSource getDataSource() {
-        return Objects.requireNonNull(dataSourceRegistry.resolve(dataSourceName), format("DataSource %s could not be resolved", dataSourceName));
-    }
-
-    private Connection getConnection() throws SQLException {
-        return getDataSource().getConnection();
     }
 }

--- a/extensions/store/sql/identity-hub-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/SqlIdentityHubStoreExtension.java
+++ b/extensions/store/sql/identity-hub-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/SqlIdentityHubStoreExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Amadeus
+ *  Copyright (c) 2020 - 2023 Amadeus
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -56,6 +56,6 @@ public class SqlIdentityHubStoreExtension implements ServiceExtension {
     public IdentityHubStore identityHubStore(ServiceExtensionContext context) {
         var s = Objects.requireNonNullElse(statements, new BaseSqlIdentityHubStatements());
         var dataSource = context.getSetting(DATASOURCE_NAME_SETTING, DEFAULT_DATASOURCE_NAME);
-        return new SqlIdentityHubStore(dataSourceRegistry, dataSource, trxContext, s);
+        return new SqlIdentityHubStore(dataSourceRegistry, dataSource, trxContext, s, context.getTypeManager().getMapper());
     }
 }

--- a/extensions/store/sql/identity-hub-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/PostgresParticipantStoreTest.java
+++ b/extensions/store/sql/identity-hub-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/PostgresParticipantStoreTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 - 2022 Amadeus
+ *  Copyright (c) 2020 - 2023 Amadeus
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -18,90 +18,36 @@ import org.eclipse.edc.identityhub.store.spi.IdentityHubStore;
 import org.eclipse.edc.identityhub.store.spi.IdentityHubStoreTestBase;
 import org.eclipse.edc.identityhub.store.sql.schema.BaseSqlIdentityHubStatements;
 import org.eclipse.edc.junit.annotations.PostgresqlDbIntegrationTest;
-import org.eclipse.edc.sql.testfixtures.PostgresqlLocalInstance;
-import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
-import org.eclipse.edc.transaction.spi.NoopTransactionContext;
-import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.postgresql.ds.PGSimpleDataSource;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.SQLException;
-import javax.sql.DataSource;
-
-import static org.eclipse.edc.sql.SqlQueryExecutor.executeQuery;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 @PostgresqlDbIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
 public class PostgresParticipantStoreTest extends IdentityHubStoreTestBase {
-
-    protected static final String DATASOURCE_NAME = "identityhub";
-    private static final String POSTGRES_USER = "postgres";
-    private static final String POSTGRES_PASSWORD = "password";
-    private static final String POSTGRES_DATABASE = "itest";
-
-    private TransactionContext transactionContext;
-    private Connection connection;
     private SqlIdentityHubStore store;
 
-    @BeforeAll
-    static void prepare() {
-        PostgresqlLocalInstance.createDatabase(POSTGRES_DATABASE);
-    }
-
     @BeforeEach
-    void setUp() throws SQLException, IOException {
-        transactionContext = new NoopTransactionContext();
-        var dataSourceRegistry = mock(DataSourceRegistry.class);
-
+    void setUp(PostgresqlStoreSetupExtension extension) throws IOException {
         var statements = new BaseSqlIdentityHubStatements();
+        var typeManager = new TypeManager();
 
-        var ds = new PGSimpleDataSource();
-        ds.setServerNames(new String[]{ "localhost" });
-        ds.setPortNumbers(new int[]{ 5432 });
-        ds.setUser(POSTGRES_USER);
-        ds.setPassword(POSTGRES_PASSWORD);
-        ds.setDatabaseName(POSTGRES_DATABASE);
-
-        // do not actually close
-        connection = spy(ds.getConnection());
-        doNothing().when(connection).close();
-
-        var datasourceMock = mock(DataSource.class);
-        when(datasourceMock.getConnection()).thenReturn(connection);
-        when(dataSourceRegistry.resolve(DATASOURCE_NAME)).thenReturn(datasourceMock);
-
-        store = new SqlIdentityHubStore(dataSourceRegistry, DATASOURCE_NAME, transactionContext, statements);
+        store = new SqlIdentityHubStore(extension.getDataSourceRegistry(), extension.getDatasourceName(), extension.getTransactionContext(), statements, typeManager.getMapper());
 
         var schema = Files.readString(Paths.get("docs/schema.sql"));
-        try {
-            transactionContext.execute(() -> {
-                executeQuery(connection, schema);
-                return null;
-            });
-        } catch (Exception exc) {
-            fail(exc);
-        }
+        extension.runQuery(schema);
     }
 
     @AfterEach
-    void tearDown() throws Exception {
-        transactionContext.execute(() -> {
-            var dialect = new BaseSqlIdentityHubStatements();
-            executeQuery(connection, "DROP TABLE " + dialect.getTable());
-        });
-        doCallRealMethod().when(connection).close();
-        connection.close();
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        var dialect = new BaseSqlIdentityHubStatements();
+        extension.runQuery("DROP TABLE " + dialect.getTable());
     }
 
     @Override


### PR DESCRIPTION
## What this PR changes/adds

Apply AbstractSqlStore class and PostgresqlStoreSetupExtension in test.

## Why it does that

Code simplification.

## Linked Issue(s)

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
