### PR TITLE
feat(IdentityHubStore): provide CosmosDB implementation of `IdentityHubStore`

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -71,6 +71,36 @@ jobs:
         run: docker-compose -f system-tests/docker-compose.yml logs
         if: always()
 
+  Check-Cosmos-Key:
+    runs-on: ubuntu-latest
+    steps:
+      - id: has-cosmos-key
+        env:
+          HAS_COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+        if: "${{ env.HAS_COSMOS_KEY != '' }}"
+        run: echo "::set-output name=defined::true"
+    outputs:
+      has-cosmos-key: ${{ steps.has-cosmos-key.outputs.defined }}
+
+  Azure-CosmosDB-Integration-Tests:
+    # run only if COSMOS_KEY is present
+    needs: [ Check-Cosmos-Key ]
+    if: needs.Check-Cosmos-Key.outputs.has-cosmos-key == 'true'
+    runs-on: ubuntu-latest
+
+    env:
+      COSMOS_KEY: ${{ secrets.COSMOS_KEY }}
+      COSMOS_URL: ${{ secrets.COSMOS_URL }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/gradle-setup
+
+      - name: Azure CosmosDB Tests
+        uses: ./.github/actions/run-tests
+        with:
+          command: ./gradlew test -DincludeTags="AzureCosmosDbIntegrationTest"
+
   Postgresql-Integration-Tests:
     runs-on: ubuntu-latest
     env:
@@ -97,6 +127,7 @@ jobs:
     needs:
       - Test
       - Postgresql-Integration-Tests
+      - Azure-CosmosDB-Integration-Tests
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/extensions/store/cosmos/identity-hub-store-cosmos/build.gradle.kts
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/build.gradle.kts
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":spi:identity-hub-store-spi"))
+    api(edc.ext.azure.cosmos.core)
+
+    implementation(libs.failsafe.core)
+    implementation(libs.azure.cosmos)
+
+    testImplementation(testFixtures(project(":spi:identity-hub-store-spi")))
+    testImplementation(testFixtures(edc.ext.azure.test))
+
+}
+
+publishing {
+    publications {
+        create<MavenPublication>(project.name) {
+            from(components["java"])
+        }
+    }
+}
+

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStore.java
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStore.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.store.cosmos;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.failsafe.RetryPolicy;
+import org.eclipse.edc.azure.cosmos.CosmosDbApi;
+import org.eclipse.edc.identityhub.store.cosmos.model.IdentityHubRecordDocument;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubRecord;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubStore;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static dev.failsafe.Failsafe.with;
+
+/**
+ * CosmosDB implementation for {@link org.eclipse.edc.identityhub.store.spi.IdentityHubStore}.
+ */
+public class CosmosIdentityHubStore implements IdentityHubStore {
+    private final CosmosDbApi cosmosDbApi;
+    private final String partitionKey;
+    private final ObjectMapper objectMapper;
+    private final RetryPolicy<Object> retryPolicy;
+
+
+    public CosmosIdentityHubStore(CosmosDbApi participantDb, String partitionKey, ObjectMapper objectMapper, RetryPolicy<Object> retryPolicy) {
+        this.cosmosDbApi = Objects.requireNonNull(participantDb);
+        this.partitionKey = partitionKey;
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.retryPolicy = Objects.requireNonNull(retryPolicy);
+    }
+
+    @Override
+    public @NotNull Stream<IdentityHubRecord> getAll() {
+        return with(retryPolicy).get(() -> cosmosDbApi.queryAllItems())
+                .stream()
+                .map(this::convertObject)
+                .map(IdentityHubRecordDocument::getWrappedInstance);
+    }
+
+    @Override
+    public void add(IdentityHubRecord record) {
+        var document = new IdentityHubRecordDocument(record, partitionKey);
+        cosmosDbApi.saveItem(document);
+    }
+
+    private IdentityHubRecordDocument convertObject(Object databaseDocument) {
+        try {
+            return objectMapper.readValue(objectMapper.writeValueAsString(databaseDocument), IdentityHubRecordDocument.class);
+        } catch (JsonProcessingException e) {
+            throw new EdcPersistenceException(e);
+        }
+    }
+}

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStoreConfig.java
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStoreConfig.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.store.cosmos;
+
+import org.eclipse.edc.azure.cosmos.AbstractCosmosConfig;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+public class CosmosIdentityHubStoreConfig extends AbstractCosmosConfig {
+
+    @Setting(required = true, value = "CosmosDB account name for IdentityHub Store")
+    public static final String COSMOS_ACCOUNTNAME_SETTING = "edc.identityhubstore.cosmos.account-name";
+    @Setting(required = true, value = "CosmosDB database name for IdentityHub Store")
+    public static final String COSMOS_DBNAME_SETTING = "edc.identityhubstore.cosmos.database-name";
+    @Setting(value = "CosmosDB preferred region for IdentityHub Store")
+    public static final String COSMOS_PREFERRED_REGION_SETTING = "edc.identityhubstore.cosmos.preferred-region";
+    @Setting(value = "CosmosDB container name for IdentityHub Store")
+    public static final String COSMOS_CONTAINER_NAME_SETTING = "edc.identityhubstore.cosmos.container-name";
+
+    /**
+     * Create a config object to interact with a Cosmos database.
+     *
+     * @param context Service extension context
+     */
+    protected CosmosIdentityHubStoreConfig(ServiceExtensionContext context) {
+        super(context);
+    }
+
+    @Override
+    protected String getAccountNameSetting() {
+        return COSMOS_ACCOUNTNAME_SETTING;
+    }
+
+    @Override
+    protected String getDbNameSetting() {
+        return COSMOS_DBNAME_SETTING;
+    }
+
+    @Override
+    protected String getCosmosPreferredRegionSetting() {
+        return COSMOS_PREFERRED_REGION_SETTING;
+    }
+
+    @Override
+    protected String getContainerNameSetting() {
+        return COSMOS_CONTAINER_NAME_SETTING;
+    }
+}

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStoreExtension.java
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStoreExtension.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.store.cosmos;
+
+import dev.failsafe.RetryPolicy;
+import org.eclipse.edc.azure.cosmos.CosmosClientProvider;
+import org.eclipse.edc.azure.cosmos.CosmosDbApi;
+import org.eclipse.edc.azure.cosmos.CosmosDbApiImpl;
+import org.eclipse.edc.identityhub.store.cosmos.model.IdentityHubRecordDocument;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.health.HealthCheckService;
+
+/**
+ * Extension that provides a {@link org.eclipse.edc.identityhub.store.spi.IdentityHubStore} with CosmosDB as backend storage
+ */
+@Extension(value = CosmosIdentityHubStoreExtension.NAME)
+public class CosmosIdentityHubStoreExtension implements ServiceExtension {
+
+    public static final String NAME = "Cosmos IdentityHub Store";
+
+    @Inject
+    private RetryPolicy<Object> retryPolicy;
+    @Inject
+    private Vault vault;
+    @Inject
+    private CosmosClientProvider clientProvider;
+
+    private CosmosDbApi cosmosDbApi;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        context.getService(HealthCheckService.class).addReadinessProvider(() -> cosmosDbApi.get().forComponent(name()));
+        context.getTypeManager().registerTypes(IdentityHubRecordDocument.class);
+    }
+
+
+    @Provider
+    public IdentityHubStore identityHubStore(ServiceExtensionContext context) {
+        var configuration = new CosmosIdentityHubStoreConfig(context);
+        var client = clientProvider.createClient(vault, configuration);
+        cosmosDbApi = new CosmosDbApiImpl(configuration, client);
+        return new CosmosIdentityHubStore(cosmosDbApi, configuration.getPartitionKey(), context.getTypeManager().getMapper(), retryPolicy);
+    }
+}

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/model/IdentityHubRecordDocument.java
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/main/java/org/eclipse/edc/identityhub/store/cosmos/model/IdentityHubRecordDocument.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.store.cosmos.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.eclipse.edc.azure.cosmos.CosmosDocument;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubRecord;
+
+
+@JsonTypeName("dataspaceconnector:identityhubrecorddocument")
+public class IdentityHubRecordDocument extends CosmosDocument<IdentityHubRecord> {
+
+    @JsonCreator
+    public IdentityHubRecordDocument(@JsonProperty("wrappedInstance") IdentityHubRecord record,
+                                     @JsonProperty("partitionKey") String partitionKey) {
+        super(record, partitionKey);
+    }
+
+    @Override
+    public String getId() {
+        return getWrappedInstance().getId();
+    }
+}

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Amadeus
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Amadeus - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.store.cosmos.CosmosIdentityHubStoreExtension

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/test/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStoreIntegrationTest.java
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/test/java/org/eclipse/edc/identityhub/store/cosmos/CosmosIdentityHubStoreIntegrationTest.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.store.cosmos;
+
+import com.azure.cosmos.CosmosContainer;
+import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.PartitionKey;
+import dev.failsafe.RetryPolicy;
+import org.eclipse.edc.azure.cosmos.CosmosDbApiImpl;
+import org.eclipse.edc.azure.testfixtures.CosmosTestClient;
+import org.eclipse.edc.azure.testfixtures.annotations.AzureCosmosDbIntegrationTest;
+import org.eclipse.edc.identityhub.store.cosmos.model.IdentityHubRecordDocument;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubRecord;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubStore;
+import org.eclipse.edc.identityhub.store.spi.IdentityHubStoreTestBase;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AzureCosmosDbIntegrationTest
+class CosmosIdentityHubStoreIntegrationTest extends IdentityHubStoreTestBase {
+    private static final String TEST_ID = UUID.randomUUID().toString();
+    private static final String DATABASE_NAME = "connector-itest-" + TEST_ID;
+    private static final String CONTAINER_NAME = "CosmosIdentityHubRecordIndexTest-" + TEST_ID;
+    private static final String TEST_PARTITION_KEY = "test-partitionkey";
+    private static CosmosContainer container;
+    private static CosmosDatabase database;
+    private CosmosIdentityHubStore store;
+
+    @BeforeAll
+    static void prepareCosmosClient() {
+        var client = CosmosTestClient.createClient();
+
+        var response = client.createDatabaseIfNotExists(DATABASE_NAME);
+        database = client.getDatabase(response.getProperties().getId());
+        var containerIfNotExists = database.createContainerIfNotExists(CONTAINER_NAME, "/partitionKey");
+        container = database.getContainer(containerIfNotExists.getProperties().getId());
+    }
+
+    @AfterAll
+    static void deleteDatabase() {
+        if (database != null) {
+            var delete = database.delete();
+            assertThat(delete.getStatusCode()).isGreaterThanOrEqualTo(200).isLessThan(300);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        assertThat(database).describedAs("CosmosDB database is null - did something go wrong during initialization?").isNotNull();
+
+        var typeManager = new TypeManager();
+        typeManager.registerTypes(IdentityHubRecord.class, IdentityHubRecordDocument.class);
+        var api = new CosmosDbApiImpl(container, true);
+        store = new CosmosIdentityHubStore(api, TEST_PARTITION_KEY, typeManager.getMapper(), RetryPolicy.ofDefaults());
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Delete items one by one as deleteAllItemsByPartitionKey is disabled by default on new Cosmos DB accounts.
+        var partitionKey = new PartitionKey(TEST_PARTITION_KEY);
+        container.readAllItems(partitionKey, CosmosDbEntity.class)
+                .stream().parallel()
+                .forEach(i -> container.deleteItem(i.id, partitionKey, null));
+    }
+
+    @Override
+    protected IdentityHubStore getStore() {
+        return store;
+    }
+
+    static class CosmosDbEntity {
+        String id;
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+}

--- a/extensions/store/cosmos/identity-hub-store-cosmos/src/test/java/org/eclipse/edc/identityhub/store/cosmos/model/IdentityHubRecordDocumentSerializationTest.java
+++ b/extensions/store/cosmos/identity-hub-store-cosmos/src/test/java/org/eclipse/edc/identityhub/store/cosmos/model/IdentityHubRecordDocumentSerializationTest.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2023 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.store.cosmos.model;
+
+import org.eclipse.edc.identityhub.store.spi.IdentityHubRecord;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityHubRecordDocumentSerializationTest {
+
+    private TypeManager typeManager;
+
+
+    @BeforeEach
+    void setup() {
+        typeManager = new TypeManager();
+        typeManager.registerTypes(IdentityHubRecordDocument.class, IdentityHubRecord.class);
+    }
+
+    @Test
+    void testSerialization() {
+        var record = createRecord();
+
+        var document = new IdentityHubRecordDocument(record, "partitionkey-test");
+
+        var s = typeManager.writeValueAsString(document);
+
+        assertThat(s).isNotNull()
+                .contains("\"partitionKey\":\"partitionkey-test\"")
+                .contains("\"id\":\"id-test\"")
+                .contains("\"payloadFormat\":\"format-test\"")
+                .contains("\"payload\":");
+    }
+
+    @Test
+    void testDeserialization() {
+        var record = createRecord();
+
+        var document = new IdentityHubRecordDocument(record, "partitionkey-test");
+        var json = typeManager.writeValueAsString(document);
+
+        var deserialized = typeManager.readValue(json, IdentityHubRecordDocument.class);
+        assertThat(deserialized.getWrappedInstance()).usingRecursiveComparison().isEqualTo(document.getWrappedInstance());
+    }
+
+    private static IdentityHubRecord createRecord() {
+        return IdentityHubRecord.Builder.newInstance()
+                .id("id-test")
+                .payloadFormat("format-test")
+                .payload("test".getBytes())
+                .build();
+    }
+}

--- a/extensions/store/sql/identity-hub-store-sql/build.gradle.kts
+++ b/extensions/store/sql/identity-hub-store-sql/build.gradle.kts
@@ -16,8 +16,7 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("identity-hub-store-sql") {
-            artifactId = "identity-hub-store-sql"
+        create<MavenPublication>(project.name) {
             from(components["java"])
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,7 +44,8 @@ dependencyResolutionManagement {
             library("ext-identity-did-web", "org.eclipse.edc", "identity-did-web").versionRef("edc")
             library("ext-http", "org.eclipse.edc", "http").versionRef("edc")
             library("ext-observability", "org.eclipse.edc", "api-observability").versionRef("edc")
-
+            library("ext-azure-cosmos-core", "org.eclipse.edc", "azure-cosmos-core").versionRef("edc")
+            library("ext-azure-test", "org.eclipse.edc", "azure-test").versionRef("edc")
         }
     }
 }
@@ -58,6 +59,7 @@ include(":core:identity-hub-verifier")
 
 
 include(":extensions:store:sql:identity-hub-store-sql")
+include(":extensions:store:cosmos:identity-hub-store-cosmos")
 include(":extensions:identity-hub-api")
 include(":extensions:identity-hub-verifier-jwt")
 include(":extensions:credentials:identity-hub-credentials-jwt")


### PR DESCRIPTION
## What this PR changes/adds

Provide CosmosDB implementation of the `IdentityHubStore` which is used for storing Verifiable Credentials.

## Why it does that

Provide persistence for the `IdentityHubStore`.

## Further notes

## Linked Issue(s)

Closes #39.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
