### PR TITLE
chore(build): fix verifier-jwt artifact name

### DIFF
--- a/extensions/identity-hub-verifier-jwt/build.gradle.kts
+++ b/extensions/identity-hub-verifier-jwt/build.gradle.kts
@@ -39,8 +39,7 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("identity-hub-credentials-verifier") {
-            artifactId = "identity-hub-credentials-verifier"
+        create<MavenPublication>(project.name) {
             from(components["java"])
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

Fixes the name of the artifact for  module `identity-hub-verifier-jwt`

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
