### PR TITLE
chore: update snapshot version to 0.1.0-SNAPSHOT

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -31,7 +31,7 @@ runs:
         newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+1))"-SNAPSHOT
 
         # replace every occurrence of =$oldVersion with =$newVersion
-        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i 's/$oldVersion/$newVersion/g'
+        grep -rlz "$oldVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$oldVersion/$newVersion/g"
 
         echo "Bumped the version from $oldVersion to $newVersion"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group=org.eclipse.edc
-version=0.0.1-SNAPSHOT
+version=0.1.0-SNAPSHOT
 
-edcGradlePluginsVersion=0.0.1-SNAPSHOT
-annotationProcessorVersion=0.0.1-SNAPSHOT
-metaModelVersion=0.0.1-SNAPSHOT
+edcGradlePluginsVersion=0.1.0-SNAPSHOT
+annotationProcessorVersion=0.1.0-SNAPSHOT
+metaModelVersion=0.1.0-SNAPSHOT
 
 # information required for publishing artifacts:
 edcScmConnection=scm:git:git@github.com:eclipse-edc/IdentityHub.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 assertj = "3.23.1"
-edc = "0.0.1-SNAPSHOT"
+edc = "0.1.0-SNAPSHOT"
 failsafe = "3.3.1"
 jackson = "2.14.2"
 jupiter = "5.9.2"

--- a/identity-hub-cli/README.md
+++ b/identity-hub-cli/README.md
@@ -29,7 +29,7 @@ cd IdentityHub
 
 ```
 cd OtherDirectory
-mvn dependency:copy -Dartifact=org.eclipse.edc:identity-hub-cli:0.0.1-SNAPSHOT:jar:all -DoutputDirectory=.
-java -jar identity-hub-cli-0.0.1-SNAPSHOT-all.jar --help
+mvn dependency:copy -Dartifact=org.eclipse.edc:identity-hub-cli:0.1.0-SNAPSHOT:jar:all -DoutputDirectory=.
+java -jar identity-hub-cli-0.1.0-SNAPSHOT-all.jar --help
 ```
 


### PR DESCRIPTION
## What this PR changes/adds

Update snapshot version to `0.1.0-SNAPSHOT`

## Why it does that

Our next release version will be `0.1.0`, thus the next snapshot will be `0.1.1-SNAPSHOT` and the automatic version bump mechanism currently only bumps the `patch` version.

## Further notes

- depends on https://github.com/eclipse-edc/GradlePlugins/pull/162
- depends on https://github.com/eclipse-edc/Connector/pull/3108


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md)._
