### PR TITLE
feat: implement CredentialQueryResolver

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -314,19 +314,12 @@ maven/mavencentral/org.jetbrains/annotations/13.0, Apache-2.0, approved, clearly
 maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.jetbrains/annotations/24.0.1, Apache-2.0, approved, #7417
 maven/mavencentral/org.junit-pioneer/junit-pioneer/2.1.0, EPL-2.0, approved, #10550
-maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.0, EPL-2.0, approved, #9714
 maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.1, EPL-2.0, approved, #9714
-maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.0, EPL-2.0, approved, #9711
 maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.1, EPL-2.0, approved, #9711
-maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.0, EPL-2.0, approved, #9708
 maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.10.1, EPL-2.0, approved, #9708
-maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.0, EPL-2.0, approved, #9715
 maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.1, EPL-2.0, approved, #9715
-maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.0, EPL-2.0, approved, #9709
 maven/mavencentral/org.junit.platform/junit-platform-engine/1.10.1, EPL-2.0, approved, #9709
-maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.0, EPL-2.0, approved, #9704
 maven/mavencentral/org.junit.platform/junit-platform-launcher/1.10.1, EPL-2.0, approved, #9704
-maven/mavencentral/org.junit/junit-bom/5.10.0, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.10.1, EPL-2.0, approved, #9844
 maven/mavencentral/org.junit/junit-bom/5.9.2, EPL-2.0, approved, #4711
 maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ21484

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityservice/api/v1/PresentationApiController.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityservice/api/v1/PresentationApiController.java
@@ -85,7 +85,7 @@ public class PresentationApiController implements PresentationApi {
         var credentials = queryResolver.query(presentationQuery, issuerScopes).orElseThrow(f -> new NotAuthorizedException(f.getFailureDetail()));
 
         // package the credentials in a VP and sign
-        var presentationResponse = presentationGenerator.createPresentation(credentials, presentationQuery.getPresentationDefinition())
+        var presentationResponse = presentationGenerator.createPresentation(credentials.toList(), presentationQuery.getPresentationDefinition())
                 .orElseThrow(failure -> new EdcException("Error creating VerifiablePresentation: %s".formatted(failure.getFailureDetail())));
         return Response.ok()
                 .entity(presentationResponse)

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -41,6 +41,7 @@ import java.sql.Date;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static jakarta.json.Json.createObjectBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -148,7 +149,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         var presentationQueryBuilder = createPresentationQueryBuilder().build();
         when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(PresentationQuery.class))).thenReturn(Result.success(presentationQueryBuilder));
         when(accessTokenVerifier.verify(anyString())).thenReturn(Result.success(List.of("test-scope1")));
-        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.success(List.of()));
+        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.success(Stream.empty()));
 
         when(generator.createPresentation(anyList(), any())).thenReturn(Result.failure("test-failure"));
 
@@ -163,7 +164,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         var presentationQueryBuilder = createPresentationQueryBuilder().build();
         when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(PresentationQuery.class))).thenReturn(Result.success(presentationQueryBuilder));
         when(accessTokenVerifier.verify(anyString())).thenReturn(Result.success(List.of("test-scope1")));
-        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.success(List.of()));
+        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.success(Stream.empty()));
 
         var pres = new PresentationResponse(generateJwt(), new PresentationSubmission("id", "def-id", List.of(new InputDescriptorMapping("id", "ldp_vp", "$.verifiableCredentials[0]"))));
         when(generator.createPresentation(anyList(), any())).thenReturn(Result.success(pres));

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.identityhub.spi.model.PresentationResponse;
 import org.eclipse.edc.identityhub.spi.model.PresentationSubmission;
 import org.eclipse.edc.identityhub.spi.model.presentationdefinition.PresentationDefinition;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
+import org.eclipse.edc.identityhub.spi.resolution.QueryResult;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.EdcException;
@@ -49,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.edc.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.edc.identityhub.spi.model.PresentationQuery.PRESENTATION_QUERY_TYPE_PROPERTY;
+import static org.eclipse.edc.identityhub.spi.resolution.QueryResult.success;
 import static org.eclipse.edc.validator.spi.ValidationResult.failure;
 import static org.eclipse.edc.validator.spi.ValidationResult.success;
 import static org.eclipse.edc.validator.spi.Violation.violation;
@@ -135,7 +137,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         var presentationQueryBuilder = createPresentationQueryBuilder().build();
         when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(PresentationQuery.class))).thenReturn(Result.success(presentationQueryBuilder));
         when(accessTokenVerifier.verify(anyString())).thenReturn(Result.success(List.of("test-scope1")));
-        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.failure("test-failure"));
+        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(QueryResult.unauthorized("test-failure"));
 
         assertThatThrownBy(() -> controller().queryPresentation(createObjectBuilder().build(), generateJwt()))
                 .isInstanceOf(NotAuthorizedException.class)
@@ -149,7 +151,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         var presentationQueryBuilder = createPresentationQueryBuilder().build();
         when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(PresentationQuery.class))).thenReturn(Result.success(presentationQueryBuilder));
         when(accessTokenVerifier.verify(anyString())).thenReturn(Result.success(List.of("test-scope1")));
-        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.success(Stream.empty()));
+        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(success(Stream.empty()));
 
         when(generator.createPresentation(anyList(), any())).thenReturn(Result.failure("test-failure"));
 
@@ -164,7 +166,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         var presentationQueryBuilder = createPresentationQueryBuilder().build();
         when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(PresentationQuery.class))).thenReturn(Result.success(presentationQueryBuilder));
         when(accessTokenVerifier.verify(anyString())).thenReturn(Result.success(List.of("test-scope1")));
-        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(Result.success(Stream.empty()));
+        when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(success(Stream.empty()));
 
         var pres = new PresentationResponse(generateJwt(), new PresentationSubmission("id", "def-id", List.of(new InputDescriptorMapping("id", "ldp_vp", "$.verifiableCredentials[0]"))));
         when(generator.createPresentation(anyList(), any())).thenReturn(Result.success(pres));

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -41,7 +41,7 @@ public class DefaultServicesExtension implements ServiceExtension {
     @Provider(isDefault = true)
     public ScopeToCriterionTransformer createScopeTransformer(ServiceExtensionContext context) {
         context.getMonitor().warning("Using the default EdcScopeToCriterionTransformer. This is not intended for production use and should be replaced " +
-                "with a specialized implementation for your dataspace!");
+                "with a specialized implementation for your dataspace");
         return new EdcScopeToCriterionTransformer();
     }
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.identityhub;
 
 import org.eclipse.edc.identityhub.defaults.InMemoryCredentialStore;
 import org.eclipse.edc.identityhub.spi.generator.PresentationGenerator;
-import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -29,12 +28,6 @@ public class DefaultServicesExtension implements ServiceExtension {
     public CredentialStore createInMemStore() {
         return new InMemoryCredentialStore();
 
-    }
-
-    @Provider(isDefault = true)
-    public CredentialQueryResolver createCredentialResolver(ServiceExtensionContext context) {
-        context.getMonitor().warning("  #### Creating a default NOOP CredentialQueryResolver, that will always return 'null'!");
-        return (query, issuerScopes) -> null;
     }
 
     @Provider(isDefault = true)

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.identityhub;
 
+import org.eclipse.edc.identityhub.defaults.EdcScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.defaults.InMemoryCredentialStore;
+import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.spi.generator.PresentationGenerator;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -35,4 +37,12 @@ public class DefaultServicesExtension implements ServiceExtension {
         context.getMonitor().warning("  #### Creating a default NOOP PresentationGenerator, that will always return 'null'!");
         return (credentials, presentationDefinition) -> null;
     }
+
+    @Provider(isDefault = true)
+    public ScopeToCriterionTransformer createScopeTransformer(ServiceExtensionContext context) {
+        context.getMonitor().warning("Using the default EdcScopeToCriterionTransformer. This is not intended for production use and should be replaced " +
+                "with a specialized implementation for your dataspace!");
+        return new EdcScopeToCriterionTransformer();
+    }
+
 }

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.identityhub.core;
 import org.eclipse.edc.iam.did.spi.key.PublicKeyWrapper;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.iam.identitytrust.validation.SelfIssuedIdTokenValidator;
+import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
@@ -66,6 +67,9 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private CredentialStore credentialStore;
 
+    @Inject
+    private ScopeToCriterionTransformer transformer;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         // Setup API
@@ -95,7 +99,7 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Provider
     public CredentialQueryResolver createCredentialQueryResolver(ServiceExtensionContext context) {
-        return new CredentialQueryResolverImpl(credentialStore);
+        return new CredentialQueryResolverImpl(credentialStore, transformer);
     }
 
     private String getOwnDid(ServiceExtensionContext context) {

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.identityhub.core;
 import org.eclipse.edc.iam.did.spi.key.PublicKeyWrapper;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.iam.identitytrust.validation.SelfIssuedIdTokenValidator;
+import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
+import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
 import org.eclipse.edc.identityhub.token.verification.AccessTokenVerifierImpl;
 import org.eclipse.edc.identitytrust.validation.JwtValidator;
@@ -61,6 +63,9 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private JsonLd jsonLd;
 
+    @Inject
+    private CredentialStore credentialStore;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         // Setup API
@@ -86,6 +91,11 @@ public class CoreServicesExtension implements ServiceExtension {
             jwtVerifier = new SelfIssuedIdTokenVerifier(didResolverRegistry);
         }
         return jwtVerifier;
+    }
+
+    @Provider
+    public CredentialQueryResolver createCredentialQueryResolver(ServiceExtensionContext context) {
+        return new CredentialQueryResolverImpl(credentialStore);
     }
 
     private String getOwnDid(ServiceExtensionContext context) {

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -98,7 +98,7 @@ public class CoreServicesExtension implements ServiceExtension {
     }
 
     @Provider
-    public CredentialQueryResolver createCredentialQueryResolver(ServiceExtensionContext context) {
+    public CredentialQueryResolver createCredentialQueryResolver() {
         return new CredentialQueryResolverImpl(credentialStore, transformer);
     }
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
@@ -35,9 +35,7 @@ import static org.eclipse.edc.spi.result.Result.success;
 
 public class CredentialQueryResolverImpl implements CredentialQueryResolver {
 
-
     private final CredentialStore credentialStore;
-
     private final ScopeToCriterionTransformer scopeTransformer;
 
     public CredentialQueryResolverImpl(CredentialStore credentialStore, ScopeToCriterionTransformer scopeTransformer) {
@@ -104,8 +102,15 @@ public class CredentialQueryResolverImpl implements CredentialQueryResolver {
         };
     }
 
-    private Result<List<Criterion>> parseScopes(List<String> query) {
-        var transformResult = query.stream()
+    /**
+     * Parses a list of scope strings, converts them to {@link Criterion} objects, and returns a {@link Result} containing
+     * the list of converted criteria. If any scope string fails to be converted, a failure result is returned.
+     *
+     * @param scopes The list of scope strings to parse and convert.
+     * @return A {@link Result} containing the list of converted {@link Criterion} objects.
+     */
+    private Result<List<Criterion>> parseScopes(List<String> scopes) {
+        var transformResult = scopes.stream()
                 .map(scopeTransformer::transform)
                 .toList();
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
@@ -17,21 +17,172 @@ package org.eclipse.edc.identityhub.core;
 import org.eclipse.edc.identityhub.spi.model.PresentationQuery;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
+import org.eclipse.edc.identityhub.spi.store.model.VerifiableCredentialResource;
 import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.Result;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+
 
 public class CredentialQueryResolverImpl implements CredentialQueryResolver {
 
+    private static final String SCOPE_SEPARATOR = ":";
     private final CredentialStore credentialStore;
+    private final List<String> allowedOperations = List.of("read", "*", "all");
 
     public CredentialQueryResolverImpl(CredentialStore credentialStore) {
         this.credentialStore = credentialStore;
     }
 
     @Override
-    public Result<List<VerifiableCredentialContainer>> query(PresentationQuery query, List<String> issuerScopes) {
+    public Result<Stream<VerifiableCredentialContainer>> query(PresentationQuery query, List<String> issuerScopes) {
+        if (query.getPresentationDefinition() != null) {
+            throw new UnsupportedOperationException("Querying with a DIF Presentation Exchange definition is not yet supported.");
+        }
+        if (query.getScopes().isEmpty()) {
+            return failure("Invalid query: must contain at least one scope.");
+        }
+
+        // check that all prover scopes are valid
+        var proverScopeFailures = checkScope(query.getScopes());
+        if (proverScopeFailures != null) return proverScopeFailures;
+
+        // check that all issuer scopes are valid
+        var issuerScopeFailures = checkScope(issuerScopes);
+        if (issuerScopeFailures != null) return issuerScopeFailures;
+
+        // query storage for requested credentials
+        var queryspec = convertToQuerySpec(query.getScopes());
+        var res = credentialStore.query(queryspec);
+        if (res.failed()) {
+            return failure(res.getFailureMessages());
+        }
+
+        // the credentials requested by the other party
+        var wantedCredentials = res.getContent().toList();
+
+        // check that prover scope is not wider than issuer scope
+        var issuerQuery = convertToQuerySpec(issuerScopes);
+        var predicate = issuerQuery.getFilterExpression().stream()
+                .map(c -> credentialsPredicate(c.getOperandRight().toString()))
+                .reduce(Predicate::or)
+                .orElse(x -> false);
+
+        // now narrow down the requested credentials to only contain allowed creds
+        var allowedCredentials = wantedCredentials.stream().filter(predicate).toList();
+
+        var isValidQuery = validateResults(new ArrayList<>(wantedCredentials), new ArrayList<>(allowedCredentials));
+
+        return isValidQuery ?
+                success(wantedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential))
+                : failure("Invalid query: requested Credentials outside of scope.");
+    }
+
+    /**
+     * Returns a predicate that filters {@link VerifiableCredentialResource} objects based on the provided type by
+     * inspecting the {@code types} property of the {@link org.eclipse.edc.identitytrust.model.VerifiableCredential} that is
+     * encapsulated in the resource.
+     *
+     * @param type The type to filter by.
+     * @return A predicate that filters {@link VerifiableCredentialResource} objects based on the provided type.
+     */
+    private Predicate<VerifiableCredentialResource> credentialsPredicate(String type) {
+        return resource -> {
+            var cred = resource.getVerifiableCredential();
+            return cred != null && cred.credential() != null && cred.credential().getTypes().contains(type);
+        };
+    }
+
+    @Nullable
+    private Result<Stream<VerifiableCredentialContainer>> checkScope(List<String> query) {
+        var proverScopeFailures = query.stream()
+                .map(this::isValidScope)
+                .filter(AbstractResult::failed)
+                .flatMap(r -> r.getFailureMessages().stream())
+                .toList();
+        if (!proverScopeFailures.isEmpty()) {
+            return failure(proverScopeFailures);
+        }
         return null;
+    }
+
+    /**
+     * Checks whether the list of requested credentials is valid. Validity is determined by whether the list of requested credentials
+     * contains elements that are not in the list of allowed credentials. The list of allowed credentials may contain more elements, but not less.
+     * Every element, that is in the list of requested credentials must be found in the list of allowed credentials.
+     *
+     * @param requestedCredentials The list of requested credentials.
+     * @param allowedCredentials   The list of allowed credentials.
+     * @return true if the list of requested credentials contains only elements that can be found in the list of allowed credentials, false otherwise.
+     */
+    private boolean validateResults(List<VerifiableCredentialResource> requestedCredentials, List<VerifiableCredentialResource> allowedCredentials) {
+        if (requestedCredentials == allowedCredentials) {
+            return true;
+        }
+        if (requestedCredentials.size() != allowedCredentials.size()) {
+            return false;
+        }
+
+        requestedCredentials.removeAll(allowedCredentials);
+        return requestedCredentials.isEmpty();
+    }
+
+    private QuerySpec convertToQuerySpec(List<String> scopes) {
+        var criteria = scopes.stream()
+                .map(this::convertScopeToCriterion)
+                .toList();
+
+        return QuerySpec.Builder.newInstance()
+                .filter(criteria)
+                .build();
+    }
+
+    /**
+     * Converts a scope string to a {@link Criterion} object. For example,
+     * <pre>
+     *     org.eclipse.edc.vc.type:DemoCredential:read
+     * </pre>
+     * would be converted to
+     * <pre>
+     *     verifiableCredential.credential.types contains DemoCredential
+     * </pre>
+     * <p>
+     * take note that the operation ("read") must be checked somewhere else, and is ignored here.
+     *
+     * @param scope The scope string to convert.
+     * @return The converted {@link Criterion} object.
+     */
+    //todo: make this pluggable and more versatile
+    private Criterion convertScopeToCriterion(String scope) {
+        var tokens = isValidScope(scope);
+        if (tokens.failed()) {
+            throw new IllegalArgumentException("Scope string cannot be converted: %s".formatted(tokens.getFailureDetail()));
+        }
+        var credentialType = tokens.getContent()[1];
+        return new Criterion("verifiableCredential.credential.types", "like", credentialType);
+    }
+
+    private Result<String[]> isValidScope(String scope) {
+        if (scope == null) return failure("Scope was null");
+
+        var tokens = scope.split(SCOPE_SEPARATOR);
+        if (tokens.length != 3) {
+            return failure("Scope string has invalid format.");
+        }
+        if (!allowedOperations.contains(tokens[2])) {
+            return failure("Invalid scope operation: " + tokens[2]);
+        }
+
+        return success(tokens);
     }
 }

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.core;
+
+import org.eclipse.edc.identityhub.spi.model.PresentationQuery;
+import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
+import org.eclipse.edc.identityhub.spi.store.CredentialStore;
+import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.List;
+
+public class CredentialQueryResolverImpl implements CredentialQueryResolver {
+
+    private final CredentialStore credentialStore;
+
+    public CredentialQueryResolverImpl(CredentialStore credentialStore) {
+        this.credentialStore = credentialStore;
+    }
+
+    @Override
+    public Result<List<VerifiableCredentialContainer>> query(PresentationQuery query, List<String> issuerScopes) {
+        return null;
+    }
+}

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformer.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformer.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.defaults;
+
+import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.List;
+
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+
+/**
+ * Implementation of the {@link ScopeToCriterionTransformer} interface that converts a scope string to a {@link Criterion} object.
+ * This is a default/example implementation, that assumes scope strings adhere to the following format:
+ * <pre>
+ *  org.eclipse.edc.vc.type:SomeCredential:[read|all|*]
+ * </pre>
+ * This scope string will get translated into a {@link Criterion} like:
+ * <pre>
+ *     verifiableCredential.credential.types like SomeCredential
+ * </pre>
+ *
+ * <em>This MUST be adapted to the needs and requirements of the dataspace!</em>
+ * <em>Do NOT use this in production code!</em>
+ */
+public class EdcScopeToCriterionTransformer implements ScopeToCriterionTransformer {
+    public static final String TYPE_OPERAND = "verifiableCredential.credential.types";
+    public static final String ALIAS_LITERAL = "org.eclipse.edc.vc.type";
+    public static final String LIKE_OPERATOR = "like";
+    private static final String SCOPE_SEPARATOR = ":";
+    private final List<String> allowedOperations = List.of("read", "*", "all");
+
+    @Override
+    public Result<Criterion> transform(String scope) {
+        var tokens = parseScope(scope);
+        if (tokens.failed()) {
+            return failure("Scope string cannot be converted: %s".formatted(tokens.getFailureDetail()));
+        }
+        var credentialType = tokens.getContent()[1];
+        return success(new Criterion(TYPE_OPERAND, LIKE_OPERATOR, credentialType));
+    }
+
+    private Result<String[]> parseScope(String scope) {
+        if (scope == null) return failure("Scope was null");
+
+        var tokens = scope.split(SCOPE_SEPARATOR);
+        if (tokens.length != 3) {
+            return failure("Scope string has invalid format.");
+        }
+        if (!ALIAS_LITERAL.equalsIgnoreCase(tokens[0])) {
+            return failure("Scope alias MUST be %s but was %s".formatted(ALIAS_LITERAL, tokens[0]));
+        }
+        if (!allowedOperations.contains(tokens[2])) {
+            return failure("Invalid scope operation: " + tokens[2]);
+        }
+
+        return success(tokens);
+    }
+}

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.core;
 
 
+import org.eclipse.edc.identityhub.defaults.EdcScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.spi.model.PresentationQuery;
 import org.eclipse.edc.identityhub.spi.model.presentationdefinition.PresentationDefinition;
 import org.eclipse.edc.identityhub.spi.resolution.QueryFailure;
@@ -46,7 +47,7 @@ import static org.mockito.Mockito.when;
 class CredentialQueryResolverImplTest {
 
     private final CredentialStore storeMock = mock();
-    private final CredentialQueryResolverImpl resolver = new CredentialQueryResolverImpl(storeMock);
+    private final CredentialQueryResolverImpl resolver = new CredentialQueryResolverImpl(storeMock, new EdcScopeToCriterionTransformer());
 
     @Test
     void query_noResult() {
@@ -73,7 +74,7 @@ class CredentialQueryResolverImplTest {
                 List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
         assertThat(res.failed()).isTrue();
         assertThat(res.reason()).isEqualTo(QueryFailure.Reason.INVALID_SCOPE);
-        assertThat(res.getFailureDetail()).isEqualTo("Scope string has invalid format.");
+        assertThat(res.getFailureDetail()).contains("Scope string has invalid format.");
     }
 
     @Test
@@ -81,7 +82,7 @@ class CredentialQueryResolverImplTest {
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:write"), List.of("ignored"));
         assertThat(res.failed()).isTrue();
         assertThat(res.reason()).isEqualTo(QueryFailure.Reason.INVALID_SCOPE);
-        assertThat(res.getFailureDetail()).isEqualTo("Invalid scope operation: write");
+        assertThat(res.getFailureDetail()).contains("Invalid scope operation: write");
     }
 
     @Test

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.identityhub.core;
 
 import org.eclipse.edc.identityhub.spi.model.PresentationQuery;
 import org.eclipse.edc.identityhub.spi.model.presentationdefinition.PresentationDefinition;
+import org.eclipse.edc.identityhub.spi.resolution.QueryFailure;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.identityhub.spi.store.model.VerifiableCredentialResource;
 import org.eclipse.edc.identitytrust.model.CredentialFormat;
@@ -61,6 +62,7 @@ class CredentialQueryResolverImplTest {
         when(storeMock.query(any())).thenReturn(success(Stream.empty()));
         var res = resolver.query(createPresentationQuery(), List.of("foobar"));
         assertThat(res.succeeded()).isFalse();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.INVALID_SCOPE);
         assertThat(res.getFailureDetail()).contains("Invalid query: must contain at least one scope.");
     }
 
@@ -70,6 +72,7 @@ class CredentialQueryResolverImplTest {
         var res = resolver.query(createPresentationQuery("invalid"),
                 List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
         assertThat(res.failed()).isTrue();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.INVALID_SCOPE);
         assertThat(res.getFailureDetail()).isEqualTo("Scope string has invalid format.");
     }
 
@@ -77,6 +80,7 @@ class CredentialQueryResolverImplTest {
     void query_scopeStringHasWrongOperator_shouldReturnFailure() {
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:write"), List.of("ignored"));
         assertThat(res.failed()).isTrue();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.INVALID_SCOPE);
         assertThat(res.getFailureDetail()).isEqualTo("Invalid scope operation: write");
     }
 
@@ -122,6 +126,7 @@ class CredentialQueryResolverImplTest {
                 List.of("org.eclipse.edc.vc.type:TestCredential:read"));
 
         assertThat(res.failed()).isTrue();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
         assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
     }
 
@@ -158,6 +163,7 @@ class CredentialQueryResolverImplTest {
                 List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
 
         assertThat(res.failed()).isTrue();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
         assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
     }
 
@@ -170,6 +176,7 @@ class CredentialQueryResolverImplTest {
                 List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
 
         assertThat(res.failed()).isTrue();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.STORAGE_FAILURE);
         assertThat(res.getFailureDetail()).isEqualTo("test-failure");
     }
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.core;
+
+
+import org.eclipse.edc.identityhub.spi.model.PresentationQuery;
+import org.eclipse.edc.identityhub.spi.model.presentationdefinition.PresentationDefinition;
+import org.eclipse.edc.identityhub.spi.store.CredentialStore;
+import org.eclipse.edc.identityhub.spi.store.model.VerifiableCredentialResource;
+import org.eclipse.edc.identitytrust.model.CredentialFormat;
+import org.eclipse.edc.identitytrust.model.CredentialSubject;
+import org.eclipse.edc.identitytrust.model.Issuer;
+import org.eclipse.edc.identitytrust.model.VerifiableCredential;
+import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.spi.result.StoreResult.success;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CredentialQueryResolverImplTest {
+
+    private final CredentialStore storeMock = mock();
+    private final CredentialQueryResolverImpl resolver = new CredentialQueryResolverImpl(storeMock);
+
+    @Test
+    void query_noResult() {
+        when(storeMock.query(any())).thenReturn(success(Stream.empty()));
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
+                List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
+        assertThat(res.succeeded()).isTrue();
+        assertThat(res.getContent()).isEmpty();
+    }
+
+    @Test
+    void query_noProverScope_shouldReturnEmpty() {
+        when(storeMock.query(any())).thenReturn(success(Stream.empty()));
+        var res = resolver.query(createPresentationQuery(), List.of("foobar"));
+        assertThat(res.succeeded()).isFalse();
+        assertThat(res.getFailureDetail()).contains("Invalid query: must contain at least one scope.");
+    }
+
+    @Test
+    void query_proverScopeStringInvalid_shouldReturnFailure() {
+        when(storeMock.query(any())).thenReturn(success(Stream.empty()));
+        var res = resolver.query(createPresentationQuery("invalid"),
+                List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
+        assertThat(res.failed()).isTrue();
+        assertThat(res.getFailureDetail()).isEqualTo("Scope string has invalid format.");
+    }
+
+    @Test
+    void query_scopeStringHasWrongOperator_shouldReturnFailure() {
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:write"), List.of("ignored"));
+        assertThat(res.failed()).isTrue();
+        assertThat(res.getFailureDetail()).isEqualTo("Invalid scope operation: write");
+    }
+
+    @Test
+    void query_singleScopeString() {
+        var credential = createCredentialResource("TestCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential)));
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
+                List.of("org.eclipse.edc.vc.type:TestCredential:read"));
+        assertThat(res.succeeded()).withFailMessage(res::getFailureDetail).isTrue();
+        assertThat(res.getContent()).containsExactly(credential.getVerifiableCredential());
+    }
+
+    @Test
+    void query_multipleScopeStrings() {
+        var credential1 = createCredentialResource("TestCredential");
+        var credential2 = createCredentialResource("AnotherCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1, credential2)));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read",
+                        "org.eclipse.edc.vc.type:AnotherCredential:read"),
+                List.of("org.eclipse.edc.vc.type:TestCredential:read", "org.eclipse.edc.vc.type:AnotherCredential:read"));
+        assertThat(res.succeeded()).withFailMessage(res::getFailureDetail).isTrue();
+        assertThat(res.getContent()).containsExactlyInAnyOrder(credential1.getVerifiableCredential(), credential2.getVerifiableCredential());
+    }
+
+    @Test
+    void query_presentationDefinition_unsupported() {
+        var q = PresentationQuery.Builder.newinstance().presentationDefinition(PresentationDefinition.Builder.newInstance().id("test-pd").build()).build();
+        assertThatThrownBy(() -> resolver.query(q, List.of("org.eclipse.edc.vc.type:SomeCredential:read")))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Querying with a DIF Presentation Exchange definition is not yet supported.");
+    }
+
+    @Test
+    void query_requestsTooManyCredentials_shouldReturnFailure() {
+        var credential1 = createCredentialResource("TestCredential");
+        var credential2 = createCredentialResource("AnotherCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1, credential2)));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read",
+                        "org.eclipse.edc.vc.type:AnotherCredential:read"),
+                List.of("org.eclipse.edc.vc.type:TestCredential:read"));
+
+        assertThat(res.failed()).isTrue();
+        assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
+    }
+
+    @Test
+    void query_moreCredentialsAllowed_shouldReturnOnlyRequested() {
+        var credential1 = createCredentialResource("TestCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
+                List.of("org.eclipse.edc.vc.type:TestCredential:read", "org.eclipse.edc.vc.type:AnotherCredential:read"));
+
+        assertThat(res.succeeded()).isTrue();
+        assertThat(res.getContent()).containsOnly(credential1.getVerifiableCredential());
+    }
+
+    @Test
+    void query_exactMatchAllowedAndRequestedCredentials() {
+        var credential1 = createCredentialResource("TestCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
+                List.of("org.eclipse.edc.vc.type:TestCredential:read"));
+
+        assertThat(res.succeeded()).isTrue();
+        assertThat(res.getContent()).containsOnly(credential1.getVerifiableCredential());
+    }
+
+    @Test
+    void query_requestedCredentialNotAllowed() {
+        var credential1 = createCredentialResource("TestCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
+                List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
+
+        assertThat(res.failed()).isTrue();
+        assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
+    }
+
+    @Test
+    void query_storeReturnsFailure() {
+        var credential1 = createCredentialResource("TestCredential");
+        when(storeMock.query(any())).thenReturn(StoreResult.notFound("test-failure"));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
+                List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
+
+        assertThat(res.failed()).isTrue();
+        assertThat(res.getFailureDetail()).isEqualTo("test-failure");
+    }
+
+    private PresentationQuery createPresentationQuery(@Nullable String... scope) {
+        var scopes = new ArrayList<>(Arrays.asList(scope));
+        return PresentationQuery.Builder.newinstance().scopes(scopes).build();
+    }
+
+    private VerifiableCredentialResource createCredentialResource(String... type) {
+        var cred = VerifiableCredential.Builder.newInstance()
+                .types(Arrays.asList(type))
+                .issuer(new Issuer("test-issuer", Map.of()))
+                .issuanceDate(Instant.now())
+                .credentialSubject(CredentialSubject.Builder.newInstance().id("test-cred-id").claim("test-claim", "test-value").build())
+                .build();
+        return VerifiableCredentialResource.Builder.newInstance()
+                .credential(new VerifiableCredentialContainer("foobar", CredentialFormat.JSON_LD, cred))
+                .holderId("test-holder")
+                .issuerId("test-issuer")
+                .build();
+    }
+}

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
@@ -169,6 +169,20 @@ class CredentialQueryResolverImplTest {
     }
 
     @Test
+    void query_sameSizeDifferentScope() {
+        var credential1 = createCredentialResource("TestCredential");
+        var credential2 = createCredentialResource("AnotherCredential");
+        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+
+        var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read", "org.eclipse.edc.vc.type:AnotherCredential:read"),
+                List.of("org.eclipse.edc.vc.type:FooCredential:read", "org.eclipse.edc.vc.type:BarCredential:read"));
+
+        assertThat(res.failed()).isTrue();
+        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
+        assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
+    }
+
+    @Test
     void query_storeReturnsFailure() {
         var credential1 = createCredentialResource("TestCredential");
         when(storeMock.query(any())).thenReturn(StoreResult.notFound("test-failure"));

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformerTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformerTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.defaults;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class EdcScopeToCriterionTransformerTest {
+    private final EdcScopeToCriterionTransformer transformer = new EdcScopeToCriterionTransformer();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "org.eclipse.edc.vc.type:TestCredential:read",
+            "org.eclipse.edc.vc.type:TestCredential:*",
+            "org.eclipse.edc.vc.type:TestCredential:all",
+            "org.eclipse.edc.vc.type:foo:all",
+    })
+    void transform_validScope(String scope) {
+        assertThat(transformer.transform(scope)).isSucceeded();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "invalidAlias:TestCredential:read",
+            "org.eclipse.edc.vc.type:TestCredential:write",
+            "org.eclipse.edc.vc.type:TestCredential:foo",
+            "org.eclipse.edc::foo",
+            "org.eclipse.edc:foo",
+    })
+    void transform_invalidScope(String scope) {
+        assertThat(transformer.transform(scope)).isFailed();
+    }
+}

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ResolutionApiComponentTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ResolutionApiComponentTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.identityhub.spi.model.InputDescriptorMapping;
 import org.eclipse.edc.identityhub.spi.model.PresentationResponse;
 import org.eclipse.edc.identityhub.spi.model.PresentationSubmission;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
+import org.eclipse.edc.identityhub.spi.resolution.QueryResult;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubRuntimeConfiguration;
 import org.eclipse.edc.identityhub.tests.fixtures.TestData;
@@ -157,7 +158,7 @@ public class ResolutionApiComponentTest {
     void query_queryResolutionFails_shouldReturn403() {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
-        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(failure("scope mismatch!"));
+        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(QueryResult.unauthorized("scope mismatch!"));
 
         IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType(JSON)
@@ -175,7 +176,7 @@ public class ResolutionApiComponentTest {
     void query_presentationGenerationFails_shouldReturn500() {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
-        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(success(Stream.empty()));
+        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(QueryResult.success(Stream.empty()));
         when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null))).thenReturn(failure("generator test error"));
 
         IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
@@ -192,7 +193,7 @@ public class ResolutionApiComponentTest {
     void query_success() {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
-        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(success(Stream.empty()));
+        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(QueryResult.success(Stream.empty()));
         when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null))).thenReturn(success(createPresentationResponse()));
 
         var resp = IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ResolutionApiComponentTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ResolutionApiComponentTest.java
@@ -23,13 +23,14 @@ import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubRuntimeConfiguration;
 import org.eclipse.edc.identityhub.tests.fixtures.TestData;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
@@ -44,8 +45,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@EndToEndTest
-public class ResolutionApiEndToEndTest {
+@ComponentTest
+public class ResolutionApiComponentTest {
     public static final String VALID_QUERY_WITH_SCOPE = """
             {
               "@context": [
@@ -174,7 +175,7 @@ public class ResolutionApiEndToEndTest {
     void query_presentationGenerationFails_shouldReturn500() {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
-        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(success(List.of()));
+        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(success(Stream.empty()));
         when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null))).thenReturn(failure("generator test error"));
 
         IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
@@ -191,7 +192,7 @@ public class ResolutionApiEndToEndTest {
     void query_success() {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
-        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(success(List.of()));
+        when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(success(Stream.empty()));
         when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null))).thenReturn(success(createPresentationResponse()));
 
         var resp = IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()

--- a/extensions/cryptography/public-key-provider/src/main/java/org/eclipse/edc/identityhub/publickey/resolver/PublicKeyWrapperExtension.java
+++ b/extensions/cryptography/public-key-provider/src/main/java/org/eclipse/edc/identityhub/publickey/resolver/PublicKeyWrapperExtension.java
@@ -51,6 +51,9 @@ public class PublicKeyWrapperExtension implements ServiceExtension {
     @Setting(value = "Path to a file that holds the public key, e.g. a PEM file. Do not use in production!")
     public static final String PUBLIC_KEY_PATH_PROPERTY = "edc.ih.iam.publickey.path";
 
+    @Setting(value = "Public key in PEM format")
+    public static final String PUBLIC_KEY_PEM = "edc.ih.iam.publickey.pem";
+
     @Inject
     private Vault vault;
 
@@ -65,6 +68,11 @@ public class PublicKeyWrapperExtension implements ServiceExtension {
         var path = context.getSetting(PUBLIC_KEY_PATH_PROPERTY, null);
         if (path != null) {
             return getPublicKeyFromFile(path);
+        }
+
+        var pem = context.getSetting(PUBLIC_KEY_PEM, null);
+        if (pem != null) {
+            return parseRawPublicKey(pem);
         }
 
         throw new EdcException("No public key was configured! Please either configure '%s' or '%s'.".formatted(PUBLIC_KEY_PATH_PROPERTY, PUBLIC_KEY_VAULT_ALIAS_PROPERTY));

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/ScopeToCriterionTransformer.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/ScopeToCriterionTransformer.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi;
+
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.result.Result;
+
+/**
+ * Converts a scope string to a {@link Criterion} object. Implementations must be able to parse the shape of the
+ * scope string and convert it into a {@link Criterion}.
+ * <p>
+ * The shape of the scope string is specific to the dataspace.
+ */
+@FunctionalInterface
+public interface ScopeToCriterionTransformer {
+    /**
+     * Converts a scope string to a {@link Criterion} object. If the scope string is invalid, a failure result is returned.
+     * This can happen, for example if the shape of the string is not correct, or if a wrong operator is used in a specific
+     * context.
+     *
+     * @param scope The scope string to convert.
+     * @return A {@link Result} with the converted {@link Criterion}.
+     */
+    Result<Criterion> transform(String scope);
+}

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/CredentialQueryResolver.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/CredentialQueryResolver.java
@@ -16,10 +16,8 @@ package org.eclipse.edc.identityhub.spi.resolution;
 
 import org.eclipse.edc.identityhub.spi.model.PresentationQuery;
 import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
-import org.eclipse.edc.spi.result.Result;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * Resolves a list of {@link VerifiableCredentialContainer} objects based on an incoming {@link PresentationQuery} and a list of scope strings.
@@ -34,5 +32,5 @@ public interface CredentialQueryResolver {
      * @param query        The representation of the query to be executed.
      * @param issuerScopes The list of issuer scopes to be considered during the query processing.
      */
-    Result<Stream<VerifiableCredentialContainer>> query(PresentationQuery query, List<String> issuerScopes);
+    QueryResult query(PresentationQuery query, List<String> issuerScopes);
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/CredentialQueryResolver.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/CredentialQueryResolver.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
 import org.eclipse.edc.spi.result.Result;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Resolves a list of {@link VerifiableCredentialContainer} objects based on an incoming {@link PresentationQuery} and a list of scope strings.
@@ -33,5 +34,5 @@ public interface CredentialQueryResolver {
      * @param query        The representation of the query to be executed.
      * @param issuerScopes The list of issuer scopes to be considered during the query processing.
      */
-    Result<List<VerifiableCredentialContainer>> query(PresentationQuery query, List<String> issuerScopes);
+    Result<Stream<VerifiableCredentialContainer>> query(PresentationQuery query, List<String> issuerScopes);
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/QueryFailure.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/QueryFailure.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.resolution;
+
+import org.eclipse.edc.spi.result.Failure;
+
+import java.util.List;
+
+public class QueryFailure extends Failure {
+    private final Reason reason;
+
+    QueryFailure(List<String> messages, Reason reason) {
+        super(messages);
+        this.reason = reason;
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public enum Reason {
+        INVALID_SCOPE,
+        STORAGE_FAILURE,
+        UNAUTHORIZED_SCOPE,
+        OTHER
+    }
+}

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/QueryResult.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/QueryResult.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.resolution;
+
+import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
+import org.eclipse.edc.spi.result.AbstractResult;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.INVALID_SCOPE;
+import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.OTHER;
+import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.STORAGE_FAILURE;
+import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.UNAUTHORIZED_SCOPE;
+
+
+public class QueryResult extends AbstractResult<Stream<VerifiableCredentialContainer>, QueryFailure, QueryResult> {
+    protected QueryResult(Stream<VerifiableCredentialContainer> content, QueryFailure failure) {
+        super(content, failure);
+    }
+
+    public QueryFailure.Reason reason() {
+        return getFailure().getReason();
+    }
+
+    @Override
+    protected <R1 extends AbstractResult<C1, QueryFailure, R1>, C1> @NotNull R1 newInstance(@Nullable C1 content, @Nullable QueryFailure failure) {
+        if (content instanceof Stream) {
+            return (R1) new QueryResult((Stream) content, failure);
+        }
+        return (R1) new QueryResult(null, failure);
+    }
+
+    public static QueryResult other(String... message) {
+        return new QueryResult(null, new QueryFailure(Arrays.asList(message), OTHER));
+    }
+
+    public static QueryResult noScopeFound(String message) {
+        return new QueryResult(null, new QueryFailure(List.of(message), INVALID_SCOPE));
+    }
+
+    public static QueryResult storageFailure(List<String> failureMessages) {
+        return new QueryResult(null, new QueryFailure(failureMessages, STORAGE_FAILURE));
+    }
+
+    public static QueryResult invalidScope(List<String> failureMessages) {
+        return new QueryResult(null, new QueryFailure(failureMessages, INVALID_SCOPE));
+    }
+
+    public static QueryResult unauthorized(String failureMessage) {
+        return new QueryResult(null, new QueryFailure(List.of(failureMessage), UNAUTHORIZED_SCOPE));
+    }
+
+    public static QueryResult success(Stream<VerifiableCredentialContainer> credentials) {
+        return new QueryResult(credentials, null);
+    }
+
+}

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/QueryResult.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/QueryResult.java
@@ -19,16 +19,16 @@ import org.eclipse.edc.spi.result.AbstractResult;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.INVALID_SCOPE;
-import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.OTHER;
 import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.STORAGE_FAILURE;
 import static org.eclipse.edc.identityhub.spi.resolution.QueryFailure.Reason.UNAUTHORIZED_SCOPE;
 
-
+/**
+ * Represents a query executed by the {@link CredentialQueryResolver}
+ */
 public class QueryResult extends AbstractResult<Stream<VerifiableCredentialContainer>, QueryFailure, QueryResult> {
     protected QueryResult(Stream<VerifiableCredentialContainer> content, QueryFailure failure) {
         super(content, failure);
@@ -46,26 +46,37 @@ public class QueryResult extends AbstractResult<Stream<VerifiableCredentialConta
         return (R1) new QueryResult(null, failure);
     }
 
-    public static QueryResult other(String... message) {
-        return new QueryResult(null, new QueryFailure(Arrays.asList(message), OTHER));
-    }
-
+    /**
+     * The query failed because no scope string was found
+     */
     public static QueryResult noScopeFound(String message) {
         return new QueryResult(null, new QueryFailure(List.of(message), INVALID_SCOPE));
     }
 
+    /**
+     * The query failed because the credential storage reported an error
+     */
     public static QueryResult storageFailure(List<String> failureMessages) {
         return new QueryResult(null, new QueryFailure(failureMessages, STORAGE_FAILURE));
     }
 
+    /**
+     * The query failed, because the scope string was not valid (format, allowed values, etc.)
+     */
     public static QueryResult invalidScope(List<String> failureMessages) {
         return new QueryResult(null, new QueryFailure(failureMessages, INVALID_SCOPE));
     }
 
+    /**
+     * The query failed because the query is unauthorized, e.g. by insufficiently broad scopes
+     */
     public static QueryResult unauthorized(String failureMessage) {
         return new QueryResult(null, new QueryFailure(List.of(failureMessage), UNAUTHORIZED_SCOPE));
     }
 
+    /**
+     * Query successful. List of credentials is in the content.
+     */
     public static QueryResult success(Stream<VerifiableCredentialContainer> credentials) {
         return new QueryResult(credentials, null);
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR implements the `CredentialQueryResolver` that accepts a presentation query and returns a list of VerifiableCredentials.

It also adds a default Scope-to-Criterion converter.

## Why it does that

Being able to query the database based off of a scope string.

## Further notes

- Using DIF Presentation Exchange definitions is not yet supported. Attempting to do that will throw an `UnsupportedOperationException`.
- the `EdcScopeToCriterionTransformer` is intended for demo purposes only, do **not** use it in production code!

## Linked Issue(s)

Closes #153

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
