### PR TITLE
feat!: avoid empty nested arrays when generating VP

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/token/verification/AccessTokenVerifierImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/token/verification/AccessTokenVerifierImpl.java
@@ -68,7 +68,7 @@ public class AccessTokenVerifierImpl implements AccessTokenVerifier {
 
         // make sure an access_token claim exists
         var claimToken = validationResult.getContent();
-        if (claimToken.getClaim("access_token") == null) {
+        if (claimToken.getClaim(ACCES_TOKEN_CLAIM) == null) {
             return failure("No 'access_token' claim was found on ID Token.");
         }
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/PresentationGeneratorImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/PresentationGeneratorImplTest.java
@@ -63,7 +63,7 @@ class PresentationGeneratorImplTest {
         List<VerifiableCredentialContainer> ldpVcs = List.of();
 
         var result = presentationGenerator.createPresentation(ldpVcs, null);
-        assertThat(result).isSucceeded();
+        assertThat(result).isSucceeded().matches(pr -> pr.vpToken().length == 0, "VP Tokens should be empty");
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

This PR avoids the generation of nested empty arrays when generating VPs without any VC. 
- Before: `{"vpToken": [ [] ], ...}`
- After: `{"vpToken": [], ...}`


## Why it does that

Bugfix

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
