### PR TITLE
fix: various smaller fixes for IATP

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -3,7 +3,7 @@ maven/mavencentral/com.apicatalog/iron-ed25519-cryptosuite-2020/0.8.1, Apache-2.
 maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0, approved, #9234
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
-maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.2, Apache-2.0, approved, #8912
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.3, Apache-2.0, approved, #8912
 maven/mavencentral/com.ethlo.time/itu/1.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.0, Apache-2.0, approved, #5303
@@ -12,11 +12,12 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.1, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.2, Apache-2.0, approved, #7947
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.3, Apache-2.0, approved, #7947
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.0, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.1, Apache-2.0 AND MIT, approved, #4303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.2, Apache-2.0 AND MIT, approved, #4303
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.1, MIT AND Apache-2.0, approved, #7932
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.2, MIT AND Apache-2.0, approved, #7932
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.3, MIT AND Apache-2.0, approved, #7932
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.0, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.11.0, Apache-2.0, approved, CQ23093
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.0, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.1, Apache-2.0, approved, #4105
@@ -24,24 +25,27 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.2, Apache-2.
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.1, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.2, Apache-2.0, approved, #7934
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.15.3, Apache-2.0, approved, #7934
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.0, Apache-2.0, approved, #11605
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.0, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.1, Apache-2.0, approved, #8802
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2, Apache-2.0, approved, #8802
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.3, Apache-2.0, approved, #8802
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.15.3, Apache-2.0, approved, #9179
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.0, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.2, Apache-2.0, approved, #4699
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.1, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2, Apache-2.0, approved, #7930
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.3, Apache-2.0, approved, #7930
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.15.3, Apache-2.0, approved, #9235
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.16.0, , restricted, clearlydefined
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.1, Apache-2.0, approved, #9236
 maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.2, Apache-2.0, approved, #9236
-maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.15.3, Apache-2.0, approved, #9236
+maven/mavencentral/com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.14.1, Apache-2.0, approved, #5308
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.15.3, Apache-2.0, approved, #9241
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.1, Apache-2.0, approved, #7929
-maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.15.3, Apache-2.0, approved, #7929
+maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.0, , restricted, clearlydefined
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.3, Apache-2.0, approved, #10346
@@ -81,7 +85,7 @@ maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11086
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11701
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
@@ -120,8 +124,8 @@ maven/mavencentral/io.netty/netty-tcnative-boringssl-static/2.0.56.Final, Apache
 maven/mavencentral/io.netty/netty-tcnative-classes/2.0.56.Final, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 maven/mavencentral/io.netty/netty-transport/4.1.86.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-maven/mavencentral/io.opentelemetry/opentelemetry-api/1.31.0, Apache-2.0, approved, #11087
-maven/mavencentral/io.opentelemetry/opentelemetry-context/1.31.0, Apache-2.0, approved, #11088
+maven/mavencentral/io.opentelemetry/opentelemetry-api/1.32.0, Apache-2.0, approved, #11682
+maven/mavencentral/io.opentelemetry/opentelemetry-context/1.32.0, Apache-2.0, approved, #11683
 maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, approved, clearlydefined
@@ -210,11 +214,11 @@ maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, 
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.76, MIT, approved, #9825
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.76, MIT AND CC0-1.0, approved, #9827
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.76, MIT, approved, #9828
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
@@ -363,5 +367,4 @@ maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
-maven/mavencentral/org.yaml/snakeyaml/2.1, Apache-2.0, approved, #9847
 maven/mavencentral/org.yaml/snakeyaml/2.2, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #10232

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -153,7 +153,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         when(accessTokenVerifier.verify(anyString())).thenReturn(Result.success(List.of("test-scope1")));
         when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(success(Stream.empty()));
 
-        when(generator.createPresentation(anyList(), any())).thenReturn(Result.failure("test-failure"));
+        when(generator.createPresentation(anyList(), any(), any())).thenReturn(Result.failure("test-failure"));
 
         assertThatThrownBy(() -> controller().queryPresentation(createObjectBuilder().build(), generateJwt()))
                 .isExactlyInstanceOf(EdcException.class)
@@ -169,7 +169,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         when(queryResolver.query(any(), eq(List.of("test-scope1")))).thenReturn(success(Stream.empty()));
 
         var pres = new PresentationResponse(new Object[] {generateJwt()}, new PresentationSubmission("id", "def-id", List.of(new InputDescriptorMapping("id", "ldp_vp", "$.verifiableCredentials[0]"))));
-        when(generator.createPresentation(anyList(), any())).thenReturn(Result.success(pres));
+        when(generator.createPresentation(anyList(), any(), any())).thenReturn(Result.success(pres));
 
         var response = controller().queryPresentation(createObjectBuilder().build(), generateJwt());
         assertThat(response).isNotNull();

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
@@ -75,13 +75,13 @@ public class CredentialQueryResolverImpl implements CredentialQueryResolver {
 
         // check that prover scope is not wider than issuer scope
         var issuerQuery = convertToQuerySpec(issuerScopeResult.getContent());
-        var predicate = issuerQuery.getFilterExpression().stream()
-                .map(c -> credentialsPredicate(c.getOperandRight().toString()))
-                .reduce(Predicate::or)
-                .orElse(x -> false);
+        var allowedCred = credentialStore.query(issuerQuery);
+        if (allowedCred.failed()) {
+            return QueryResult.invalidScope(allowedCred.getFailureMessages());
+        }
 
         // now narrow down the requested credentials to only contain allowed credentials
-        var isValidQuery = requestedCredentials.stream().filter(predicate).count() == requestedCredentials.size();
+        var isValidQuery = allowedCred.getContent().count() == requestedCredentials.size();
 
         return isValidQuery ?
                 QueryResult.success(requestedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential))

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImpl.java
@@ -81,7 +81,8 @@ public class CredentialQueryResolverImpl implements CredentialQueryResolver {
         }
 
         // now narrow down the requested credentials to only contain allowed credentials
-        var isValidQuery = allowedCred.getContent().count() == requestedCredentials.size();
+        var content = allowedCred.getContent().toList();
+        var isValidQuery = content.equals(requestedCredentials);
 
         return isValidQuery ?
                 QueryResult.success(requestedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential))

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/PresentationCreatorRegistryImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/PresentationCreatorRegistryImpl.java
@@ -37,11 +37,11 @@ public class PresentationCreatorRegistryImpl implements PresentationCreatorRegis
     }
 
     @Override
-    public <T> T createPresentation(List<VerifiableCredentialContainer> credentials, CredentialFormat format) {
+    public <T> T createPresentation(List<VerifiableCredentialContainer> credentials, CredentialFormat format, Map<String, Object> additionalData) {
         var creator = ofNullable(creators.get(format)).orElseThrow(() -> new EdcException("No PresentationCreator was found for CredentialFormat %s".formatted(format)));
         var keyId = ofNullable(keyIds.get(format)).orElseThrow(() -> new EdcException("No key ID was registered for CredentialFormat %s".formatted(format)));
 
-        return (T) creator.createPresentation(credentials, keyId);
+        return (T) creator.createPresentation(credentials, keyId, additionalData);
     }
 
     @Override

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformer.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformer.java
@@ -41,20 +41,21 @@ public class EdcScopeToCriterionTransformer implements ScopeToCriterionTransform
     public static final String TYPE_OPERAND = "verifiableCredential.credential.types";
     public static final String ALIAS_LITERAL = "org.eclipse.edc.vc.type";
     public static final String LIKE_OPERATOR = "like";
+    public static final String CONTAINS_OPERATOR = "contains";
     private static final String SCOPE_SEPARATOR = ":";
     private final List<String> allowedOperations = List.of("read", "*", "all");
 
     @Override
     public Result<Criterion> transform(String scope) {
-        var tokens = parseScope(scope);
+        var tokens = tokenize(scope);
         if (tokens.failed()) {
             return failure("Scope string cannot be converted: %s".formatted(tokens.getFailureDetail()));
         }
         var credentialType = tokens.getContent()[1];
-        return success(new Criterion(TYPE_OPERAND, LIKE_OPERATOR, credentialType));
+        return success(new Criterion(TYPE_OPERAND, CONTAINS_OPERATOR, credentialType));
     }
 
-    private Result<String[]> parseScope(String scope) {
+    protected Result<String[]> tokenize(String scope) {
         if (scope == null) return failure("Scope was null");
 
         var tokens = scope.split(SCOPE_SEPARATOR);

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/defaults/InMemoryCredentialStore.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/defaults/InMemoryCredentialStore.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.spi.result.StoreResult;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.spi.result.StoreResult.alreadyExists;
@@ -54,7 +55,7 @@ public class InMemoryCredentialStore implements CredentialStore {
     public StoreResult<Stream<VerifiableCredentialResource>> query(QuerySpec querySpec) {
         lock.readLock().lock();
         try {
-            var result = queryResolver.query(store.values().stream(), querySpec);
+            var result = queryResolver.query(store.values().stream(), querySpec, Predicate::or, x -> false);
             return success(result);
         } finally {
             lock.readLock().unlock();

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
@@ -51,7 +51,7 @@ class CredentialQueryResolverImplTest {
 
     @Test
     void query_noResult() {
-        when(storeMock.query(any())).thenReturn(success(Stream.empty()));
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.empty()));
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
                 List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
         assertThat(res.succeeded()).isTrue();
@@ -88,7 +88,7 @@ class CredentialQueryResolverImplTest {
     @Test
     void query_singleScopeString() {
         var credential = createCredentialResource("TestCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential)));
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential)));
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
                 List.of("org.eclipse.edc.vc.type:TestCredential:read"));
         assertThat(res.succeeded()).withFailMessage(res::getFailureDetail).isTrue();
@@ -99,7 +99,7 @@ class CredentialQueryResolverImplTest {
     void query_multipleScopeStrings() {
         var credential1 = createCredentialResource("TestCredential");
         var credential2 = createCredentialResource("AnotherCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1, credential2)));
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential1, credential2)));
 
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read",
                         "org.eclipse.edc.vc.type:AnotherCredential:read"),
@@ -120,7 +120,8 @@ class CredentialQueryResolverImplTest {
     void query_requestsTooManyCredentials_shouldReturnFailure() {
         var credential1 = createCredentialResource("TestCredential");
         var credential2 = createCredentialResource("AnotherCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1, credential2)));
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential1, credential2)))
+                .thenAnswer(i -> success(Stream.of(credential1)));
 
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read",
                         "org.eclipse.edc.vc.type:AnotherCredential:read"),
@@ -134,7 +135,7 @@ class CredentialQueryResolverImplTest {
     @Test
     void query_moreCredentialsAllowed_shouldReturnOnlyRequested() {
         var credential1 = createCredentialResource("TestCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential1)));
 
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
                 List.of("org.eclipse.edc.vc.type:TestCredential:read", "org.eclipse.edc.vc.type:AnotherCredential:read"));
@@ -146,7 +147,7 @@ class CredentialQueryResolverImplTest {
     @Test
     void query_exactMatchAllowedAndRequestedCredentials() {
         var credential1 = createCredentialResource("TestCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential1)));
 
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
                 List.of("org.eclipse.edc.vc.type:TestCredential:read"));
@@ -158,7 +159,9 @@ class CredentialQueryResolverImplTest {
     @Test
     void query_requestedCredentialNotAllowed() {
         var credential1 = createCredentialResource("TestCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+        var credential2 = createCredentialResource("AnotherCredential");
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential1)))
+                .thenAnswer(i -> success(Stream.of(credential2)));
 
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read"),
                 List.of("org.eclipse.edc.vc.type:AnotherCredential:read"));
@@ -172,12 +175,15 @@ class CredentialQueryResolverImplTest {
     void query_sameSizeDifferentScope() {
         var credential1 = createCredentialResource("TestCredential");
         var credential2 = createCredentialResource("AnotherCredential");
-        when(storeMock.query(any())).thenReturn(success(Stream.of(credential1)));
+        var credential3 = createCredentialResource("FooCredential");
+        var credential4 = createCredentialResource("BarCredential");
+        when(storeMock.query(any())).thenAnswer(i -> success(Stream.of(credential1, credential2)))
+                .thenAnswer(i -> success(Stream.of(credential3, credential4)));
 
         var res = resolver.query(createPresentationQuery("org.eclipse.edc.vc.type:TestCredential:read", "org.eclipse.edc.vc.type:AnotherCredential:read"),
                 List.of("org.eclipse.edc.vc.type:FooCredential:read", "org.eclipse.edc.vc.type:BarCredential:read"));
 
-        assertThat(res.failed()).isTrue();
+        assertThat(res.succeeded()).isFalse();
         assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
         assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
     }

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/PresentationGeneratorImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/PresentationGeneratorImplTest.java
@@ -58,7 +58,7 @@ class PresentationGeneratorImplTest {
 
     @Test
     void generate_noCredentials() {
-        when(registry.createPresentation(anyList(), eq(JSON_LD))).thenReturn(jsonObject(EMPTY_LDP_VP));
+        when(registry.createPresentation(anyList(), eq(JSON_LD), any())).thenReturn(jsonObject(EMPTY_LDP_VP));
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
         List<VerifiableCredentialContainer> ldpVcs = List.of();
 
@@ -68,85 +68,85 @@ class PresentationGeneratorImplTest {
 
     @Test
     void generate_defaultFormatLdp_containsOnlyLdpVc() {
-        when(registry.createPresentation(any(), eq(JSON_LD))).thenReturn(jsonObject(LDP_VP_WITH_PROOF));
+        when(registry.createPresentation(any(), eq(JSON_LD), any())).thenReturn(jsonObject(LDP_VP_WITH_PROOF));
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JSON_LD));
         var result = presentationGenerator.createPresentation(credentials, null);
 
         assertThat(result).isSucceeded();
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JSON_LD));
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JSON_LD), any());
     }
 
     @Test
     void generate_defaultFormatLdp_mixedVcs() {
-        when(registry.createPresentation(any(), eq(JSON_LD))).thenReturn(jsonObject(LDP_VP_WITH_PROOF));
-        when(registry.createPresentation(any(), eq(JWT))).thenReturn(JWT_VP);
+        when(registry.createPresentation(any(), eq(JSON_LD), any())).thenReturn(jsonObject(LDP_VP_WITH_PROOF));
+        when(registry.createPresentation(any(), eq(JWT), any())).thenReturn(JWT_VP);
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JWT));
 
         var result = presentationGenerator.createPresentation(credentials, null);
         assertThat(result).isSucceeded();
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 1), eq(JWT));
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 1), eq(JSON_LD));
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 1), eq(JWT), any());
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 1), eq(JSON_LD), any());
         verify(monitor).warning(eq("The VP was requested in JSON_LD format, but the request yielded 1 JWT-VCs, which cannot be transported in a LDP-VP. A second VP will be returned, containing JWT-VCs"));
     }
 
     @Test
     void generate_defaultFormatLdp_onlyJwtVcs() {
-        when(registry.createPresentation(any(), eq(JWT))).thenReturn(JWT_VP);
-        when(registry.createPresentation(any(), eq(JSON_LD))).thenReturn(jsonObject(EMPTY_LDP_VP));
+        when(registry.createPresentation(any(), eq(JWT), any())).thenReturn(JWT_VP);
+        when(registry.createPresentation(any(), eq(JSON_LD), any())).thenReturn(jsonObject(EMPTY_LDP_VP));
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
 
         var credentials = List.of(createCredential(JWT), createCredential(JWT));
 
         var result = presentationGenerator.createPresentation(credentials, null);
         assertThat(result).isSucceeded();
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT));
-        verify(registry, never()).createPresentation(any(), eq(JSON_LD));
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
+        verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
         verify(monitor).warning(eq("The VP was requested in JSON_LD format, but the request yielded 2 JWT-VCs, which cannot be transported in a LDP-VP. A second VP will be returned, containing JWT-VCs"));
     }
 
     @Test
     void generate_defaultFormatJwt_onlyJwtVcs() {
-        when(registry.createPresentation(any(), eq(JWT))).thenReturn(JWT_VP);
-        when(registry.createPresentation(any(), eq(JSON_LD))).thenReturn(jsonObject(EMPTY_LDP_VP));
+        when(registry.createPresentation(any(), eq(JWT), any())).thenReturn(JWT_VP);
+        when(registry.createPresentation(any(), eq(JSON_LD), any())).thenReturn(jsonObject(EMPTY_LDP_VP));
         presentationGenerator = new PresentationGeneratorImpl(JWT, registry, monitor);
 
         var credentials = List.of(createCredential(JWT), createCredential(JWT));
 
         var result = presentationGenerator.createPresentation(credentials, null);
         assertThat(result).isSucceeded();
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT));
-        verify(registry, never()).createPresentation(any(), eq(JSON_LD));
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
+        verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
     }
 
     @Test
     void generate_defaultFormatJwt_mixedVcs() {
-        when(registry.createPresentation(any(), eq(JSON_LD))).thenReturn(jsonObject(LDP_VP_WITH_PROOF));
-        when(registry.createPresentation(any(), eq(JWT))).thenReturn(JWT_VP);
+        when(registry.createPresentation(any(), eq(JSON_LD), any())).thenReturn(jsonObject(LDP_VP_WITH_PROOF));
+        when(registry.createPresentation(any(), eq(JWT), any())).thenReturn(JWT_VP);
         presentationGenerator = new PresentationGeneratorImpl(JWT, registry, monitor);
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JWT));
 
         var result = presentationGenerator.createPresentation(credentials, null);
         assertThat(result).isSucceeded();
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT));
-        verify(registry, never()).createPresentation(any(), eq(JSON_LD));
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
+        verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
     }
 
     @Test
     void generate_defaultFormatJwt_onlyLdpVc() {
-        when(registry.createPresentation(any(), eq(JWT))).thenReturn(JWT_VP);
+        when(registry.createPresentation(any(), eq(JWT), any())).thenReturn(JWT_VP);
         presentationGenerator = new PresentationGeneratorImpl(JWT, registry, monitor);
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JSON_LD));
         var result = presentationGenerator.createPresentation(credentials, null);
 
         assertThat(result).isSucceeded();
-        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT));
-        verify(registry, never()).createPresentation(any(), eq(JSON_LD));
+        verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
+        verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
     }
 
     @Test

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/PresentationGeneratorImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/PresentationGeneratorImplTest.java
@@ -62,7 +62,7 @@ class PresentationGeneratorImplTest {
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
         List<VerifiableCredentialContainer> ldpVcs = List.of();
 
-        var result = presentationGenerator.createPresentation(ldpVcs, null);
+        var result = presentationGenerator.createPresentation(ldpVcs, null, null);
         assertThat(result).isSucceeded().matches(pr -> pr.vpToken().length == 0, "VP Tokens should be empty");
     }
 
@@ -72,7 +72,7 @@ class PresentationGeneratorImplTest {
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JSON_LD));
-        var result = presentationGenerator.createPresentation(credentials, null);
+        var result = presentationGenerator.createPresentation(credentials, null, null);
 
         assertThat(result).isSucceeded();
         verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JSON_LD), any());
@@ -86,7 +86,7 @@ class PresentationGeneratorImplTest {
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JWT));
 
-        var result = presentationGenerator.createPresentation(credentials, null);
+        var result = presentationGenerator.createPresentation(credentials, null, null);
         assertThat(result).isSucceeded();
         verify(registry).createPresentation(argThat(argument -> argument.size() == 1), eq(JWT), any());
         verify(registry).createPresentation(argThat(argument -> argument.size() == 1), eq(JSON_LD), any());
@@ -101,7 +101,7 @@ class PresentationGeneratorImplTest {
 
         var credentials = List.of(createCredential(JWT), createCredential(JWT));
 
-        var result = presentationGenerator.createPresentation(credentials, null);
+        var result = presentationGenerator.createPresentation(credentials, null, null);
         assertThat(result).isSucceeded();
         verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
         verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
@@ -116,7 +116,7 @@ class PresentationGeneratorImplTest {
 
         var credentials = List.of(createCredential(JWT), createCredential(JWT));
 
-        var result = presentationGenerator.createPresentation(credentials, null);
+        var result = presentationGenerator.createPresentation(credentials, null, null);
         assertThat(result).isSucceeded();
         verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
         verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
@@ -130,7 +130,7 @@ class PresentationGeneratorImplTest {
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JWT));
 
-        var result = presentationGenerator.createPresentation(credentials, null);
+        var result = presentationGenerator.createPresentation(credentials, null, null);
         assertThat(result).isSucceeded();
         verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
         verify(registry, never()).createPresentation(any(), eq(JSON_LD), any());
@@ -142,7 +142,7 @@ class PresentationGeneratorImplTest {
         presentationGenerator = new PresentationGeneratorImpl(JWT, registry, monitor);
 
         var credentials = List.of(createCredential(JSON_LD), createCredential(JSON_LD));
-        var result = presentationGenerator.createPresentation(credentials, null);
+        var result = presentationGenerator.createPresentation(credentials, null, null);
 
         assertThat(result).isSucceeded();
         verify(registry).createPresentation(argThat(argument -> argument.size() == 2), eq(JWT), any());
@@ -152,7 +152,7 @@ class PresentationGeneratorImplTest {
     @Test
     void generate_withPresentationDef_shouldLogWarning() {
         presentationGenerator = new PresentationGeneratorImpl(JSON_LD, registry, monitor);
-        presentationGenerator.createPresentation(List.of(), PresentationDefinition.Builder.newInstance().id("test-id").build());
+        presentationGenerator.createPresentation(List.of(), PresentationDefinition.Builder.newInstance().id("test-id").build(), null);
         verify(monitor).warning(contains("A PresentationDefinition was submitted, but is currently ignored by the generator."));
 
     }

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/defaults/InMemoryCredentialStoreTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/defaults/InMemoryCredentialStoreTest.java
@@ -61,9 +61,9 @@ class InMemoryCredentialStoreTest {
 
         resources.forEach(store::create);
 
-        var res = store.query(QuerySpec.max());
+        var res = store.query(QuerySpec.none());
         assertThat(res).isSucceeded();
-        Assertions.assertThat(res.getContent()).hasSize(5).containsAll(resources);
+        Assertions.assertThat(res.getContent()).isEmpty();
     }
 
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/token/verification/AccessTokenVerifierImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/token/verification/AccessTokenVerifierImplTest.java
@@ -53,7 +53,7 @@ class AccessTokenVerifierImplTest {
     private final JwtVerifier jwtVerifierMock = mock();
     private final JwtValidator jwtValidatorMock = mock();
     private final PublicKeyWrapper pkWrapper = mock();
-    private final AccessTokenVerifierImpl verifier = new AccessTokenVerifierImpl(jwtVerifierMock, jwtValidatorMock, OWN_DID, pkWrapper);
+    private final AccessTokenVerifierImpl verifier = new AccessTokenVerifierImpl(jwtVerifierMock, jwtValidatorMock, OWN_DID, pkWrapper, mock());
 
     @BeforeEach
     void setup() throws JOSEException {
@@ -62,23 +62,12 @@ class AccessTokenVerifierImplTest {
         when(pkWrapper.verifier()).thenReturn(new ECDSAVerifier(CONSUMER_KEY));
     }
 
-    private ClaimToken convert(TokenRepresentation argument) {
-        try {
-            var ctb = ClaimToken.Builder.newInstance();
-            SignedJWT.parse(argument.getToken()).getJWTClaimsSet().getClaims().forEach(ctb::claim);
-            return ctb.build();
-        } catch (ParseException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     void verify_validJwt() {
         assertThat(verifier.verify(generateSiToken(OWN_DID, OWN_DID, OTHER_PARTICIPANT_DID, OTHER_PARTICIPANT_DID)))
                 .isSucceeded()
                 .satisfies(strings -> Assertions.assertThat(strings).containsOnly(TEST_SCOPE));
     }
-
 
     @Test
     void verify_jwtVerifierFails() {
@@ -137,6 +126,16 @@ class AccessTokenVerifierImplTest {
 
         assertThat(verifier.verify(siToken)).isFailed()
                 .detail().contains("No scope claim was found on the access_token");
+    }
+
+    private ClaimToken convert(TokenRepresentation argument) {
+        try {
+            var ctb = ClaimToken.Builder.newInstance();
+            SignedJWT.parse(argument.getToken()).getJWTClaimsSet().getClaims().forEach(ctb::claim);
+            return ctb.build();
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ResolutionApiComponentTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ResolutionApiComponentTest.java
@@ -177,7 +177,7 @@ public class ResolutionApiComponentTest {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
         when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(QueryResult.success(Stream.empty()));
-        when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null))).thenReturn(failure("generator test error"));
+        when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null), any())).thenReturn(failure("generator test error"));
 
         IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType(JSON)
@@ -194,7 +194,7 @@ public class ResolutionApiComponentTest {
         var token = generateSiToken();
         when(ACCESS_TOKEN_VERIFIER.verify(eq(token))).thenReturn(success(List.of("test-scope1")));
         when(CREDENTIAL_QUERY_RESOLVER.query(any(), ArgumentMatchers.anyList())).thenReturn(QueryResult.success(Stream.empty()));
-        when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null))).thenReturn(success(createPresentationResponse()));
+        when(PRESENTATION_GENERATOR.createPresentation(anyList(), eq(null), any())).thenReturn(success(createPresentationResponse()));
 
         var resp = IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType(JSON)

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/generator/PresentationCreatorRegistry.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/generator/PresentationCreatorRegistry.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.identitytrust.model.CredentialFormat;
 import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Registry that contains multiple {@link PresentationCreator} objects and assigns them a {@link CredentialFormat}.
@@ -34,15 +35,16 @@ public interface PresentationCreatorRegistry {
      * Creates a VerifiablePresentation based on a list of verifiable credentials and a credential format. How the presentation will be represented
      * depends on the format. JWT-VPs will be represented as {@link String}, LDP-VPs will be represented as {@link jakarta.json.JsonObject}.
      *
-     * @param credentials The list of verifiable credentials to include in the presentation.
-     * @param format      The format for the presentation.
-     * @param <T>         The type of the presentation. Can be {@link String}, when format is {@link CredentialFormat#JWT}, or {@link jakarta.json.JsonObject},
-     *                    when the format is {@link CredentialFormat#JSON_LD}
+     * @param <T>            The type of the presentation. Can be {@link String}, when format is {@link CredentialFormat#JWT}, or {@link jakarta.json.JsonObject},
+     *                       when the format is {@link CredentialFormat#JSON_LD}
+     * @param credentials    The list of verifiable credentials to include in the presentation.
+     * @param format         The format for the presentation.
+     * @param additionalData Optional additional data that might be required to create the presentation, such as types, etc.
      * @return The created presentation.
      * @throws IllegalArgumentException         if the credential cannot be represented in the desired format. For example, LDP-VPs cannot contain JWT-VCs.
      * @throws org.eclipse.edc.spi.EdcException if no creator is registered for a particular format
      */
-    <T> T createPresentation(List<VerifiableCredentialContainer> credentials, CredentialFormat format);
+    <T> T createPresentation(List<VerifiableCredentialContainer> credentials, CredentialFormat format, Map<String, Object> additionalData);
 
     /**
      * Specify, which key ID is to be used for which {@link CredentialFormat}. It is recommended to use a separate key for every format.

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/generator/PresentationGenerator.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/generator/PresentationGenerator.java
@@ -33,7 +33,8 @@ public interface PresentationGenerator {
      *
      * @param credentials            The list of verifiable credentials to include in the presentation.
      * @param presentationDefinition The optional presentation definition.
+     * @param audience               The Participant ID of the party who the presentation is intended for. May not be relevant for all VP formats
      * @return A Result object containing a PresentationResponse if the presentation creation is successful, or a failure message if it fails.
      */
-    Result<PresentationResponse> createPresentation(List<VerifiableCredentialContainer> credentials, @Nullable PresentationDefinition presentationDefinition);
+    Result<PresentationResponse> createPresentation(List<VerifiableCredentialContainer> credentials, @Nullable PresentationDefinition presentationDefinition, @Nullable String audience);
 }

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/IdentityResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/IdentityResource.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.spi.store.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.time.Clock;
 import java.util.Objects;
 import java.util.UUID;
@@ -28,6 +30,7 @@ public abstract class IdentityResource {
     protected long timestamp;
     protected String issuerId;
     protected String holderId;
+    @JsonIgnore
     protected Clock clock;
 
     public Clock getClock() {


### PR DESCRIPTION
- fix: several minor improvements and fixes
- add "audience" parameter

## What this PR changes/adds

This is a collection PR for the following minor improvements/fixes:
- `LdpPresentationCreator`: add proof purpose and verification method properties when signing LDP-VPs
- `CredentialQueryResolver`: execute actual database query when comparing issuer and prover scope. This was necessary because the in-memory predicate does not properly map the credential types
- `PresentationGenerator`: pass additional data to VP creators (e.g. "aud" for JWT-VPs)
- `AccessTokenVerifierImpl`: only issue a warning when proof-of-possession was not established. This is a specific issue when the Participant ID and the token subject are not equal
- add some source doc and comments

## Why it does that

These issues arose during end-to-end testing and setting up a demo installation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
