### PR TITLE
feat: implement local DidPublisher

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -57,9 +57,9 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.crypto.tink/tink/1.11.0, Apache-2.0, approved, #10719
+maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/28.1-android, Apache-2.0, approved, clearlydefined
@@ -69,14 +69,13 @@ maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clea
 maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
-maven/mavencentral/com.google.protobuf/protobuf-java/3.19.6, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.jayway.jsonpath/json-path/2.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.jcraft/jzlib/1.1.3, BSD-2-Clause, approved, CQ6218
 maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37, Apache-2.0, approved, #11701
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
@@ -124,11 +123,10 @@ maven/mavencentral/io.prometheus/simpleclient_httpserver/0.16.0, Apache-2.0, app
 maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.rest-assured/json-path/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/rest-assured/5.3.2, Apache-2.0, approved, #9262
-maven/mavencentral/io.rest-assured/rest-assured/5.4.0, , restricted, clearlydefined
-maven/mavencentral/io.rest-assured/xml-path/5.4.0, , restricted, clearlydefined
+maven/mavencentral/io.rest-assured/json-path/5.4.0, Apache-2.0, approved, #12042
+maven/mavencentral/io.rest-assured/rest-assured-common/5.4.0, Apache-2.0, approved, #12039
+maven/mavencentral/io.rest-assured/rest-assured/5.4.0, Apache-2.0, approved, #12040
+maven/mavencentral/io.rest-assured/xml-path/5.4.0, Apache-2.0, approved, #12038
 maven/mavencentral/io.setl/rdf-urdna/1.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.15, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.18, Apache-2.0, approved, #5947
@@ -215,7 +213,7 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.31.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/api-observability/0.4.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.4.2-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -290,15 +288,15 @@ maven/mavencentral/org.glassfish.hk2/hk2-api/3.0.5, EPL-2.0 OR GPL-2.0-only with
 maven/mavencentral/org.glassfish.hk2/hk2-locator/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/hk2-utils/3.0.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 maven/mavencentral/org.glassfish.hk2/osgi-resource-locator/1.0.3, CDDL-1.0, approved, CQ10889
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.4, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.5, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
 maven/mavencentral/org.hamcrest/hamcrest-core/1.3, BSD-2-Clause, approved, CQ11429
 maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, clearlydefined
@@ -344,7 +342,7 @@ maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
 maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.ow2.asm/asm/9.2, BSD-3-Clause, approved, CQ23635
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
-maven/mavencentral/org.postgresql/postgresql/42.7.0, BSD-2-Clause AND Apache-2.0, approved, #11681
+maven/mavencentral/org.postgresql/postgresql/42.7.1, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, approved, clearlydefined
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/1.7.22, MIT, approved, CQ11943

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityservice/api/PresentationApiExtension.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityservice/api/PresentationApiExtension.java
@@ -34,37 +34,36 @@ import org.eclipse.edc.web.jersey.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.jersey.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 
+import static org.eclipse.edc.identityservice.api.PresentationApiExtension.NAME;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
-@Extension(value = "Presentation API Extension")
+@Extension(value = NAME)
 public class PresentationApiExtension implements ServiceExtension {
 
+    public static final String NAME = "Presentation API Extension";
     public static final String RESOLUTION_SCOPE = "resolution-scope";
     public static final String RESOLUTION_CONTEXT = "resolution";
-
     @Inject
     private TypeTransformerRegistry typeTransformer;
-
     @Inject
     private JsonObjectValidatorRegistry validatorRegistry;
-
     @Inject
     private WebService webService;
-
     @Inject
     private AccessTokenVerifier accessTokenVerifier;
-
     @Inject
     private CredentialQueryResolver credentialResolver;
-
     @Inject
     private VerifiablePresentationService verifiablePresentationService;
-
     @Inject
     private JsonLd jsonLd;
-
     @Inject
     private TypeManager typeManager;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
 
     @Override
     public void initialize(ServiceExtensionContext context) {

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImpl.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.did;
+
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisher;
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * In-mem variant of the publisher registry.
+ */
+public class DidDocumentPublisherRegistryImpl implements DidDocumentPublisherRegistry {
+    private final Map<String, DidDocumentPublisher> publishers = new HashMap<>();
+
+
+    @Override
+    public void addPublisher(String didMethodName, DidDocumentPublisher publisher) {
+        publishers.put(didMethodName, publisher);
+    }
+
+    @Override
+    public DidDocumentPublisher getPublisher(String did) {
+        return publishers.get(did);
+    }
+
+    @Override
+    public boolean canPublish(String did) {
+        return publishers.containsKey(did);
+    }
+}

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -14,7 +14,9 @@
 
 package org.eclipse.edc.identityhub.did;
 
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
 
 import static org.eclipse.edc.identityhub.did.DidServicesExtension.NAME;
@@ -22,4 +24,14 @@ import static org.eclipse.edc.identityhub.did.DidServicesExtension.NAME;
 @Extension(value = NAME)
 public class DidServicesExtension implements ServiceExtension {
     public static final String NAME = "DID Service Extension";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public DidDocumentPublisherRegistry createRegistry() {
+        return new DidDocumentPublisherRegistryImpl();
+    }
 }

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/defaults/DidDefaultServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/defaults/DidDefaultServicesExtension.java
@@ -25,6 +25,11 @@ import static org.eclipse.edc.identityhub.did.defaults.DidDefaultServicesExtensi
 public class DidDefaultServicesExtension implements ServiceExtension {
     public static final String NAME = "DID Default Services Extension";
 
+    @Override
+    public String name() {
+        return NAME;
+    }
+
     @Provider(isDefault = true)
     public DidResourceStore createInMemoryDidResourceStore() {
         return new InMemoryDidResourceStore();

--- a/extensions/did/local-did-publisher/build.gradle.kts
+++ b/extensions/did/local-did-publisher/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+    `maven-publish`
+}
+
+val swagger: String by project
+
+dependencies {
+
+    api(project(":spi:identity-hub-did-spi"))
+    implementation(libs.jakarta.rsApi)
+    implementation(libs.edc.spi.web)
+
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.restAssured)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+}

--- a/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/DidWebController.java
+++ b/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/DidWebController.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.publisher.did.local;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.DidWebParser;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("{any:.*}")
+public class DidWebController {
+    private static final Charset DEFAULT_CHARSET = Charset.defaultCharset();
+    private static final Pattern CHARSET_REGEX_PATTERN = Pattern.compile("(?i)\\bcharset=\\s*\"?([^\\s;\"]*)");
+    private final Monitor monitor;
+    private final DidResourceStore didResourceStore;
+    private final DidWebParser didWebParser;
+
+    public DidWebController(Monitor monitor, DidResourceStore didResourceStore, DidWebParser didWebParser) {
+        this.monitor = monitor;
+        this.didResourceStore = didResourceStore;
+        this.didWebParser = didWebParser;
+    }
+
+    @GET
+    public DidDocument getDidDocument(@Context ContainerRequestContext context) {
+
+        var httpUrl = context.getUriInfo().getAbsolutePath();
+
+        var charset = extractCharset(context.getHeaderString(CONTENT_TYPE));
+        String did;
+        did = didWebParser.parse(httpUrl, charset);
+
+
+        var q = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("state", "=", DidState.PUBLISHED.code()))
+                .filter(new Criterion("did", "=", did))
+                .build();
+
+        monitor.debug("Looking up '%s'".formatted(did));
+        var dids = didResourceStore.query(q)
+                .stream()
+                .map(DidResource::getDocument)
+                .toList();
+
+        if (dids.size() > 1) {
+            throw new InvalidRequestException("DID '%s' resolved more than one document".formatted(did));
+        }
+
+        return dids.stream().findFirst().orElse(null);
+    }
+
+    private Charset extractCharset(String contentType) {
+        return Optional.ofNullable(contentType)
+                .map(this::parseCharsetFromContentType)
+                .orElse(DEFAULT_CHARSET);
+    }
+
+    /**
+     * Parses the "charset" attribute from the Content-Type header. Returns the value of the charset attribute,
+     * or {@link Charset#defaultCharset()} if the attribute was not present or represents an invalid charset
+     *
+     * @param contentType The Content-Type header
+     * @return The value of the charset attribute or the default charset
+     */
+    private Charset parseCharsetFromContentType(String contentType) {
+        var m = CHARSET_REGEX_PATTERN.matcher(contentType);
+        if (m.find()) {
+            var cs = m.group(1).trim().toUpperCase();
+            if (Charset.isSupported(cs)) {
+                return Charset.forName(cs);
+            } else {
+                monitor.warning("Charset '%s' is not supported, defaulting to %s".formatted(cs, DEFAULT_CHARSET));
+                return DEFAULT_CHARSET;
+            }
+        }
+        return DEFAULT_CHARSET;
+    }
+}

--- a/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisher.java
+++ b/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisher.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.publisher.did.local;
+
+import org.eclipse.edc.identithub.did.spi.DidConstants;
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisher;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+
+import java.util.Collection;
+
+import static org.eclipse.edc.identithub.did.spi.DidConstants.DID_WEB_METHOD_REGEX;
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+
+/**
+ * A DID publisher that maintains "did:web" documents by making them available through a simple HTTP endpoint ({@link DidWebController}).
+ * All documents in the database ({@link DidResourceStore})where the {@link DidResource#getState()} == {@link DidState#PUBLISHED}
+ * are regarded as published and are made available through an HTTP endpoint.
+ */
+public class LocalDidPublisher implements DidDocumentPublisher {
+
+    private final DidResourceStore didResourceStore;
+    private final Monitor monitor;
+
+    public LocalDidPublisher(DidResourceStore didResourceStore, Monitor monitor) {
+        this.didResourceStore = didResourceStore;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public boolean canHandle(String id) {
+        return DID_WEB_METHOD_REGEX.matcher(id).matches();
+    }
+
+    @Override
+    public Result<Void> publish(String did) {
+        var existingDocument = didResourceStore.findById(did);
+        if (existingDocument == null) {
+            return Result.failure("A DID Resource with the ID '%s' was not found.".formatted(did));
+        }
+
+        if (isPublished(existingDocument)) {
+            monitor.warning("DID '%s' is already published - this action will overwrite it.".formatted(did));
+        }
+
+        existingDocument.transitionState(DidState.PUBLISHED);
+
+        return didResourceStore.update(existingDocument)
+                .map(v -> success())
+                .orElse(f -> failure(f.getFailureDetail()));
+    }
+
+    @Override
+    public Result<Void> unpublish(String did) {
+        var existingDocument = didResourceStore.findById(did);
+        if (existingDocument == null) {
+            return Result.failure("A DID Resource with the ID '%s' was not found.".formatted(did));
+        }
+
+        if (!isPublished(existingDocument)) {
+            monitor.info("Un-publish DID Resource '%s': not published -> NOOP.".formatted(did));
+            // do not return early, the state could be anything
+        }
+
+        existingDocument.transitionState(DidState.UNPUBLISHED);
+        return didResourceStore.update(existingDocument)
+                .map(v -> success())
+                .orElse(f -> failure(f.getFailureDetail()));
+
+    }
+
+    @Override
+    public Collection<DidResource> getPublishedDocuments() {
+        var q = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("state", "=", DidState.PUBLISHED.code()))
+                .filter(new Criterion("did", "like", DidConstants.DID_WEB_METHOD + "%"))
+                .build();
+
+        return didResourceStore.query(q);
+    }
+
+    private boolean isPublished(DidResource didResource) {
+        return didResource.getState() == DidState.PUBLISHED.code();
+    }
+}

--- a/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherExtension.java
+++ b/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherExtension.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.publisher.did.local;
+
+import org.eclipse.edc.identithub.did.spi.DidConstants;
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
+import org.eclipse.edc.identithub.did.spi.DidWebParser;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+
+import static org.eclipse.edc.identityhub.publisher.did.local.LocalDidPublisherExtension.NAME;
+
+@Extension(value = NAME)
+public class LocalDidPublisherExtension implements ServiceExtension {
+    public static final String NAME = "Local DID publisher extension";
+    private static final String DID_CONTEXT_ALIAS = "did";
+    private static final String DEFAULT_DID_PATH = "/";
+    private static final int DEFAULT_DID_PORT = 10100;
+    public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
+            .apiConfigKey("web.http." + DID_CONTEXT_ALIAS)
+            .contextAlias(DID_CONTEXT_ALIAS)
+            .defaultPath(DEFAULT_DID_PATH)
+            .defaultPort(DEFAULT_DID_PORT)
+            .useDefaultContext(false)
+            .name("DID:WEB Endpoint API")
+            .build();
+    @Inject
+    private DidDocumentPublisherRegistry registry;
+    @Inject
+    private DidResourceStore didResourceStore;
+    @Inject
+    private WebService webService;
+    @Inject
+    private WebServiceConfigurer configurator;
+    @Inject
+    private WebServer webServer;
+
+    /**
+     * Allow extensions to contribute their own DID WEB parser, in case some special url modification is needed.
+     */
+    @Inject(required = false)
+    private DidWebParser didWebParser;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var webServiceConfiguration = configurator.configure(context, webServer, SETTINGS);
+        var localPublisher = new LocalDidPublisher(didResourceStore, context.getMonitor());
+        registry.addPublisher(DidConstants.DID_WEB_METHOD, localPublisher);
+        webService.registerResource(webServiceConfiguration.getContextAlias(), new DidWebController(context.getMonitor(), didResourceStore, getDidParser()));
+    }
+
+    private DidWebParser getDidParser() {
+        return didWebParser != null ? didWebParser : new DidWebParser();
+    }
+}

--- a/extensions/did/local-did-publisher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/did/local-did-publisher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.publisher.did.local.LocalDidPublisherExtension

--- a/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/DidWebControllerTest.java
+++ b/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/DidWebControllerTest.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.publisher.did.local;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.DidWebParser;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.identityhub.publisher.did.local.TestFunctions.createDidResource;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DidWebControllerTest extends RestControllerTestBase {
+
+    private final DidResourceStore storeMock = mock();
+
+    @Test
+    void getDidDocument() {
+        when(storeMock.query(any())).thenReturn(List.of(publishedDid("did:web:testdid1")));
+
+        var doc = baseRequest()
+                .get("/foo/bar")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().as(DidDocument.class);
+        assertThat(doc).isNotNull()
+                .extracting(DidDocument::getId).isEqualTo("did:web:testdid1");
+    }
+
+    @Test
+    void getDidDocument_multipleDocumentsForDid() {
+        when(storeMock.query(any())).thenReturn(List.of(publishedDid("did:web:testdid1"), publishedDid("did:web:testdid1")));
+
+        baseRequest()
+                .get("/foo/bar")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400)
+                .body(containsString("DID '%s' resolved more than one document".formatted("did:web:localhost%%3A%s:foo:bar".formatted(port))));
+    }
+
+    @Test
+    void getDidDocument_withWellKnown() {
+        when(storeMock.query(any())).thenReturn(List.of(publishedDid("did:web:testdid1")));
+
+
+        baseRequest()
+                .get("/foo/bar/.well-known/did.json")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body(containsString("did:web:testdid1"));
+
+        // verify that the query to the store was issued using the parsed DID
+        verify(storeMock).query(argThat(qs -> qs.getFilterExpression().stream().anyMatch(c -> c.getOperandRight().equals("did:web:localhost%%3A%s:foo:bar".formatted(port)))));
+    }
+
+    @Test
+    void getDidDocument_noResult() {
+        baseRequest()
+                .get("/foo/bar")
+                .then()
+                .log().ifError()
+                .statusCode(204)
+                .body(emptyString());
+    }
+
+    @Override
+    protected Object controller() {
+        return new DidWebController(monitor, storeMock, new DidWebParser());
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:" + port)
+                .when();
+    }
+
+    private static DidResource publishedDid(String did) {
+        return createDidResource(did).state(DidState.PUBLISHED).build();
+    }
+}

--- a/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherTest.java
+++ b/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherTest.java
@@ -1,0 +1,188 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.publisher.did.local;
+
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.junit.assertions.AbstractResultAssert;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.identityhub.publisher.did.local.TestFunctions.createDidResource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class LocalDidPublisherTest {
+
+    public static final String DID = "did:web:test";
+    private final DidResourceStore storeMock = mock();
+    private LocalDidPublisher publisher;
+    private Monitor monitor;
+
+    @BeforeEach
+    void setUp() {
+        monitor = mock();
+        publisher = new LocalDidPublisher(storeMock, monitor);
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {DID, "DID:web:test", "DID:WEB:TEST"})
+    void canHandle(String validDid) {
+        assertThat(publisher.canHandle(validDid)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"did:web", "DID:web:", "did:indy:whatever", "dod:web:something"})
+    void canHandle_invalid(String validDid) {
+        assertThat(publisher.canHandle(validDid)).isFalse();
+    }
+
+    @Test
+    void publish_success() {
+        when(storeMock.findById(anyString())).thenReturn(createDidResource().build());
+        when(storeMock.update(any())).thenReturn(StoreResult.success());
+
+        AbstractResultAssert.assertThat(publisher.publish(DID)).isSucceeded();
+
+        verify(storeMock).findById(anyString());
+        verify(storeMock).update(argThat(dr -> dr.getState() == DidState.PUBLISHED.code()));
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void publish_notExists_returnsFailure() {
+        when(storeMock.findById(any())).thenReturn(null);
+
+        AbstractResultAssert.assertThat(publisher.publish("did:web:foo")).isFailed()
+                .detail()
+                .isEqualTo("A DID Resource with the ID 'did:web:foo' was not found.");
+
+        verify(storeMock).findById(anyString());
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void publish_alreadyPublished_expectWarning() {
+        when(storeMock.findById(anyString())).thenReturn(createDidResource()
+                .state(DidState.PUBLISHED)
+                .build());
+        when(storeMock.update(any())).thenReturn(StoreResult.success());
+
+        AbstractResultAssert.assertThat(publisher.publish(DID)).isSucceeded();
+
+        verify(storeMock).findById(anyString());
+        verify(storeMock).update(any());
+        verify(monitor).warning("DID 'did:web:test' is already published - this action will overwrite it.");
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void publish_storeFailsUpdate_returnsFailure() {
+        when(storeMock.findById(anyString())).thenReturn(createDidResource().build());
+        when(storeMock.update(any())).thenReturn(StoreResult.duplicateKeys("test error"));
+
+        AbstractResultAssert.assertThat(publisher.publish(DID)).isFailed()
+                .detail()
+                .isEqualTo("test error");
+
+        verify(storeMock).findById(anyString());
+        verify(storeMock).update(any());
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void unpublish_success() {
+        when(storeMock.findById(anyString())).thenReturn(createDidResource()
+                .state(DidState.PUBLISHED)
+                .build());
+        when(storeMock.update(any())).thenReturn(StoreResult.success());
+
+        AbstractResultAssert.assertThat(publisher.unpublish(DID)).isSucceeded();
+
+        verify(storeMock).findById(anyString());
+        verify(storeMock).update(argThat(dr -> dr.getState() == DidState.UNPUBLISHED.code()));
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void unpublish_notExists_returnsFailure() {
+        when(storeMock.findById(anyString())).thenReturn(null);
+
+        AbstractResultAssert.assertThat(publisher.unpublish(DID)).isFailed()
+                .detail()
+                .contains("A DID Resource with the ID 'did:web:test' was not found.");
+
+        verify(storeMock).findById(anyString());
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void unpublish_notPublished_expectWarning() {
+        when(storeMock.findById(anyString())).thenReturn(createDidResource()
+                .state(DidState.UNPUBLISHED)
+                .build());
+        when(storeMock.update(any())).thenReturn(StoreResult.success());
+
+        AbstractResultAssert.assertThat(publisher.unpublish(DID)).isSucceeded();
+
+        verify(storeMock).findById(anyString());
+        verify(storeMock).update(any());
+        verifyNoMoreInteractions(storeMock);
+        verify(monitor).info("Un-publish DID Resource 'did:web:test': not published -> NOOP.");
+    }
+
+    @Test
+    void unpublish_storeFailsUpdate_returnsFailure() {
+        when(storeMock.findById(anyString())).thenReturn(createDidResource()
+                .state(DidState.PUBLISHED)
+                .build());
+        when(storeMock.update(any())).thenReturn(StoreResult.notFound("foobar"));
+
+        AbstractResultAssert.assertThat(publisher.unpublish(DID)).isFailed()
+                .detail()
+                .isEqualTo("foobar");
+
+        verify(storeMock).findById(anyString());
+        verify(storeMock).update(any());
+        verifyNoMoreInteractions(storeMock);
+    }
+
+    @Test
+    void getPublishedDocuments() {
+        var list = range(0, 10)
+                .mapToObj(i -> createDidResource().did("did:web:" + i).state(DidState.PUBLISHED).build())
+                .toList();
+
+        when(storeMock.query(any())).thenReturn(list);
+
+        assertThat(publisher.getPublishedDocuments())
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsAll(list);
+    }
+
+
+}

--- a/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/TestFunctions.java
+++ b/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/TestFunctions.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.publisher.did.local;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+
+public interface TestFunctions {
+    static DidResource.Builder createDidResource() {
+        return createDidResource("did:web:test");
+    }
+
+    static DidResource.Builder createDidResource(String did) {
+        return DidResource.Builder.newInstance()
+                .did(did)
+                .state(DidState.GENERATED)
+                .document(DidDocument.Builder.newInstance()
+                        .id(did)
+                        .build())
+                .state(DidState.INITIAL);
+    }
+}

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -20,8 +20,10 @@ plugins {
 
 dependencies {
     runtimeOnly(project(":core:identity-hub-api"))
+    runtimeOnly(project(":core:identity-hub-did"))
     runtimeOnly(project(":core:identity-hub-credentials"))
     runtimeOnly(project(":extensions:cryptography:public-key-provider"))
+    runtimeOnly(project(":extensions:did:local-did-publisher"))
     runtimeOnly(libs.edc.identity.did.core)
     runtimeOnly(libs.edc.identity.did.web)
     runtimeOnly(libs.bundles.connector)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(":core:identity-hub-did")
 include(":extensions:cryptography:public-key-provider")
 include(":extensions:store:sql:identity-hub-did-store-sql")
 include(":extensions:store:sql:identity-hub-credentials-store-sql")
+include(":extensions:did:local-did-publisher")
 
 // other modules
 include(":launcher")

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidConstants.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidConstants.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identithub.did.spi;
+
+import java.util.regex.Pattern;
+
+public interface DidConstants {
+    /**
+     * Constant for the DID:WEB method
+     */
+    String DID_WEB_METHOD = "did:web";
+    /**
+     * Pattern for use to parse a DID:WEB identifier
+     */
+    Pattern DID_WEB_METHOD_REGEX = Pattern.compile("(?i)did:web:.+");
+    /**
+     * the /.well-known path extension. Useful when resolving or parsing DIDs. Must be ignored when parsing a URL to a DID.
+     */
+    String WELL_KNOWN = "/.well-known";
+    /**
+     * last path segment when resolving DID documents. Must be clipped off before parsing a URL to a DID
+     */
+    String DID_WEB_DID_DOCUMENT = "did.json";
+}

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisher.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisher.java
@@ -15,8 +15,11 @@
 package org.eclipse.edc.identithub.did.spi;
 
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
+
+import java.util.Collection;
 
 /**
  * The DidDocumentPublisher is responsible for taking a {@link DidDocument} and making it available at a VDR (verifiable data registry).
@@ -35,18 +38,27 @@ public interface DidDocumentPublisher {
     boolean canHandle(String id);
 
     /**
-     * Publishes a given {@link DidDocument} to a verifiable data registry (VDR).
+     * Publishes a given {@link DidDocument} to a verifiable data registry (VDR). Publishing the same DID twice is a noop.
      *
-     * @param document the {@link DidDocument} to be published
+     * @param did the DID to publish. A document with that DID must exist in the database.
      * @return a {@link Result} object indicating the success or failure of the operation.
      */
-    Result<Void> publish(DidDocument document);
+    Result<Void> publish(String did);
 
     /**
-     * Unpublishes a given {@link DidDocument} from a verifiable data registry (VDR).
+     * Unpublishes a given {@link DidDocument} from a verifiable data registry (VDR). Attempting to unpublish a DID document
+     * that isn't published will result in an error.
      *
-     * @param document the {@link DidDocument} to be unpublished
+     * @param did the DID to unpublish. A document with that DID must exist in the database.
      * @return a {@link Result} object indicating the success or failure of the operation.
      */
-    Result<Void> unpublish(DidDocument document);
+    Result<Void> unpublish(String did);
+
+    /**
+     * Returns a list of all {@link DidDocument}s that are managed by this publisher, and are currently published.
+     *
+     * @return a list of documents that are currently published.
+     */
+    //todo: not sure if needed?
+    Collection<DidResource> getPublishedDocuments();
 }

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisherRegistry.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisherRegistry.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identithub.did.spi;
+
+/**
+ * Registry that hosts multiple {@link DidDocumentPublisher}s to dispatch the publishing of a DID document based on
+ * its DID method.
+ * There can only be one publisher per method.
+ */
+public interface DidDocumentPublisherRegistry {
+
+    /**
+     * Registers a {@link DidDocumentPublisher} for a given DID method.
+     *
+     * @param didMethodName The DID method name. This may include the "did:" prefix, so both "did:web" and "web" would be valid.
+     * @param publisher     The publisher to register
+     */
+    void addPublisher(String didMethodName, DidDocumentPublisher publisher);
+
+    /**
+     * Returns the publisher that was registered for a particular DID method.
+     *
+     * @param did the DID method for which the publisher was previously registered
+     * @return A {@link DidDocumentPublisher}, or null if none was registered.
+     */
+    DidDocumentPublisher getPublisher(String did);
+
+
+    /**
+     * Determines whether a given DID can be published by this registry. The DID must conform to the <a href="https://www.w3.org/TR/did-core/#did-syntax">W3C DID Syntax</a>
+     *
+     * @param did The W3C DID to examine
+     * @return true if a publisher is found for this DID method, false if no publisher is found, or the DID is not valid.
+     */
+    boolean canPublish(String did);
+}

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidWebParser.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidWebParser.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identithub.did.spi;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+import static org.eclipse.edc.identithub.did.spi.DidConstants.DID_WEB_DID_DOCUMENT;
+import static org.eclipse.edc.identithub.did.spi.DidConstants.WELL_KNOWN;
+
+/**
+ * Converts a URL into a did:web identifier by parsing the authority and the path. For example the following conversion applies:
+ * <pre>
+ *     https://foo.bar/some/path/.well-known/did.json -> did:web:foo.bar:some:path
+ *     https://foo.bar/some/path -> did:web:foo.bar:some:path
+ * </pre>
+ */
+@ExtensionPoint
+public class DidWebParser {
+
+    /**
+     * Parses a HTTP URL using the specified charset by performing the following steps:
+     * <ul>
+     *     <li>strip away any trailing slash from the path</li>
+     *     <li>strip away "did.json" and ".well-known" if present on the path</li>
+     *     <li>replace all remaining slashes with colons ":" in the path</li>
+     *     <li>URL-Encode the authority ("host:port") to clearly distinguish it from the method separator ":"</li>
+     *     <li>prepend "did:web:"</li>
+     * </ul>
+     *
+     * @param url     The input URL
+     * @param charset The charset used for encoding the {@link URL#getAuthority()}. Defaults to {@link Charset#defaultCharset()}
+     * @return a "did:web:XYZ" identifier
+     */
+    public String parse(URI url, Charset charset) {
+        var path = url.getPath();
+        path = stripTrailingSlash(path);
+
+        if (path.endsWith(DID_WEB_DID_DOCUMENT)) {
+            path = path.substring(0, path.indexOf(DID_WEB_DID_DOCUMENT));
+            path = stripTrailingSlash(path);
+        }
+        if (path.endsWith(WELL_KNOWN)) {
+            path = path.replace(DidConstants.WELL_KNOWN, "");
+            path = stripTrailingSlash(path);
+        }
+        path = path.replace("/", ":");
+
+        // ports must be percent-encoded:
+        var identifier = "%s%s".formatted(URLEncoder.encode(url.getAuthority(), charset), path);
+
+        return "%s:%s".formatted(DidConstants.DID_WEB_METHOD, identifier);
+    }
+
+    @NotNull
+    private String stripTrailingSlash(String path) {
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.lastIndexOf("/"));
+        }
+        return path;
+    }
+
+}

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
@@ -61,6 +61,10 @@ public class DidResource {
         return document;
     }
 
+    public void transitionState(DidState newState) {
+        this.state = newState.code();
+    }
+
     public static final class Builder {
         private final DidResource resource;
 

--- a/spi/identity-hub-did-spi/src/test/java/org/eclipse/edc/identithub/did/spi/DidWebParserTest.java
+++ b/spi/identity-hub-did-spi/src/test/java/org/eclipse/edc/identithub/did/spi/DidWebParserTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identithub.did.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.charset.Charset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DidWebParserTest {
+    private static final Charset DEFAULT_CHARSET = Charset.defaultCharset();
+    private final DidWebParser parser = new DidWebParser();
+
+    @Test
+    void parse() throws MalformedURLException {
+        assertThat(parser.parse(URI.create("http://localhost:123"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123");
+        assertThat(parser.parse(URI.create("http://localhost:123/.well-known"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/.well-known"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/.well-known/"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/.well-known/did.json"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/.well-known/did.json/"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/.well-known/did.json/asdf"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh:.well-known:did.json:asdf");
+        assertThat(parser.parse(URI.create("http://localhost:123/asdf/gh/.well-known/did.json/asdf/"), DEFAULT_CHARSET)).isEqualTo("did:web:localhost%3A123:asdf:gh:.well-known:did.json:asdf");
+
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a local `DidPublisher`, that is intended for testing and demo purposes to provide a working out-of-the-box experience.

The `LocalDidPublisher` "publishes" DID documents by simply modifying their `DidState` and setting it to `PUBLISHED`. Then, there is the 
`DidWebController`, which serves DID documents by taking the request URL and converting it to a DID.  For example if the controller's context is configured as
```properties
web.http.did.port=10100
web.http.did.path="/"
```
then the `DidWebController` would accept all paths starting with "/". That means, that DID documents with the following IDs would be returned, provided they are found in the database:

```
http://localhost:10100/did/someone/say/cookie                      --> did:web:localhost%3A10100:did:someone:say:cookie
http://localhost:10100/did/someone/say/cookie/.well-known/did.json --> did:web:localhost%3A10100:did:someone:say:cookie
http://localhost:10100/.well-known/did.json                        --> did:web:localhost%3A10100
http://loclahost:10100/                                            --> did:web:localhost%3A10100
```

Note that the port of the host gets URL-encoded.

The `LocalDidPublisher` only works with `did:web` DIDs.

## Why it does that

out-of-the-box experience for IATP

## Further notes, questions

- the IDs of the documents that are stored in the DB will depend on the URL of the endpoint, which may make it necessary to dynamically generate DID documents. This could be cumbersome, especially in clustered environments. so maybe we could make the `DidWebParser` extensible, to intercept the URL->DID conversion?
- similarly, an endpoint may be reachable via multiple URLs, e.g. Kubernetes: pod IPs, Service addresses, ingresses, LBs,... Being able to define aliases could be beneficial there too.

## Linked Issue(s)

Closes #189

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
