### PR TITLE
feat: implement DID management API

### DIFF
--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,19 +8,19 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.identityservice.api;
+package org.eclipse.edc.identityhub.api;
 
 import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToPresentationQueryTransformer;
+import org.eclipse.edc.identityhub.api.v1.PresentationApiController;
+import org.eclipse.edc.identityhub.api.validation.PresentationQueryValidator;
 import org.eclipse.edc.identityhub.spi.generator.VerifiablePresentationService;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
-import org.eclipse.edc.identityservice.api.v1.PresentationApiController;
-import org.eclipse.edc.identityservice.api.validation.PresentationQueryValidator;
 import org.eclipse.edc.identitytrust.model.credentialservice.PresentationQuery;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -34,7 +34,7 @@ import org.eclipse.edc.web.jersey.jsonld.JerseyJsonLdInterceptor;
 import org.eclipse.edc.web.jersey.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 
-import static org.eclipse.edc.identityservice.api.PresentationApiExtension.NAME;
+import static org.eclipse.edc.identityhub.api.PresentationApiExtension.NAME;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 @Extension(value = NAME)

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/ApiSchema.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/ApiSchema.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.identityservice.api.v1;
+package org.eclipse.edc.identityhub.api.v1;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApi.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApi.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.identityservice.api.v1;
+package org.eclipse.edc.identityhub.api.v1;
 
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
@@ -29,7 +29,6 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.Response;
-import org.eclipse.edc.identityservice.api.v1.ApiSchema.ApiErrorDetailSchema;
 import org.eclipse.edc.identitytrust.model.credentialservice.PresentationResponse;
 
 @OpenAPIDefinition(
@@ -50,14 +49,14 @@ public interface PresentationApi {
                     @ApiResponse(responseCode = "200", description = "The query was successfully processed, the response contains the VerifiablePresentation",
                             content = @Content(schema = @Schema(implementation = PresentationResponse.class), mediaType = "application/ld+json")),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, for example when both scope and presentationDefinition are given",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetailSchema.class)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "No Authorization header was given.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetailSchema.class)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "403", description = "The given authentication token could not be validated. This can happen, when the request body " +
                             "calls for a broader query scope than the granted scope in the auth token",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetailSchema.class)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "501", description = "When the request contained a presentationDefinition object, but the implementation does not support it.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetailSchema.class)), mediaType = "application/json"))
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json"))
             }
     )
     Response queryPresentation(JsonObject query, String authHeader);

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.identityservice.api.v1;
+package org.eclipse.edc.identityhub.api.v1;
 
 import com.nimbusds.jwt.SignedJWT;
 import jakarta.json.JsonObject;

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/validation/PresentationQueryValidator.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/validation/PresentationQueryValidator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,11 +8,11 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 
-package org.eclipse.edc.identityservice.api.validation;
+package org.eclipse.edc.identityhub.api.validation;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityservice.api.v1;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.api.v1.PresentationApiController;
 import org.eclipse.edc.identityhub.spi.generator.VerifiablePresentationService;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.resolution.QueryResult;

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/validation/PresentationQueryValidatorTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/validation/PresentationQueryValidatorTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.api.validation.PresentationQueryValidator;
 import org.eclipse.edc.identitytrust.model.credentialservice.PresentationQuery;
 import org.eclipse.edc.identitytrust.model.presentationdefinition.Constraints;
 import org.eclipse.edc.identitytrust.model.presentationdefinition.Field;

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImpl.java
@@ -24,23 +24,29 @@ import java.util.Map;
  * In-mem variant of the publisher registry.
  */
 public class DidDocumentPublisherRegistryImpl implements DidDocumentPublisherRegistry {
-    public static final String DID_PREFIX = "did:";
+    public static final String DID_PREFIX = "did";
     public static final String DID_METHOD_SEPARATOR = ":";
+    private static final int DID_PREFIX_INDEX = 4;
     private final Map<String, DidDocumentPublisher> publishers = new HashMap<>();
 
     @Override
-    public void addPublisher(String didMethodName, DidDocumentPublisher publisher) {
-        publishers.put(didMethodName, publisher);
+    public void addPublisher(String didMethodNameIncludingPrefix, DidDocumentPublisher publisher) {
+        publishers.put(didMethodNameIncludingPrefix, publisher);
     }
 
     @Override
     public DidDocumentPublisher getPublisher(String did) {
-        // only need the "did" and method prefix
-        did = did.replace(DID_PREFIX, "");
-        var endIndex = did.indexOf(DID_METHOD_SEPARATOR);
-        return endIndex >= 0 ?
-                publishers.get(DID_PREFIX + did.substring(0, endIndex)) :
-                null;
+
+        if (!did.startsWith(DID_PREFIX)) {
+            throw new IllegalArgumentException("A DID must include the 'did' prefix.");
+        }
+        var endIndex = did.indexOf(DID_METHOD_SEPARATOR, DID_PREFIX_INDEX);
+        if (endIndex >= 0) {
+            var method = did.substring(0, endIndex);
+            return publishers.get(method);
+        } else {
+            return publishers.get(did); // endIndex can be -1 when only the method was passed, e.g. "did:web"
+        }
     }
 
 }

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImpl.java
@@ -24,8 +24,9 @@ import java.util.Map;
  * In-mem variant of the publisher registry.
  */
 public class DidDocumentPublisherRegistryImpl implements DidDocumentPublisherRegistry {
+    public static final String DID_PREFIX = "did:";
+    public static final String DID_METHOD_SEPARATOR = ":";
     private final Map<String, DidDocumentPublisher> publishers = new HashMap<>();
-
 
     @Override
     public void addPublisher(String didMethodName, DidDocumentPublisher publisher) {
@@ -34,11 +35,12 @@ public class DidDocumentPublisherRegistryImpl implements DidDocumentPublisherReg
 
     @Override
     public DidDocumentPublisher getPublisher(String did) {
-        return publishers.get(did);
+        // only need the "did" and method prefix
+        did = did.replace(DID_PREFIX, "");
+        var endIndex = did.indexOf(DID_METHOD_SEPARATOR);
+        return endIndex >= 0 ?
+                publishers.get(DID_PREFIX + did.substring(0, endIndex)) :
+                null;
     }
 
-    @Override
-    public boolean canPublish(String did) {
-        return publishers.containsKey(did);
-    }
 }

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.did;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.util.Collection;
+
+/**
+ * This is an aggregate service to manage CRUD operations of {@link DidDocument}s as well as handle their
+ * publishing and un-publishing. All methods are executed transactionally.
+ */
+public class DidDocumentServiceImpl implements DidDocumentService {
+
+    private final TransactionContext transactionContext;
+    private final DidResourceStore didResourceStore;
+    private final DidDocumentPublisherRegistry registry;
+
+    public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry) {
+        this.transactionContext = transactionContext;
+        this.didResourceStore = didResourceStore;
+        this.registry = registry;
+    }
+
+    @Override
+    public ServiceResult<Void> store(DidDocument document) {
+        return transactionContext.execute(() -> {
+            var res = DidResource.Builder.newInstance()
+                    .document(document)
+                    .did(document.getId())
+                    .build();
+            var result = didResourceStore.save(res);
+            return result.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.fromFailure(result);
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> publish(String did) {
+        return transactionContext.execute(() -> {
+            var existingDoc = didResourceStore.findById(did);
+            if (existingDoc == null) {
+                return ServiceResult.notFound(notFoundMessage(did));
+            }
+            var publisher = registry.getPublisher(did);
+            if (publisher == null) {
+                return ServiceResult.badRequest(noPublisherFoundMessage(did));
+            }
+            var publishResult = publisher.publish(did);
+            return publishResult.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.badRequest(publishResult.getFailureDetail());
+
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> unpublish(String did) {
+        return transactionContext.execute(() -> {
+            var existingDoc = didResourceStore.findById(did);
+            if (existingDoc == null) {
+                return ServiceResult.notFound(notFoundMessage(did));
+            }
+            var publisher = registry.getPublisher(did);
+            if (publisher == null) {
+                return ServiceResult.badRequest(noPublisherFoundMessage(did));
+            }
+            var publishResult = publisher.unpublish(did);
+            return publishResult.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.badRequest(publishResult.getFailureDetail());
+
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> update(DidDocument document) {
+        return transactionContext.execute(() -> {
+            // obtain existing resource from storage
+            var did = document.getId();
+            var existing = didResourceStore.findById(did);
+            if (existing == null) {
+                return ServiceResult.notFound(notFoundMessage(did));
+            }
+
+            //update only the did document
+            var updatedResource = DidResource.Builder.newInstance()
+                    .document(document)
+                    .did(did)
+                    .state(existing.getState())
+                    .createTimestamp(existing.getCreateTimestamp())
+                    .stateTimeStamp(existing.getStateTimestamp())
+                    .build();
+
+            var res = didResourceStore.update(updatedResource);
+            return res.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.fromFailure(res);
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> deleteById(String did) {
+        return transactionContext.execute(() -> {
+            var existing = didResourceStore.findById(did);
+            if (existing == null) {
+                return ServiceResult.notFound(notFoundMessage(did));
+            }
+            if (existing.getState() == DidState.PUBLISHED.code()) {
+                return ServiceResult.conflict("Cannot delete DID '%s' because it is already published. Un-publish first!".formatted(did));
+            }
+            var res = didResourceStore.deleteById(did);
+            return res.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.fromFailure(res);
+        });
+    }
+
+    @Override
+    public ServiceResult<Collection<DidDocument>> queryDocuments(QuerySpec query) {
+        return transactionContext.execute(() -> {
+            var res = didResourceStore.query(query);
+            return ServiceResult.success(res.stream().map(DidResource::getDocument).toList());
+        });
+    }
+
+    @Override
+    public DidResource findById(String did) {
+        return transactionContext.execute(() -> didResourceStore.findById(did));
+    }
+}

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -15,15 +15,25 @@
 package org.eclipse.edc.identityhub.did;
 
 import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import static org.eclipse.edc.identityhub.did.DidServicesExtension.NAME;
 
 @Extension(value = NAME)
 public class DidServicesExtension implements ServiceExtension {
     public static final String NAME = "DID Service Extension";
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private DidResourceStore didResourceStore;
+
+    private DidDocumentPublisherRegistry didPublisherRegistry;
 
     @Override
     public String name() {
@@ -31,7 +41,15 @@ public class DidServicesExtension implements ServiceExtension {
     }
 
     @Provider
-    public DidDocumentPublisherRegistry createRegistry() {
-        return new DidDocumentPublisherRegistryImpl();
+    public DidDocumentPublisherRegistry getDidPublisherRegistry() {
+        if (didPublisherRegistry == null) {
+            didPublisherRegistry = new DidDocumentPublisherRegistryImpl();
+        }
+        return didPublisherRegistry;
+    }
+
+    @Provider
+    public DidDocumentService createDidDocumentService() {
+        return new DidDocumentServiceImpl(transactionContext, didResourceStore, getDidPublisherRegistry());
     }
 }

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentPublisherRegistryImplTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.did;
+
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisher;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.edc.identithub.did.spi.DidConstants.DID_WEB_METHOD;
+import static org.mockito.Mockito.mock;
+
+class DidDocumentPublisherRegistryImplTest {
+    private final DidDocumentPublisherRegistryImpl registry = new DidDocumentPublisherRegistryImpl();
+
+    @Test
+    void getPublisher_exists() {
+        var mockedPublisher = mock(DidDocumentPublisher.class);
+        registry.addPublisher(DID_WEB_METHOD, mockedPublisher);
+        assertThat(registry.getPublisher(DID_WEB_METHOD + ":foobar")).isEqualTo(mockedPublisher);
+    }
+
+    @Test
+    void getPublisher_whenOnlyMethod() {
+        var mockedPublisher = mock(DidDocumentPublisher.class);
+        registry.addPublisher(DID_WEB_METHOD, mockedPublisher);
+        assertThat(registry.getPublisher(DID_WEB_METHOD)).isEqualTo(mockedPublisher);
+        assertThat(registry.getPublisher(DID_WEB_METHOD + ":")).isEqualTo(mockedPublisher);
+    }
+
+    @Test
+    void getPublisher_notExists() {
+        assertThat(registry.getPublisher(DID_WEB_METHOD + ":foobar")).isNull();
+    }
+
+    @Test
+    void getPublisher_invalidDid() {
+        assertThatThrownBy(() -> registry.getPublisher("web:foobar")).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -1,0 +1,283 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.did;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisher;
+import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class DidDocumentServiceImplTest {
+    private final DidResourceStore storeMock = mock();
+    private final DidDocumentPublisherRegistry publisherRegistry = mock();
+    private final DidDocumentPublisher publisherMock = mock();
+    private DidDocumentServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        var trx = new NoopTransactionContext();
+        when(publisherRegistry.getPublisher(startsWith("did:web:"))).thenReturn(publisherMock);
+
+        service = new DidDocumentServiceImpl(trx, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void store() {
+        var doc = createDidDocument().build();
+        when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.success());
+        assertThat(service.store(doc)).isSucceeded();
+    }
+
+    @Test
+    void store_alreadyExists() {
+        var doc = createDidDocument().build();
+        when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.alreadyExists("foo"));
+        assertThat(service.store(doc)).isFailed().detail().isEqualTo("foo");
+        verify(storeMock).save(any());
+        verifyNoInteractions(publisherMock);
+    }
+
+    @Test
+    void publish() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(publisherMock.publish(did)).thenReturn(Result.success());
+
+        assertThat(service.publish(did)).isSucceeded();
+
+        verify(storeMock).findById(did);
+        verify(publisherMock).publish(did);
+        verifyNoMoreInteractions(publisherMock, storeMock);
+    }
+
+    @Test
+    void publish_notExist() {
+        var did = "did:web:test-did";
+        when(storeMock.findById(eq(did))).thenReturn(null);
+
+        assertThat(service.publish(did)).isFailed()
+                .detail().isEqualTo(service.notFoundMessage(did));
+
+        verify(storeMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, storeMock);
+    }
+
+    @Test
+    void publish_noPublisherFound() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(publisherRegistry.getPublisher(any())).thenReturn(null);
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+
+        assertThat(service.publish(did)).isFailed().detail()
+                .isEqualTo(service.noPublisherFoundMessage(did));
+
+        verify(storeMock).findById(did);
+        verify(publisherRegistry).getPublisher(did);
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void publish_publisherReportsError() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(publisherMock.publish(did)).thenReturn(Result.failure("test-failure"));
+
+        assertThat(service.publish(did)).isFailed()
+                .detail()
+                .isEqualTo("test-failure");
+
+        verify(storeMock).findById(did);
+        verify(publisherMock).publish(did);
+        verifyNoMoreInteractions(publisherMock, storeMock);
+    }
+
+    @Test
+    void unpublish() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(publisherMock.unpublish(did)).thenReturn(Result.success());
+
+        assertThat(service.unpublish(did)).isSucceeded();
+
+        verify(storeMock).findById(did);
+        verify(publisherMock).unpublish(did);
+        verifyNoMoreInteractions(publisherMock, storeMock);
+    }
+
+    @Test
+    void unpublish_notExist() {
+        var did = "did:web:test-did";
+        when(storeMock.findById(eq(did))).thenReturn(null);
+
+        assertThat(service.unpublish(did)).isFailed()
+                .detail().isEqualTo(service.notFoundMessage(did));
+
+        verify(storeMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, storeMock);
+    }
+
+    @Test
+    void unpublish_noPublisherFound() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(publisherRegistry.getPublisher(any())).thenReturn(null);
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+
+        assertThat(service.unpublish(did)).isFailed().detail()
+                .isEqualTo(service.noPublisherFoundMessage(did));
+
+        verify(storeMock).findById(did);
+        verify(publisherRegistry).getPublisher(did);
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void unpublish_publisherReportsError() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(publisherMock.unpublish(did)).thenReturn(Result.failure("test-failure"));
+
+        assertThat(service.unpublish(did)).isFailed()
+                .detail()
+                .isEqualTo("test-failure");
+
+        verify(storeMock).findById(did);
+        verify(publisherMock).unpublish(did);
+        verifyNoMoreInteractions(publisherMock, storeMock);
+    }
+
+    @Test
+    void update() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(storeMock.update(any())).thenReturn(StoreResult.success());
+
+        assertThat(service.update(doc)).isSucceeded();
+
+        verify(storeMock).findById(did);
+        verify(storeMock).update(argThat(dr -> dr.getDocument().equals(doc)));
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void update_notExists() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(null);
+        when(storeMock.update(any())).thenReturn(StoreResult.success());
+
+        assertThat(service.update(doc))
+                .isFailed()
+                .detail()
+                .isEqualTo(service.notFoundMessage(did));
+
+        verify(storeMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void deleteById() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.UNPUBLISHED).document(doc).build());
+        when(storeMock.deleteById(any())).thenReturn(StoreResult.success());
+
+        assertThat(service.deleteById(did)).isSucceeded();
+
+        verify(storeMock).findById(did);
+        verify(storeMock).deleteById(did);
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void deleteById_alreadyPublished() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+
+        assertThat(service.deleteById(did)).isFailed()
+                .detail()
+                .isEqualTo("Cannot delete DID '%s' because it is already published. Un-publish first!".formatted(did));
+
+        verify(storeMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void deleteById_notExists() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.UNPUBLISHED).document(doc).build());
+        when(storeMock.deleteById(any())).thenReturn(StoreResult.notFound("test-message"));
+
+        assertThat(service.deleteById(did)).isFailed().detail().isEqualTo("test-message");
+
+        verify(storeMock).findById(did);
+        verify(storeMock).deleteById(did);
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    @Test
+    void queryDocuments() {
+        var q = QuerySpec.max();
+        var doc = createDidDocument().build();
+        var res = DidResource.Builder.newInstance().did(doc.getId()).state(DidState.PUBLISHED).document(doc).build();
+        when(storeMock.query(any())).thenReturn(List.of(res));
+
+        assertThat(service.queryDocuments(q)).isSucceeded();
+
+        verify(storeMock).query(eq(q));
+        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+    }
+
+    private DidDocument.Builder createDidDocument() {
+        return DidDocument.Builder.newInstance()
+                .id("did:web:testdid")
+                .service(List.of(new Service("test-service", "test-service", "https://test.service.com/")))
+                .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
+                        .id("did:web:testdid#key-1")
+                        .publicKeyMultibase("saflasjdflaskjdflasdkfj")
+                        .build()));
+    }
+}

--- a/extensions/did/did-management-api/build.gradle.kts
+++ b/extensions/did/did-management-api/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(project(":spi:identity-hub-spi"))
+    api(project(":spi:identity-hub-did-spi"))
+    implementation(libs.edc.spi.validator)
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.core.jerseyproviders)
+    implementation(libs.jakarta.rsApi)
+
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.ext.jsonld)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+    testImplementation(testFixtures(project(":spi:identity-hub-spi")))
+    testImplementation(libs.nimbus.jwt)
+    testImplementation(libs.restAssured)
+}

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.didmanagement;
+
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identityhub.api.didmanagement.v1.DidManagementApiController;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+
+import static org.eclipse.edc.identityhub.api.didmanagement.DidManagementApiExtension.NAME;
+
+@Extension(value = NAME)
+public class DidManagementApiExtension implements ServiceExtension {
+
+    public static final String NAME = "DID Management API Extension";
+    private static final String MGMT_CONTEXT_ALIAS = "management";
+    private static final String DEFAULT_DID_PATH = "/api/management";
+    private static final int DEFAULT_DID_PORT = 8182;
+    public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
+            .apiConfigKey("web.http." + MGMT_CONTEXT_ALIAS)
+            .contextAlias(MGMT_CONTEXT_ALIAS)
+            .defaultPath(DEFAULT_DID_PATH)
+            .defaultPort(DEFAULT_DID_PORT)
+            .useDefaultContext(false)
+            .name("DID Management Endpoint API")
+            .build();
+    @Inject
+    private WebService webService;
+    @Inject
+    private DidDocumentService didDocumentService;
+    @Inject
+    private WebServiceConfigurer configurer;
+    @Inject
+    private WebServer webServer;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var webServiceConfiguration = configurer.configure(context, webServer, SETTINGS);
+
+        var controller = new DidManagementApiController(didDocumentService);
+        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
+    }
+
+}

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.didmanagement.v1;
+
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
+
+import java.util.Collection;
+
+@OpenAPIDefinition(
+        info = @Info(description = "This is the Management API for DID documents", title = "DID Management API", version = "1"))
+public interface DidManagementApi {
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Stores a new DID document and optionally also publishes it",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidDocument.class), mediaType = "application/json")),
+            parameters = {@Parameter(name = "publish", description = "Indicates whether the DID should be published right after creation")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully stored"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, for example the DID document was invalid",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "409", description = "Can't create the DID document, because a document with the same ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void createDidDocument(DidDocument document, boolean publish);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Publish an (existing) DID document. The DID is expected to exist in the database.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully published."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The DID could not be published because it does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void publishDidFromBody(DidRequestPayload didRequestPayload);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Un-Publish an (existing) DID document. The DID is expected to exist in the database.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully un-published."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "400", description = "The DID could not be unpublished because the underlying VDR does not support un-publishing.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The DID could not be un-published because it does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void unpublishDidFromBody(DidRequestPayload didRequestPayload);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Updates an (existing) DID document and re-publishes it if so desired. The DID is expected to exist in the database.",
+            parameters = {@Parameter(name = "republish", description = "Indicates whether the DID document should be re-published after the update.")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The DID could not be updated because it does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void updateDid(DidDocument document, boolean republish);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Delete an (existing) DID document. The DID is expected to exist in the database.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully deleted."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The DID could not be deleted because it does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "409", description = "The DID could not be deleted because it is already published. Un-publish first.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void deleteDidFromBody(DidRequestPayload request);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Query for DID documents..",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully deleted.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = DidDocument.class)))),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "400", description = "The query was malformed or was not understood by the server.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+            }
+    )
+    Collection<DidDocument> queryDid(QuerySpec querySpec);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Get state of a DID document",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID state was successfully obtained"),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The DID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+            }
+    )
+    String getState(DidRequestPayload request);
+}

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiController.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiController.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.didmanagement.v1;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identityhub.api.didmanagement.v1.validation.DidRequestValidator;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+
+import java.util.Collection;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v1/dids")
+public class DidManagementApiController implements DidManagementApi {
+
+    private final DidDocumentService documentService;
+    private final DidRequestValidator requestValidator;
+
+    public DidManagementApiController(DidDocumentService documentService) {
+        this.documentService = documentService;
+        this.requestValidator = new DidRequestValidator();
+    }
+
+    @POST
+    @Override
+    public void createDidDocument(DidDocument document, @QueryParam("publish") boolean publish) {
+        requestValidator.validate(document).orElseThrow(ValidationFailureException::new);
+
+        documentService.store(document)
+                .compose(v -> publish ? documentService.publish(document.getId()) : ServiceResult.success())
+                .orElseThrow(exceptionMapper(DidDocument.class, document.getId()));
+    }
+
+    @Override
+    @POST
+    @Path("/publish")
+    public void publishDidFromBody(DidRequestPayload didRequestPayload) {
+        documentService.publish(didRequestPayload.did())
+                .orElseThrow(exceptionMapper(DidDocument.class, didRequestPayload.did()));
+    }
+
+    @Override
+    @POST
+    @Path("/unpublish")
+    public void unpublishDidFromBody(DidRequestPayload didRequestPayload) {
+        documentService.unpublish(didRequestPayload.did())
+                .orElseThrow(exceptionMapper(DidDocument.class, didRequestPayload.did()));
+    }
+
+    @PUT
+    @Override
+    public void updateDid(DidDocument document, @QueryParam("republish") boolean republish) {
+        requestValidator.validate(document).orElseThrow(ValidationFailureException::new);
+        var did = document.getId();
+        documentService.update(document)
+                .compose(v -> republish ? documentService.publish(did) : ServiceResult.success())
+                .orElseThrow(exceptionMapper(DidDocument.class, did));
+    }
+
+    @Override
+    @DELETE
+    public void deleteDidFromBody(DidRequestPayload request) {
+        documentService.deleteById(request.did())
+                .orElseThrow(exceptionMapper(DidDocument.class, request.did()));
+    }
+
+    @POST
+    @Path("/query")
+    @Override
+    public Collection<DidDocument> queryDid(QuerySpec querySpec) {
+        return documentService.queryDocuments(querySpec)
+                .orElseThrow(exceptionMapper(DidDocument.class, null));
+    }
+
+    @Override
+    @POST
+    @Path("/state")
+    public String getState(DidRequestPayload request) {
+        var byId = documentService.findById(request.did());
+        return byId != null ? DidState.from(byId.getState()).toString() : null;
+    }
+
+}

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidRequestPayload.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidRequestPayload.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.didmanagement.v1;
+
+/**
+ * JSON container for a DID
+ */
+public record DidRequestPayload(String did) {
+}

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/validation/DidRequestValidator.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/validation/DidRequestValidator.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.didmanagement.v1.validation;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+
+import java.net.URI;
+
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+/**
+ * Validates that a {@link DidDocument} is valid by checking all mandatory properties.
+ */
+public class DidRequestValidator implements Validator<DidDocument> {
+
+    @Override
+    public ValidationResult validate(DidDocument input) {
+        if (input == null) {
+            return failure(violation("input was null", "."));
+        }
+
+        if (input.getId() == null) {
+            return failure(violation("ID was null", "id"));
+        }
+
+        if (!isValidUri(input.getId())) {
+            return failure(violation("ID is not a valid URI", "id"));
+        }
+
+        return ValidationResult.success();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private boolean isValidUri(String supposedUri) {
+        try {
+            URI.create(supposedUri);
+            return true;
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+    }
+}

--- a/extensions/did/did-management-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/did/did-management-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,4 +12,4 @@
 #
 #
 
-org.eclipse.edc.identityhub.api.PresentationApiExtension
+org.eclipse.edc.identityhub.api.didmanagement.DidManagementApiExtension

--- a/extensions/did/did-management-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiControllerTest.java
+++ b/extensions/did/did-management-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiControllerTest.java
@@ -1,0 +1,352 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.didmanagement.v1;
+
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class DidManagementApiControllerTest extends RestControllerTestBase {
+
+    public static final String TEST_DID = "did:web:host%3A1234:test-did";
+    private final DidDocumentService didDocumentServiceMock = mock();
+
+    @Test
+    void create_success() {
+        when(didDocumentServiceMock.store(any())).thenReturn(ServiceResult.success());
+        var document = createDidDocument().build();
+
+        baseRequest()
+                .with()
+                .body(document)
+                .post()
+                .then()
+                .log().ifError()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+    }
+
+    @Test
+    void create_alreadyExists_expect409() {
+        when(didDocumentServiceMock.store(any())).thenReturn(ServiceResult.conflict("already exists"));
+        var document = createDidDocument().build();
+
+        baseRequest()
+                .body(document)
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(409);
+    }
+
+    @Test
+    void create_malformedBody_expect400() {
+        when(didDocumentServiceMock.store(any())).thenReturn(ServiceResult.success());
+        var document = createDidDocument().id("not a uri").build();
+
+        baseRequest()
+                .body(document)
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+    }
+
+    @Test
+    void publish_success() {
+
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/publish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+    }
+
+    @Test
+    void publish_whenNotExist_expect404() {
+
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/publish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(equalTo(404));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void publish_whenAlreadyPublished_expect200() {
+
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/publish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void unpublish_success() {
+
+        when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/unpublish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void unpublish_whenNotExist_expect404() {
+        when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/unpublish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(404);
+        verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void unpublish_whenNotPublished_expect200() {
+        // not needed - test setup is identical to publish_success
+    }
+
+    @Test
+    void unpublish_whenAlreadyUnpublished_expect200() {
+        // not needed - test setup is identical to publish_success
+    }
+
+    @Test
+    void unpublish_whenNotSupported_expect400() {
+        when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("test-message"));
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/unpublish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+        verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void updateDid_success() {
+        var doc = createDidDocument().id(TEST_DID).build();
+        when(didDocumentServiceMock.update(any())).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(doc)
+                .put()
+                .then()
+                .log().ifError()
+                .statusCode(204);
+        verify(didDocumentServiceMock).update(argThat(dd -> dd.getId().equals(TEST_DID)));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void updateDid_success_withRepublish() {
+        var doc = createDidDocument().id(TEST_DID).build();
+        when(didDocumentServiceMock.update(any())).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(doc)
+                .put("?republish=true")
+                .then()
+                .log().ifError()
+                .statusCode(204);
+        verify(didDocumentServiceMock).update(argThat(dd -> dd.getId().equals(TEST_DID)));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void updateDid_success_withRepublishFails() {
+
+        var doc = createDidDocument().id(TEST_DID).build();
+        when(didDocumentServiceMock.update(any())).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("test-failure"));
+
+        baseRequest()
+                .body(doc)
+                .put("?republish=true")
+                .then()
+                .log().ifError()
+                .statusCode(400);
+        verify(didDocumentServiceMock).update(argThat(dd -> dd.getId().equals(TEST_DID)));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void updateDid_whenNotExist_expect404() {
+
+        var doc = createDidDocument().id(TEST_DID).build();
+        when(didDocumentServiceMock.update(any())).thenReturn(ServiceResult.notFound("test-failure"));
+
+        baseRequest()
+                .body(doc)
+                .put()
+                .then()
+                .log().ifError()
+                .statusCode(404);
+        verify(didDocumentServiceMock).update(argThat(dd -> dd.getId().equals(TEST_DID)));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void deleteDid_success() {
+
+        when(didDocumentServiceMock.deleteById(eq(TEST_DID))).thenReturn(ServiceResult.success());
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .delete("/")
+                .then()
+                .log().ifError()
+                .statusCode(204);
+        verify(didDocumentServiceMock).deleteById(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void deleteDid_whenNotExist_expect404() {
+
+        when(didDocumentServiceMock.deleteById(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .delete("/")
+                .then()
+                .log().ifError()
+                .statusCode(404);
+        verify(didDocumentServiceMock).deleteById(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void deleteDid_whenAlreadyPublished_expect409() {
+
+        when(didDocumentServiceMock.deleteById(eq(TEST_DID))).thenReturn(ServiceResult.conflict("test-message"));
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .delete("/")
+                .then()
+                .log().ifError()
+                .statusCode(409);
+        verify(didDocumentServiceMock).deleteById(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void query_withSimpleField() {
+        var resultList = List.of(createDidDocument().build());
+        when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.success(resultList));
+        var q = QuerySpec.Builder.newInstance().filter(new Criterion("id", "=", "foobar")).build();
+
+        var docListType = new TypeRef<List<DidDocument>>() {
+        };
+        var docList = baseRequest()
+                .body(q)
+                .post("/query")
+                .then()
+                .log().ifError()
+                .statusCode(200)
+                .extract().body().as(docListType);
+
+        assertThat(docList).isNotEmpty().hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .isEqualTo(resultList);
+        verify(didDocumentServiceMock).queryDocuments(eq(q));
+    }
+
+    @Test
+    void query_invalidQuery_expect400() {
+        when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.badRequest("test-message"));
+        var q = QuerySpec.Builder.newInstance().build();
+        baseRequest()
+                .body(q)
+                .post("/query")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+
+        verify(didDocumentServiceMock).queryDocuments(eq(q));
+    }
+
+    @Override
+    protected DidManagementApiController controller() {
+        return new DidManagementApiController(didDocumentServiceMock);
+    }
+
+    private DidDocument.Builder createDidDocument() {
+        return DidDocument.Builder.newInstance()
+                .id("did:web:testdid")
+                .service(List.of(new Service("test-service", "test-service", "https://test.service.com/")))
+                .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
+                        .id("did:web:testdid#key-1")
+                        .publicKeyMultibase("saflasjdflaskjdflasdkfj")
+                        .build()));
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .contentType("application/json")
+                .baseUri("http://localhost:" + port + "/v1/dids")
+                .when();
+    }
+}

--- a/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisher.java
+++ b/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisher.java
@@ -14,17 +14,12 @@
 
 package org.eclipse.edc.identityhub.publisher.did.local;
 
-import org.eclipse.edc.identithub.did.spi.DidConstants;
 import org.eclipse.edc.identithub.did.spi.DidDocumentPublisher;
 import org.eclipse.edc.identithub.did.spi.model.DidResource;
 import org.eclipse.edc.identithub.did.spi.model.DidState;
 import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
-
-import java.util.Collection;
 
 import static org.eclipse.edc.identithub.did.spi.DidConstants.DID_WEB_METHOD_REGEX;
 import static org.eclipse.edc.spi.result.Result.failure;
@@ -85,16 +80,6 @@ public class LocalDidPublisher implements DidDocumentPublisher {
                 .map(v -> success())
                 .orElse(f -> failure(f.getFailureDetail()));
 
-    }
-
-    @Override
-    public Collection<DidResource> getPublishedDocuments() {
-        var q = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("state", "=", DidState.PUBLISHED.code()))
-                .filter(new Criterion("did", "like", DidConstants.DID_WEB_METHOD + "%"))
-                .build();
-
-        return didResourceStore.query(q);
     }
 
     private boolean isPublished(DidResource didResource) {

--- a/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherTest.java
+++ b/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.identityhub.publisher.did.local.TestFunctions.createDidResource;
 import static org.mockito.ArgumentMatchers.any;
@@ -170,19 +169,4 @@ class LocalDidPublisherTest {
         verify(storeMock).update(any());
         verifyNoMoreInteractions(storeMock);
     }
-
-    @Test
-    void getPublishedDocuments() {
-        var list = range(0, 10)
-                .mapToObj(i -> createDidResource().did("did:web:" + i).state(DidState.PUBLISHED).build())
-                .toList();
-
-        when(storeMock.query(any())).thenReturn(list);
-
-        assertThat(publisher.getPublishedDocuments())
-                .usingRecursiveFieldByFieldElementComparator()
-                .containsAll(list);
-    }
-
-
 }

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     runtimeOnly(project(":core:identity-hub-credentials"))
     runtimeOnly(project(":extensions:cryptography:public-key-provider"))
     runtimeOnly(project(":extensions:did:local-did-publisher"))
+    runtimeOnly(project(":extensions:did:did-management-api"))
     runtimeOnly(libs.edc.identity.did.core)
     runtimeOnly(libs.edc.identity.did.web)
     runtimeOnly(libs.bundles.connector)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(":extensions:cryptography:public-key-provider")
 include(":extensions:store:sql:identity-hub-did-store-sql")
 include(":extensions:store:sql:identity-hub-credentials-store-sql")
 include(":extensions:did:local-did-publisher")
+include(":extensions:did:did-management-api")
 
 // other modules
 include(":launcher")

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisher.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisher.java
@@ -15,11 +15,8 @@
 package org.eclipse.edc.identithub.did.spi;
 
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
-import org.eclipse.edc.identithub.did.spi.model.DidResource;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
-
-import java.util.Collection;
 
 /**
  * The DidDocumentPublisher is responsible for taking a {@link DidDocument} and making it available at a VDR (verifiable data registry).
@@ -38,27 +35,18 @@ public interface DidDocumentPublisher {
     boolean canHandle(String id);
 
     /**
-     * Publishes a given {@link DidDocument} to a verifiable data registry (VDR). Publishing the same DID twice is a noop.
+     * Publishes a given {@link DidDocument} to a verifiable data registry (VDR).
      *
-     * @param did the DID to publish. A document with that DID must exist in the database.
+     * @param did the DID of the document to publish
      * @return a {@link Result} object indicating the success or failure of the operation.
      */
     Result<Void> publish(String did);
 
     /**
-     * Unpublishes a given {@link DidDocument} from a verifiable data registry (VDR). Attempting to unpublish a DID document
-     * that isn't published will result in an error.
+     * Unpublishes a given {@link DidDocument} from a verifiable data registry (VDR).
      *
-     * @param did the DID to unpublish. A document with that DID must exist in the database.
+     * @param did the DID of the document to un-publish
      * @return a {@link Result} object indicating the success or failure of the operation.
      */
     Result<Void> unpublish(String did);
-
-    /**
-     * Returns a list of all {@link DidDocument}s that are managed by this publisher, and are currently published.
-     *
-     * @return a list of documents that are currently published.
-     */
-    //todo: not sure if needed?
-    Collection<DidResource> getPublishedDocuments();
 }

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisherRegistry.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisherRegistry.java
@@ -37,12 +37,4 @@ public interface DidDocumentPublisherRegistry {
      */
     DidDocumentPublisher getPublisher(String did);
 
-
-    /**
-     * Determines whether a given DID can be published by this registry. The DID must conform to the <a href="https://www.w3.org/TR/did-core/#did-syntax">W3C DID Syntax</a>
-     *
-     * @param did The W3C DID to examine
-     * @return true if a publisher is found for this DID method, false if no publisher is found, or the DID is not valid.
-     */
-    boolean canPublish(String did);
 }

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisherRegistry.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentPublisherRegistry.java
@@ -24,10 +24,10 @@ public interface DidDocumentPublisherRegistry {
     /**
      * Registers a {@link DidDocumentPublisher} for a given DID method.
      *
-     * @param didMethodName The DID method name. This may include the "did:" prefix, so both "did:web" and "web" would be valid.
-     * @param publisher     The publisher to register
+     * @param didMethodNameIncludingPrefix The DID method name. This must include the "did:" prefix, so "did:web" would be valid and "web" would be invalid.
+     * @param publisher                    The publisher to register
      */
-    void addPublisher(String didMethodName, DidDocumentPublisher publisher);
+    void addPublisher(String didMethodNameIncludingPrefix, DidDocumentPublisher publisher);
 
     /**
      * Returns the publisher that was registered for a particular DID method.

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
@@ -15,27 +15,74 @@
 package org.eclipse.edc.identithub.did.spi;
 
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
-import org.eclipse.edc.identithub.did.spi.model.DidState;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.Collection;
 
 /**
  * The {@code DidDocumentService} gives access to a {@link DidDocument} that are held in storage.
  */
 public interface DidDocumentService {
 
-    /**
-     * Retrieves the {@link DidDocument} associated with the given DID, if it exists.
-     *
-     * @param did The DID for which to retrieve the DidDocument.
-     * @return A {@link ServiceResult} containing the DidDocument if it exists, or an error if it does not exist or cannot be retrieved.
-     */
-    ServiceResult<DidDocument> getDidDocument(String did);
 
     /**
-     * Retrieves the state of a DID resource.
+     * Stores a DID document in persistent storage.
      *
-     * @param did The identifier of the DID resource.
-     * @return A {@link ServiceResult} containing the state of the DID resource if it exists.
+     * @param document the {@link DidDocument} to store
+     * @return a {@link ServiceResult} to indicate success or failure.
      */
-    ServiceResult<DidState> getState(String did);
+    ServiceResult<Void> store(DidDocument document);
+
+    /**
+     * Publishes an already existing DID document. Returns a failure if the DID document was not found or cannot be published.
+     *
+     * @param did The ID of the DID document to publish. Must exist in the database.
+     * @return success, or a failure indicating what went wrong.
+     */
+    ServiceResult<Void> publish(String did);
+
+    /**
+     * Un-publishes an already existing DID document. Returns a failure if the DID document was not found or the underlying
+     * VDR does not support un-publishing
+     *
+     * @param did The ID of the DID document to un-publish. Must exist in the database.
+     * @return success, or a failure indicating what went wrong.
+     */
+    ServiceResult<Void> unpublish(String did);
+
+    /**
+     * Updates a given DID document if it exists, returns a failure otherwise.
+     *
+     * @param document The DID document to update
+     * @return success, or a failure indicating what went wrong.
+     */
+    ServiceResult<Void> update(DidDocument document);
+
+    /**
+     * Deletes a DID document if found.
+     *
+     * @param did The ID of the DID document to delete.
+     * @return A {@link ServiceResult} indicating success or failure.
+     */
+    ServiceResult<Void> deleteById(String did);
+
+    /**
+     * Queries the {@link DidDocument} objects based on the given query specification.
+     *
+     * @param spec The query
+     * @return A {@link ServiceResult} containing a collection of {@link DidDocument} objects that match the query parameters.
+     */
+    ServiceResult<Collection<DidDocument>> queryDocuments(QuerySpec spec);
+
+    default String notFoundMessage(String did) {
+        return "A DID document with ID '%s' does not exist.".formatted(did);
+    }
+
+    default String noPublisherFoundMessage(String did) {
+        return "No publisher was found for did '%s'".formatted(did);
+    }
+
+    DidResource findById(String did);
 }

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
@@ -81,7 +81,7 @@ public interface DidDocumentService {
     }
 
     default String noPublisherFoundMessage(String did) {
-        return "No publisher was found for did '%s'".formatted(did);
+        return "No publisher was found for DID '%s'".formatted(did);
     }
 
     DidResource findById(String did);

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
@@ -104,12 +104,12 @@ public class DidResource {
 
         public DidResource build() {
             Objects.requireNonNull(resource.did, "Must have an identifier");
-            Objects.requireNonNull(resource.state, "Must have a state");
-
             if (resource.stateTimestamp <= 0) {
                 resource.stateTimestamp = resource.clock.millis();
             }
-
+            if (resource.createTimestamp <= 0) {
+                resource.createTimestamp = resource.clock.millis();
+            }
             return resource;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a CRUD management API for Decentralized Identifiers (DID). More specifically, it adds:
- a `DidManagementApi` that contains swagger annotations
- a `DidManagementApiController` that implements the REST interface
- a `DidDocumentServiceImpl`, that acts as aggregate service and creates the transaction boundary
- a `DidRequestValidator`, that validates the structure of a `DidDocument`
- tests
- some refactoring w.r.t. package names 

## Why it does that

For managing DID documents

## Further notes

- Although internally the IdentityHub manages `DidResource` objects, the Management API only exposes `DidDocument` objects (which are a part of `DidResources`) and provides specific endpoints for "actions", such as `publish`. This is done because those actions are synchronous, which means there is no state machine that could pick up e.g. a state change, so they need to be executed explicitly.
- this API does not (cannot) adhere to strict REST principles: for example, publishing a DID should be `POST /v1/dids/{did}/publish`. however, since (web) DIDs can contain port definitions, which - if properly URL-encoded - are not discernible from the normal segment separator `":"` anymore. 

## Linked Issue(s)

Closes #190

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
