### PR TITLE
feat: make DidManagementApi more explicit

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -15,10 +15,10 @@
 package org.eclipse.edc.identityhub.did;
 
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.identithub.did.spi.DidDocumentPublisherRegistry;
 import org.eclipse.edc.identithub.did.spi.DidDocumentService;
 import org.eclipse.edc.identithub.did.spi.model.DidResource;
-import org.eclipse.edc.identithub.did.spi.model.DidState;
 import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -40,20 +40,6 @@ public class DidDocumentServiceImpl implements DidDocumentService {
         this.transactionContext = transactionContext;
         this.didResourceStore = didResourceStore;
         this.registry = registry;
-    }
-
-    @Override
-    public ServiceResult<Void> store(DidDocument document) {
-        return transactionContext.execute(() -> {
-            var res = DidResource.Builder.newInstance()
-                    .document(document)
-                    .did(document.getId())
-                    .build();
-            var result = didResourceStore.save(res);
-            return result.succeeded() ?
-                    ServiceResult.success() :
-                    ServiceResult.fromFailure(result);
-        });
     }
 
     @Override
@@ -94,48 +80,6 @@ public class DidDocumentServiceImpl implements DidDocumentService {
         });
     }
 
-    @Override
-    public ServiceResult<Void> update(DidDocument document) {
-        return transactionContext.execute(() -> {
-            // obtain existing resource from storage
-            var did = document.getId();
-            var existing = didResourceStore.findById(did);
-            if (existing == null) {
-                return ServiceResult.notFound(notFoundMessage(did));
-            }
-
-            //update only the did document
-            var updatedResource = DidResource.Builder.newInstance()
-                    .document(document)
-                    .did(did)
-                    .state(existing.getState())
-                    .createTimestamp(existing.getCreateTimestamp())
-                    .stateTimeStamp(existing.getStateTimestamp())
-                    .build();
-
-            var res = didResourceStore.update(updatedResource);
-            return res.succeeded() ?
-                    ServiceResult.success() :
-                    ServiceResult.fromFailure(res);
-        });
-    }
-
-    @Override
-    public ServiceResult<Void> deleteById(String did) {
-        return transactionContext.execute(() -> {
-            var existing = didResourceStore.findById(did);
-            if (existing == null) {
-                return ServiceResult.notFound(notFoundMessage(did));
-            }
-            if (existing.getState() == DidState.PUBLISHED.code()) {
-                return ServiceResult.conflict("Cannot delete DID '%s' because it is already published. Un-publish first!".formatted(did));
-            }
-            var res = didResourceStore.deleteById(did);
-            return res.succeeded() ?
-                    ServiceResult.success() :
-                    ServiceResult.fromFailure(res);
-        });
-    }
 
     @Override
     public ServiceResult<Collection<DidDocument>> queryDocuments(QuerySpec query) {
@@ -148,5 +92,65 @@ public class DidDocumentServiceImpl implements DidDocumentService {
     @Override
     public DidResource findById(String did) {
         return transactionContext.execute(() -> didResourceStore.findById(did));
+    }
+
+    @Override
+    public ServiceResult<Void> addService(String did, Service service) {
+        return transactionContext.execute(() -> {
+            var didResource = didResourceStore.findById(did);
+            if (didResource == null) {
+                return ServiceResult.notFound("DID '%s' not found.".formatted(did));
+            }
+            var services = didResource.getDocument().getService();
+            if (services.stream().anyMatch(s -> s.getId().equals(service.getId()))) {
+                return ServiceResult.conflict("DID '%s' already contains a service endpoint with ID '%s'.".formatted(did, service.getId()));
+            }
+            services.add(service);
+            var updateResult = didResourceStore.update(didResource);
+            return updateResult.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.fromFailure(updateResult);
+
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> replaceService(String did, Service service) {
+        return transactionContext.execute(() -> {
+            var didResource = didResourceStore.findById(did);
+            if (didResource == null) {
+                return ServiceResult.notFound("DID '%s' not found.".formatted(did));
+            }
+            var services = didResource.getDocument().getService();
+            if (services.stream().noneMatch(s -> s.getId().equals(service.getId()))) {
+                return ServiceResult.badRequest("DID '%s' does not contain a service endpoint with ID '%s'.".formatted(did, service.getId()));
+            }
+            services.add(service);
+            var updateResult = didResourceStore.update(didResource);
+            return updateResult.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.fromFailure(updateResult);
+
+        });
+    }
+
+    @Override
+    public ServiceResult<Void> removeService(String did, String serviceId) {
+        return transactionContext.execute(() -> {
+            var didResource = didResourceStore.findById(did);
+            if (didResource == null) {
+                return ServiceResult.notFound("DID '%s' not found.".formatted(did));
+            }
+            var services = didResource.getDocument().getService();
+            var hasRemoved = services.removeIf(s -> s.getId().equals(serviceId));
+            if (!hasRemoved) {
+                return ServiceResult.badRequest("DID '%s' does not contain a service endpoint with ID '%s'.".formatted(did, serviceId));
+            }
+            var updateResult = didResourceStore.update(didResource);
+            return updateResult.succeeded() ?
+                    ServiceResult.success() :
+                    ServiceResult.fromFailure(updateResult);
+
+        });
     }
 }

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -17,7 +17,6 @@ package org.eclipse.edc.identityhub.api.didmanagement.v1;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -26,6 +25,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
@@ -34,22 +34,6 @@ import java.util.Collection;
 @OpenAPIDefinition(
         info = @Info(description = "This is the Management API for DID documents", title = "DID Management API", version = "1"))
 public interface DidManagementApi {
-
-    @Tag(name = "DID Management API")
-    @Operation(description = "Stores a new DID document and optionally also publishes it",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidDocument.class), mediaType = "application/json")),
-            parameters = {@Parameter(name = "publish", description = "Indicates whether the DID should be published right after creation")},
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "The DID document was successfully stored"),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed, for example the DID document was invalid",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "409", description = "Can't create the DID document, because a document with the same ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
-            }
-    )
-    void createDidDocument(DidDocument document, boolean publish);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Publish an (existing) DID document. The DID is expected to exist in the database.",
@@ -80,34 +64,6 @@ public interface DidManagementApi {
     void unpublishDidFromBody(DidRequestPayload didRequestPayload);
 
     @Tag(name = "DID Management API")
-    @Operation(description = "Updates an (existing) DID document and re-publishes it if so desired. The DID is expected to exist in the database.",
-            parameters = {@Parameter(name = "republish", description = "Indicates whether the DID document should be re-published after the update.")},
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
-                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "The DID could not be updated because it does not exist.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
-            }
-    )
-    void updateDid(DidDocument document, boolean republish);
-
-    @Tag(name = "DID Management API")
-    @Operation(description = "Delete an (existing) DID document. The DID is expected to exist in the database.",
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "The DID document was successfully deleted."),
-                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "The DID could not be deleted because it does not exist.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "409", description = "The DID could not be deleted because it is already published. Un-publish first.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
-            }
-    )
-    void deleteDidFromBody(DidRequestPayload request);
-
-    @Tag(name = "DID Management API")
     @Operation(description = "Query for DID documents..",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
             responses = {
@@ -133,4 +89,49 @@ public interface DidManagementApi {
             }
     )
     String getState(DidRequestPayload request);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Adds a service endpoint to a particular DID document.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "409", description = "The DID document could not be updated, because a service endpoint with the same ID already exists.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The service endpoint could not be added because the DID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void addEndpoint(String did, Service service);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Replaces a service endpoint of a particular DID document.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "400", description = "The DID document could not be updated, because a service endpoint with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The service endpoint could not be replaced because the DID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void replaceEndpoint(String did, Service service);
+
+    @Tag(name = "DID Management API")
+    @Operation(description = "Removes a service endpoint from a particular DID document.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "400", description = "The DID document could not be updated, because a service endpoint with the same ID already exists.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "The service endpoint could not be added because the DID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void removeEndpoint(String did, String serviceId);
 }

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -103,7 +103,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void addEndpoint(String did, Service service);
+    void addEndpoint(String did, Service service, boolean autoPublish);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Replaces a service endpoint of a particular DID document.",
@@ -118,7 +118,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void replaceEndpoint(String did, Service service);
+    void replaceEndpoint(String did, Service service, boolean autoPublish);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Removes a service endpoint from a particular DID document.",
@@ -133,5 +133,5 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void removeEndpoint(String did, String serviceId);
+    void removeEndpoint(String did, String serviceId, boolean autoPublish);
 }

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.identityhub.api.didmanagement.v1;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -93,6 +94,7 @@ public interface DidManagementApi {
     @Tag(name = "DID Management API")
     @Operation(description = "Adds a service endpoint to a particular DID document.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
+            parameters = {@Parameter(name = "autoPublish", description = "Whether the DID should get republished after the removal. Defaults to false.")},
             responses = {
                     @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
@@ -108,6 +110,7 @@ public interface DidManagementApi {
     @Tag(name = "DID Management API")
     @Operation(description = "Replaces a service endpoint of a particular DID document.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
+            parameters = {@Parameter(name = "autoPublish", description = "Whether the DID should get republished after the removal. Defaults to false.")},
             responses = {
                     @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
@@ -123,6 +126,8 @@ public interface DidManagementApi {
     @Tag(name = "DID Management API")
     @Operation(description = "Removes a service endpoint from a particular DID document.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
+            parameters = {@Parameter(name = "serviceId", description = "The ID of the service that should get removed"), @Parameter(name = "autoPublish", description = "Whether the DID should " +
+                    "get republished after the removal. Defaults to false.")},
             responses = {
                     @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiController.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiController.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.identithub.did.spi.DidDocumentService;
 import org.eclipse.edc.identithub.did.spi.model.DidState;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.util.Collection;
 
@@ -81,24 +82,27 @@ public class DidManagementApiController implements DidManagementApi {
     @Override
     @POST
     @Path("/{did}/endpoints")
-    public void addEndpoint(@PathParam("did") String did, Service service) {
+    public void addEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish) {
         documentService.addService(did, service)
+                .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
                 .orElseThrow(exceptionMapper(Service.class, did));
     }
 
     @Override
     @PATCH
     @Path("/{did}/endpoints")
-    public void replaceEndpoint(@PathParam("did") String did, Service service) {
+    public void replaceEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish) {
         documentService.replaceService(did, service)
+                .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
                 .orElseThrow(exceptionMapper(Service.class, did));
     }
 
     @Override
     @DELETE
     @Path("/{did}/endpoints")
-    public void removeEndpoint(@PathParam("did") String did, @QueryParam("serviceId") String serviceId) {
+    public void removeEndpoint(@PathParam("did") String did, @QueryParam("serviceId") String serviceId, @QueryParam("autoPublish") boolean autoPublish) {
         documentService.removeService(did, serviceId)
+                .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
                 .orElseThrow(exceptionMapper(Service.class, did));
     }
 

--- a/extensions/did/did-management-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiControllerTest.java
+++ b/extensions/did/did-management-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiControllerTest.java
@@ -191,6 +191,37 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
                 .log().ifValidationFails()
                 .statusCode(anyOf(equalTo(200), equalTo(204)));
         verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void addEndpoint_withAutoPublish() {
+        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void addEndpoint_whenAutoPublishFails_expect400() {
+        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not working"));
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .post("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
     }
 
     @Test
@@ -227,6 +258,39 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
                 .log().ifValidationFails()
                 .statusCode(anyOf(equalTo(200), equalTo(204)));
         verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void replaceEndpoint_withAutoPublish() {
+        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .patch("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void replaceEndpoint_whenAutoPublishFails_expect400() {
+        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not working"));
+
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .patch("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        verifyNoMoreInteractions(didDocumentServiceMock);
     }
 
     @Test
@@ -263,6 +327,39 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
                 .log().ifValidationFails()
                 .statusCode(anyOf(equalTo(200), equalTo(204)));
         verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void removeEndpoint_withAutoPublish() {
+        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .delete("/%s/endpoints?serviceId=test-service-id&autoPublish=true".formatted(TEST_DID))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+
+        verifyNoMoreInteractions(didDocumentServiceMock);
+    }
+
+    @Test
+    void removeEndpoint_whenAutoPublishFails_expect400() {
+        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
+        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not reachable"));
+        baseRequest()
+                .body(new DidRequestPayload(TEST_DID))
+                .delete("/%s/endpoints?serviceId=test-service-id&autoPublish=true".formatted(TEST_DID))
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+        verify(didDocumentServiceMock).publish(eq(TEST_DID));
+
+        verifyNoMoreInteractions(didDocumentServiceMock);
     }
 
     @Test

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
@@ -64,9 +64,30 @@ public interface DidDocumentService {
 
     DidResource findById(String did);
 
+    /**
+     * Adds a service endpoint entry to a did document.
+     *
+     * @param did     The DID of the document to which the entry should be added.
+     * @param service The service endpoint to add.
+     * @return success if added, a failure otherwise, e.g. because that same service already exists.
+     */
     ServiceResult<Void> addService(String did, Service service);
 
+    /**
+     * Replaces a service endpoint entry in a did document.
+     *
+     * @param did     The DID of the document in which the entry should be replaced.
+     * @param service The new service endpoint .
+     * @return success if replaced, a failure otherwise, e.g. because a service with that ID does not exist exists.
+     */
     ServiceResult<Void> replaceService(String did, Service service);
 
+    /**
+     * Removes a service endpoint entry from a did document.
+     *
+     * @param did       The DID of the document from which the entry should be removed.
+     * @param serviceId The service endpoint to remove.
+     * @return success if removed, a failure otherwise, e.g. because a service with that ID does not exist exists.
+     */
     ServiceResult<Void> removeService(String did, String serviceId);
 }

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identithub.did.spi;
 
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.identithub.did.spi.model.DidResource;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -26,14 +27,6 @@ import java.util.Collection;
  */
 public interface DidDocumentService {
 
-
-    /**
-     * Stores a DID document in persistent storage.
-     *
-     * @param document the {@link DidDocument} to store
-     * @return a {@link ServiceResult} to indicate success or failure.
-     */
-    ServiceResult<Void> store(DidDocument document);
 
     /**
      * Publishes an already existing DID document. Returns a failure if the DID document was not found or cannot be published.
@@ -52,21 +45,6 @@ public interface DidDocumentService {
      */
     ServiceResult<Void> unpublish(String did);
 
-    /**
-     * Updates a given DID document if it exists, returns a failure otherwise.
-     *
-     * @param document The DID document to update
-     * @return success, or a failure indicating what went wrong.
-     */
-    ServiceResult<Void> update(DidDocument document);
-
-    /**
-     * Deletes a DID document if found.
-     *
-     * @param did The ID of the DID document to delete.
-     * @return A {@link ServiceResult} indicating success or failure.
-     */
-    ServiceResult<Void> deleteById(String did);
 
     /**
      * Queries the {@link DidDocument} objects based on the given query specification.
@@ -85,4 +63,10 @@ public interface DidDocumentService {
     }
 
     DidResource findById(String did);
+
+    ServiceResult<Void> addService(String did, Service service);
+
+    ServiceResult<Void> replaceService(String did, Service service);
+
+    ServiceResult<Void> removeService(String did, String serviceId);
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR removes generic endpoints from the DidManagementAPI, such as create, update or delete. Instead, they have been replaced with more focused endpoints for adding `serviceEndpoint` entries 
to a DID document.


## Why it does that

For the purposes of IdentityHub, the DID document is a fully managed piece of information, that is merely a representation of a particular participant. Thus, 
manually modifying that document can cause inconsistencies.

## Further notes

- the `DidDocumentService` has been adapted too, to reflect those changes.

## Linked Issue(s)

Closes #220

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
