### PR TITLE
feat: add ParticipantContext Management API

### DIFF
--- a/core/identity-hub-participants/build.gradle.kts
+++ b/core/identity-hub-participants/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     api(project(":spi:identity-hub-spi"))
     api(project(":spi:identity-hub-store-spi"))
     api(libs.edc.spi.transaction)
-
+    implementation(project(":extensions:common:security"))
+    implementation(libs.edc.common.crypto)
+    implementation(libs.edc.core.connector)
     testImplementation(libs.edc.junit)
 }

--- a/core/identity-hub-participants/build.gradle.kts
+++ b/core/identity-hub-participants/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     api(project(":spi:identity-hub-spi"))
+    api(project(":spi:identity-hub-did-spi"))
     api(project(":spi:identity-hub-store-spi"))
     api(libs.edc.spi.transaction)
     implementation(project(":extensions:common:security"))

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.participantcontext;
 
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -38,9 +39,11 @@ public class ParticipantContextExtension implements ServiceExtension {
     private TransactionContext transactionContext;
     @Inject
     private KeyParserRegistry keyParserRegistry;
+    @Inject
+    private DidDocumentService didDocumentService;
 
     @Provider
     public ParticipantContextService createParticipantService() {
-        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, new Base64StringGenerator(), keyParserRegistry);
+        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, new Base64StringGenerator(), keyParserRegistry, didDocumentService);
     }
 }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -35,9 +36,11 @@ public class ParticipantContextExtension implements ServiceExtension {
     private Vault vault;
     @Inject
     private TransactionContext transactionContext;
+    @Inject
+    private KeyParserRegistry keyParserRegistry;
 
     @Provider
     public ParticipantContextService createParticipantService() {
-        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, new Base64StringGenerator());
+        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, new Base64StringGenerator(), keyParserRegistry);
     }
 }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -39,7 +39,6 @@ import java.security.KeyPair;
 import java.security.PublicKey;
 import java.text.ParseException;
 import java.util.List;
-import java.util.UUID;
 import java.util.function.Consumer;
 
 import static org.eclipse.edc.spi.result.ServiceResult.fromFailure;
@@ -132,7 +131,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
 
     private ServiceResult<Void> generateDidDocument(ParticipantManifest manifest, JWK publicKey) {
         var doc = DidDocument.Builder.newInstance()
-                .id("did:web:" + UUID.randomUUID()) // fixme: how to determine the ID beforehand? let the publisher do it?
+                .id(manifest.getDid())
                 .service(manifest.getServiceEndpoints().stream().toList())
                 .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
                         .publicKeyJwk(publicKey.toJSONObject())

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -14,15 +14,27 @@
 
 package org.eclipse.edc.identityhub.participantcontext;
 
+import com.nimbusds.jose.jwk.JWK;
+import org.eclipse.edc.identityhub.security.KeyPairGenerator;
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.RandomStringGenerator;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContextState;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
+import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.jetbrains.annotations.NotNull;
+
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.util.function.Consumer;
 
 import static org.eclipse.edc.spi.result.ServiceResult.fromFailure;
 import static org.eclipse.edc.spi.result.ServiceResult.notFound;
@@ -40,21 +52,23 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     private final Vault vault;
     private final TransactionContext transactionContext;
     private final RandomStringGenerator tokenGenerator;
+    private final KeyParserRegistry keyParserRegistry;
 
-    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, Vault vault, TransactionContext transactionContext, RandomStringGenerator tokenGenerator) {
+    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, Vault vault, TransactionContext transactionContext, RandomStringGenerator tokenGenerator, KeyParserRegistry registry) {
         this.participantContextStore = participantContextStore;
         this.vault = vault;
         this.transactionContext = transactionContext;
         this.tokenGenerator = tokenGenerator;
+        this.keyParserRegistry = registry;
     }
 
     @Override
-    public ServiceResult<Void> createParticipantContext(ParticipantContext context) {
+    public ServiceResult<Void> createParticipantContext(ParticipantManifest manifest) {
         return transactionContext.execute(() -> {
-            var storeRes = participantContextStore.create(context);
-            return storeRes.succeeded() ?
-                    success() :
-                    fromFailure(storeRes);
+            var context = convert(manifest);
+            return createParticipantContext(context)
+                    .compose(u -> createOrUpdateKey(manifest.getKey()))
+                    .compose(u -> generateDidDocument(context));
         });
     }
 
@@ -92,6 +106,72 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
             return vault.storeSecret(alias, newToken).map(unused -> ServiceResult.success(newToken)).orElse(f -> ServiceResult.conflict("Could not store new API token: %s.".formatted(f.getFailureDetail())));
         });
     }
+
+    @Override
+    public ServiceResult<Void> updateParticipant(String participantId, Consumer<ParticipantContext> modificationFunction) {
+        return transactionContext.execute(() -> {
+            var participant = findByIdInternal(participantId);
+            if (participant == null) {
+                return ServiceResult.notFound("ParticipantContext with ID '%s' not found.".formatted(participantId));
+            }
+            modificationFunction.accept(participant);
+            var res = participantContextStore.update(participant);
+            return res.succeeded() ? ServiceResult.success() : ServiceResult.fromFailure(res);
+        });
+
+    }
+
+    private ServiceResult<Void> generateDidDocument(ParticipantContext context) {
+        return ServiceResult.success();
+    }
+
+    private ServiceResult<Void> createOrUpdateKey(KeyDescriptor key) {
+        // do we need to generate the key?
+        var keyGeneratorParams = key.getKeyGeneratorParams();
+        JWK publicKeyJwk;
+        if (keyGeneratorParams != null) {
+            var kp = KeyPairGenerator.generateKeyPair(keyGeneratorParams);
+            if (kp.failed()) {
+                return ServiceResult.badRequest("Could not generate KeyPair from generator params: %s".formatted(kp.getFailureDetail()));
+            }
+            var alias = key.getPrivateKeyAlias();
+            vault.storeSecret(alias, CryptoConverter.createJwk(kp.getContent()).toJSONString());
+            publicKeyJwk = CryptoConverter.createJwk(kp.getContent()).toPublicJWK();
+        } else if (key.getPublicKeyJwk() != null) {
+            publicKeyJwk = CryptoConverter.create(key.getPublicKeyJwk());
+
+        } else if (key.getPublicKeyPem() != null) {
+            var pubKey = keyParserRegistry.parse(key.getPublicKeyPem());
+            if (pubKey.failed()) {
+                return ServiceResult.badRequest("Cannot parse public key from PEM: %s".formatted(pubKey.getFailureDetail()));
+            }
+            publicKeyJwk = CryptoConverter.createJwk(new KeyPair((PublicKey) pubKey.getContent(), null));
+        }
+
+        // todo: create did document
+        return ServiceResult.success();
+    }
+
+    @NotNull
+    private ServiceResult<Void> createParticipantContext(ParticipantContext context) {
+        var storeRes = participantContextStore.create(context);
+        return storeRes.succeeded() ?
+                success() :
+                fromFailure(storeRes);
+    }
+
+    private ParticipantContext findByIdInternal(String participantId) {
+        var resultStream = participantContextStore.query(QuerySpec.Builder.newInstance().filter(new Criterion("participantContext", "=", participantId)).build());
+        if (resultStream.failed()) return null;
+        return resultStream.getContent().findFirst().orElse(null);
+    }
+
+
+    private ParticipantContext convert(ParticipantManifest manifest) {
+        return ParticipantContext.Builder.newInstance()
+                .participantId(manifest.getParticipantId())
+                .apiTokenAlias(tokenGenerator.generate())
+                .state(ParticipantContextState.CREATED)
+                .build();
+    }
 }
-
-

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -34,7 +34,6 @@ import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.transaction.spi.TransactionContext;
-import org.jetbrains.annotations.NotNull;
 
 import java.security.KeyPair;
 import java.security.PublicKey;
@@ -168,6 +167,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
         } else {
             return ServiceResult.badRequest("No public key information found in KeyDescriptor.");
         }
+        // insert the "kid" parameter
         var json = publicKeyJwk.toJSONObject();
         json.put(JWKParameterNames.KEY_ID, key.getKeyId());
         try {
@@ -178,7 +178,6 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
         }
     }
 
-    @NotNull
     private ServiceResult<Void> createParticipantContext(ParticipantContext context) {
         var storeRes = participantContextStore.create(context);
         return storeRes.succeeded() ?

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -118,7 +118,7 @@ class ParticipantContextServiceImplTest {
     @ValueSource(booleans = {true, false})
     void createParticipantContext_withKeyGenParams(boolean isActive) {
         when(participantContextStore.create(any())).thenReturn(StoreResult.success());
-
+        when(vault.storeSecret(anyString(), anyString())).thenReturn(Result.success());
         var ctx = createManifest()
                 .active(isActive)
                 .key(createKey().publicKeyPem(null).publicKeyJwk(null)

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -85,7 +85,7 @@ class ParticipantContextServiceImplTest {
         var ctx = createManifest()
                 .active(isActive)
                 .key(createKey()
-                        .publicKeyPem(null)
+                        .publicKeyJwk(null)
                         .publicKeyPem(pem)
                         .build()).build();
         assertThat(participantContextService.createParticipantContext(ctx))

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -70,9 +70,9 @@ class ParticipantContextServiceImplTest {
                 new Base64StringGenerator(), keyParserRegistry, didDocumentService);
     }
 
-    @ParameterizedTest(name = "autopublish: {0}")
+    @ParameterizedTest(name = "isActive: {0}")
     @ValueSource(booleans = {true, false})
-    void createParticipantContext_withPublicKeyPem(boolean autopublish) {
+    void createParticipantContext_withPublicKeyPem(boolean isActive) {
         when(participantContextStore.create(any())).thenReturn(StoreResult.success());
 
         var pem = """
@@ -83,7 +83,7 @@ class ParticipantContextServiceImplTest {
                 """;
 
         var ctx = createManifest()
-                .autoPublish(autopublish)
+                .active(isActive)
                 .key(createKey()
                         .publicKeyPem(null)
                         .publicKeyPem(pem)
@@ -93,33 +93,33 @@ class ParticipantContextServiceImplTest {
 
         verify(participantContextStore).create(any());
         verify(didDocumentService).store(any());
-        verify(didDocumentService, times(autopublish ? 1 : 0)).publish(anyString());
+        verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }
 
-    @ParameterizedTest(name = "autopublish: {0}")
+    @ParameterizedTest(name = "isActive: {0}")
     @ValueSource(booleans = {true, false})
-    void createParticipantContext_withPublicKeyJwk(boolean autopublish) {
+    void createParticipantContext_withPublicKeyJwk(boolean isActive) {
         when(participantContextStore.create(any())).thenReturn(StoreResult.success());
 
-        var ctx = createManifest().autoPublish(autopublish)
+        var ctx = createManifest().active(isActive)
                 .build();
         assertThat(participantContextService.createParticipantContext(ctx))
                 .isSucceeded();
 
         verify(participantContextStore).create(any());
         verify(didDocumentService).store(any());
-        verify(didDocumentService, times(autopublish ? 1 : 0)).publish(anyString());
+        verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }
 
-    @ParameterizedTest(name = "autopublish: {0}")
+    @ParameterizedTest(name = "isActive: {0}")
     @ValueSource(booleans = {true, false})
-    void createParticipantContext_withKeyGenParams(boolean autopublish) {
+    void createParticipantContext_withKeyGenParams(boolean isActive) {
         when(participantContextStore.create(any())).thenReturn(StoreResult.success());
 
         var ctx = createManifest()
-                .autoPublish(autopublish)
+                .active(isActive)
                 .key(createKey().publicKeyPem(null).publicKeyJwk(null)
                         .keyGeneratorParams(Map.of("algorithm", "EdDSA", "curve", "ed25519"))
                         .build())
@@ -130,7 +130,7 @@ class ParticipantContextServiceImplTest {
         verify(participantContextStore).create(any());
         verify(vault).storeSecret(eq(ctx.getKey().getPrivateKeyAlias()), anyString());
         verify(didDocumentService).store(any());
-        verify(didDocumentService, times(autopublish ? 1 : 0)).publish(anyString());
+        verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }
 
@@ -296,7 +296,7 @@ class ParticipantContextServiceImplTest {
     private ParticipantManifest.Builder createManifest() {
         return ParticipantManifest.Builder.newInstance()
                 .key(createKey().build())
-                .autoPublish(true)
+                .active(true)
                 .participantId("test-id");
     }
 

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -92,7 +92,7 @@ class ParticipantContextServiceImplTest {
                 .isSucceeded();
 
         verify(participantContextStore).create(any());
-        verify(didDocumentService).store(any());
+        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())));
         verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }
@@ -108,7 +108,7 @@ class ParticipantContextServiceImplTest {
                 .isSucceeded();
 
         verify(participantContextStore).create(any());
-        verify(didDocumentService).store(any());
+        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())));
         verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }
@@ -129,7 +129,7 @@ class ParticipantContextServiceImplTest {
 
         verify(participantContextStore).create(any());
         verify(vault).storeSecret(eq(ctx.getKey().getPrivateKeyAlias()), anyString());
-        verify(didDocumentService).store(any());
+        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())));
         verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }
@@ -207,6 +207,8 @@ class ParticipantContextServiceImplTest {
         assertThat(participantContextService.deleteParticipantContext("test-id")).isSucceeded();
 
         verify(participantContextStore).deleteById(anyString());
+        verify(didDocumentService).unpublish(any());
+        verify(didDocumentService).deleteById(any());
         verifyNoMoreInteractions(vault);
     }
 
@@ -221,7 +223,7 @@ class ParticipantContextServiceImplTest {
                 });
 
         verify(participantContextStore).deleteById(anyString());
-        verifyNoMoreInteractions(vault);
+        verifyNoMoreInteractions(vault, didDocumentService);
     }
 
     @Test
@@ -297,6 +299,7 @@ class ParticipantContextServiceImplTest {
         return ParticipantManifest.Builder.newInstance()
                 .key(createKey().build())
                 .active(true)
+                .did("did:web:test-id")
                 .participantId("test-id");
     }
 

--- a/extensions/api/management-api-configuration/build.gradle.kts
+++ b/extensions/api/management-api-configuration/build.gradle.kts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(project(":spi:identity-hub-spi"))
+    api(project(":spi:identity-hub-did-spi"))
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.core.jerseyproviders)
+    implementation(libs.jakarta.rsApi)
+
+}

--- a/extensions/api/management-api-configuration/build.gradle.kts
+++ b/extensions/api/management-api-configuration/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 

--- a/extensions/api/management-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfiguration.java
+++ b/extensions/api/management-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.configuration;
+
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
+
+/**
+ * Marker class specifically made for the configuration of all our Management APIs
+ */
+public class ManagementApiConfiguration extends WebServiceConfiguration {
+
+    public ManagementApiConfiguration(String contextAlias) {
+        super();
+        this.contextAlias = contextAlias;
+    }
+
+    public ManagementApiConfiguration(WebServiceConfiguration webServiceConfiguration) {
+        this.contextAlias = webServiceConfiguration.getContextAlias();
+        this.path = webServiceConfiguration.getPath();
+        this.port = webServiceConfiguration.getPort();
+    }
+}

--- a/extensions/api/management-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/api/management-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfigurationExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
 import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
@@ -58,7 +57,7 @@ public class ManagementApiConfigurationExtension implements ServiceExtension {
     }
 
     @Provider
-    public WebServiceConfiguration createManagementApiConfiguration(ServiceExtensionContext context) {
-        return configurer.configure(context, webServer, SETTINGS);
+    public ManagementApiConfiguration createManagementApiConfiguration(ServiceExtensionContext context) {
+        return new ManagementApiConfiguration(configurer.configure(context, webServer, SETTINGS));
     }
 }

--- a/extensions/api/management-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfigurationExtension.java
+++ b/extensions/api/management-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfigurationExtension.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.configuration;
+
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+
+import static org.eclipse.edc.identityhub.api.configuration.ManagementApiConfigurationExtension.NAME;
+
+@Extension(value = NAME)
+public class ManagementApiConfigurationExtension implements ServiceExtension {
+
+    public static final String NAME = "Management API Extension";
+    private static final String MGMT_CONTEXT_ALIAS = "management";
+    private static final String DEFAULT_DID_PATH = "/api/management";
+    private static final int DEFAULT_DID_PORT = 8182;
+    public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
+            .apiConfigKey("web.http." + MGMT_CONTEXT_ALIAS)
+            .contextAlias(MGMT_CONTEXT_ALIAS)
+            .defaultPath(DEFAULT_DID_PATH)
+            .defaultPort(DEFAULT_DID_PORT)
+            .useDefaultContext(false)
+            .name("IdentityHub Management API")
+            .build();
+    @Inject
+    private WebService webService;
+    @Inject
+    private ParticipantContextService participantContextService;
+    @Inject
+    private WebServiceConfigurer configurer;
+    @Inject
+    private WebServer webServer;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public WebServiceConfiguration createManagementApiConfiguration(ServiceExtensionContext context) {
+        return configurer.configure(context, webServer, SETTINGS);
+    }
+}

--- a/extensions/api/management-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/api/management-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2023 Metaform Systems, Inc.
+#  Copyright (c) 2024 Metaform Systems, Inc.
 #
 #  This program and the accompanying materials are made available under the
 #  terms of the Apache License, Version 2.0 which is available at

--- a/extensions/api/management-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/api/management-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.api.configuration.ManagementApiConfigurationExtension

--- a/extensions/api/management-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/api/management-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2023 Metaform Systems, Inc.
 #
 #  This program and the accompanying materials are made available under the
 #  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Contributors:
-#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#       Metaform Systems, Inc. - initial API and implementation
 #
 #
 

--- a/extensions/api/participant-context-mgmt-api/build.gradle.kts
+++ b/extensions/api/participant-context-mgmt-api/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+dependencies {
+    api(libs.edc.spi.core)
+    api(project(":spi:identity-hub-spi"))
+    api(project(":spi:identity-hub-did-spi"))
+    implementation(libs.edc.spi.validator)
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.util)
+    implementation(libs.edc.core.jerseyproviders)
+    implementation(libs.jakarta.rsApi)
+
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.ext.jsonld)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+    testImplementation(testFixtures(project(":spi:identity-hub-spi")))
+    testImplementation(libs.nimbus.jwt)
+    testImplementation(libs.restAssured)
+}

--- a/extensions/api/participant-context-mgmt-api/build.gradle.kts
+++ b/extensions/api/participant-context-mgmt-api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2024 Metaform Systems, Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Metaform Systems, Inc. - initial API and implementation
  *
  */
 

--- a/extensions/api/participant-context-mgmt-api/build.gradle.kts
+++ b/extensions/api/participant-context-mgmt-api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
     api(project(":spi:identity-hub-did-spi"))
+    implementation(project(":extensions:api:management-api-configuration"))
     implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
     implementation(libs.edc.util)

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
@@ -14,15 +14,15 @@
 
 package org.eclipse.edc.identityhub.api.participantcontext;
 
-import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identityhub.api.participantcontext.v1.ParticipantContextApiController;
+import org.eclipse.edc.identityhub.api.participantcontext.v1.validation.ParticipantManifestValidator;
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
-import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 
 import static org.eclipse.edc.identityhub.api.participantcontext.ParticipantContextManagementApiExtension.NAME;
 
@@ -30,25 +30,12 @@ import static org.eclipse.edc.identityhub.api.participantcontext.ParticipantCont
 public class ParticipantContextManagementApiExtension implements ServiceExtension {
 
     public static final String NAME = "ParticipantContext Management API Extension";
-    private static final String MGMT_CONTEXT_ALIAS = "management";
-    private static final String DEFAULT_DID_PATH = "/api/management";
-    private static final int DEFAULT_DID_PORT = 8182;
-    public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
-            .apiConfigKey("web.http." + MGMT_CONTEXT_ALIAS)
-            .contextAlias(MGMT_CONTEXT_ALIAS)
-            .defaultPath(DEFAULT_DID_PATH)
-            .defaultPort(DEFAULT_DID_PORT)
-            .useDefaultContext(false)
-            .name(NAME)
-            .build();
     @Inject
     private WebService webService;
     @Inject
-    private DidDocumentService didDocumentService;
+    private ParticipantContextService participantContextService;
     @Inject
-    private WebServiceConfigurer configurer;
-    @Inject
-    private WebServer webServer;
+    private WebServiceConfiguration webServiceConfiguration;
 
     @Override
     public String name() {
@@ -57,9 +44,7 @@ public class ParticipantContextManagementApiExtension implements ServiceExtensio
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var webServiceConfiguration = configurer.configure(context, webServer, SETTINGS);
-
+        var controller = new ParticipantContextApiController(new ParticipantManifestValidator(), participantContextService);
 //        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
     }
-
 }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext;
+
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.web.spi.WebServer;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
+import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
+
+import static org.eclipse.edc.identityhub.api.participantcontext.ParticipantContextManagementApiExtension.NAME;
+
+@Extension(value = NAME)
+public class ParticipantContextManagementApiExtension implements ServiceExtension {
+
+    public static final String NAME = "ParticipantContext Management API Extension";
+    private static final String MGMT_CONTEXT_ALIAS = "management";
+    private static final String DEFAULT_DID_PATH = "/api/management";
+    private static final int DEFAULT_DID_PORT = 8182;
+    public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
+            .apiConfigKey("web.http." + MGMT_CONTEXT_ALIAS)
+            .contextAlias(MGMT_CONTEXT_ALIAS)
+            .defaultPath(DEFAULT_DID_PATH)
+            .defaultPort(DEFAULT_DID_PORT)
+            .useDefaultContext(false)
+            .name(NAME)
+            .build();
+    @Inject
+    private WebService webService;
+    @Inject
+    private DidDocumentService didDocumentService;
+    @Inject
+    private WebServiceConfigurer configurer;
+    @Inject
+    private WebServer webServer;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var webServiceConfiguration = configurer.configure(context, webServer, SETTINGS);
+
+//        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
+    }
+
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
@@ -45,6 +45,6 @@ public class ParticipantContextManagementApiExtension implements ServiceExtensio
     @Override
     public void initialize(ServiceExtensionContext context) {
         var controller = new ParticipantContextApiController(new ParticipantManifestValidator(), participantContextService);
-//        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
+        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
     }
 }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.api.participantcontext;
 
+import org.eclipse.edc.identityhub.api.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.identityhub.api.participantcontext.v1.ParticipantContextApiController;
 import org.eclipse.edc.identityhub.api.participantcontext.v1.validation.ParticipantManifestValidator;
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
@@ -22,7 +23,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 
 import static org.eclipse.edc.identityhub.api.participantcontext.ParticipantContextManagementApiExtension.NAME;
 
@@ -35,7 +35,7 @@ public class ParticipantContextManagementApiExtension implements ServiceExtensio
     @Inject
     private ParticipantContextService participantContextService;
     @Inject
-    private WebServiceConfiguration webServiceConfiguration;
+    private ManagementApiConfiguration webServiceConfiguration;
 
     @Override
     public String name() {

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(
+        info = @Info(description = "This is the Management API for ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
+public interface ParticipantContextApi {
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
@@ -15,9 +15,97 @@
 package org.eclipse.edc.identityhub.api.participantcontext.v1;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
+import org.eclipse.edc.web.spi.ApiErrorDetail;
 
-@OpenAPIDefinition(
-        info = @Info(description = "This is the Management API for ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
+@OpenAPIDefinition(info = @Info(description = "This is the Management API for ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
 public interface ParticipantContextApi {
+
+    @Tag(name = "ParticipantContext Management API")
+    @Operation(description = "Creates a new ParticipantContext object.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The ParticipantContext was created successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "409", description = "Can't create the ParticipantContext, because a object with the same ID already exists",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void createParticipant(ParticipantManifest manifest);
+
+
+    @Tag(name = "ParticipantContext Management API")
+    @Operation(description = "Gets ParticipantContexts by ID.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The list of ParticipantContexts.",
+                            content = @Content(schema = @Schema(implementation = ParticipantContext.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    ParticipantContext getParticipant(String participantId);
+
+    @Tag(name = "ParticipantContext Management API")
+    @Operation(description = "Regenerates the API token for a ParticipantContext and returns the new token.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The API token was regenerated successfully", content = {@Content(schema = @Schema(implementation = String.class))}),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    String regenerateToken(String participantId);
+
+    @Tag(name = "ParticipantContext Management API")
+    @Operation(description = "Activates a ParticipantContext. This operation is idempotent, i.e. activating an already active ParticipantContext is a NOOP.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
+            parameters = {@Parameter(name = "isActive", description = "Whether the participantContext should be activated or deactivated. Defaults to 'false'")},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The ParticipantContext was activated/deactivated successfully", content = {@Content(schema = @Schema(implementation = String.class))}),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void activateParticipant(String participantId, boolean isActive);
+
+    @Tag(name = "ParticipantContext Management API")
+    @Operation(description = "Delete a ParticipantContext.",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The ParticipantContext was deleted successfully", content = {@Content(schema = @Schema(implementation = String.class))}),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void deleteParticipant(String participantId);
 }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
@@ -54,7 +54,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
 
     @Override
     @GET
-    @Path("/{participantId}/")
+    @Path("/{participantId}")
     public ParticipantContext getParticipant(@PathParam("participantId") String participantId) {
         return participantContextService.getParticipantContext(participantId).orElseThrow(exceptionMapper(ParticipantContext.class));
     }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import org.eclipse.edc.identityhub.api.participantcontext.v1.validation.ParticipantManifestValidator;
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v1/participants")
+public class ParticipantContextApiController implements ParticipantContextApi {
+
+    private final ParticipantManifestValidator participantManifestValidator;
+    private final ParticipantContextService participantContextService;
+
+    public ParticipantContextApiController(ParticipantManifestValidator participantManifestValidator, ParticipantContextService participantContextService) {
+        this.participantManifestValidator = participantManifestValidator;
+        this.participantContextService = participantContextService;
+    }
+
+    @Override
+    @POST
+    public void createParticipant(ParticipantManifest manifest) {
+        participantManifestValidator.validate(manifest).orElseThrow(ValidationFailureException::new);
+        participantContextService.createParticipantContext(manifest)
+                .orElseThrow(exceptionMapper(ParticipantManifest.class, manifest.getParticipantId()));
+    }
+
+    @Override
+    @GET
+    @Path("/{participantId}/")
+    public ParticipantContext getParticipant(@PathParam("participantId") String participantId) {
+        return participantContextService.getParticipantContext(participantId).orElseThrow(exceptionMapper(ParticipantContext.class));
+    }
+
+    @Override
+    @POST
+    @Path("/{participantId}/token")
+    public String regenerateToken(@PathParam("participantId") String participantId) {
+        return participantContextService.regenerateApiToken(participantId).orElseThrow(exceptionMapper(ParticipantContext.class));
+    }
+
+    @Override
+    @POST
+    @Path("/{participantId}/state")
+    public void activateParticipant(@PathParam("participantId") String participantId, @QueryParam("isActive") boolean isActive) {
+        if (isActive) {
+            participantContextService.updateParticipant(participantId, ParticipantContext::activate);
+        } else {
+            participantContextService.updateParticipant(participantId, ParticipantContext::deactivate);
+        }
+    }
+
+    @Override
+    @DELETE
+    @Path("/{participantId}")
+    public void deleteParticipant(@PathParam("participantId") String participantId) {
+        participantContextService.deleteParticipantContext(participantId).orElseThrow(exceptionMapper(ParticipantContext.class));
+    }
+
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/KeyDescriptor.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/KeyDescriptor.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Map;
+
+@JsonDeserialize(builder = KeyDescriptor.Builder.class)
+public class KeyDescriptor {
+    private String keyId;
+    private String privateKeyAlias;
+    private Map<String, Object> publicKeyJwk;
+    private String publicKeyPem;
+    private Map<String, String> keyGeneratorParams;
+
+    private KeyDescriptor() {
+    }
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public String getPrivateKeyAlias() {
+        return privateKeyAlias;
+    }
+
+    public Map<String, Object> getPublicKeyJwk() {
+        return publicKeyJwk;
+    }
+
+    public String getPublicKeyPem() {
+        return publicKeyPem;
+    }
+
+    public Map<String, String> getKeyGeneratorParams() {
+        return keyGeneratorParams;
+    }
+
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private final KeyDescriptor keyDescriptor;
+
+        private Builder() {
+            keyDescriptor = new KeyDescriptor();
+        }
+
+        public Builder keyId(String keyId) {
+            keyDescriptor.keyId = keyId;
+            return this;
+        }
+
+        public Builder privateKeyAlias(String privateKeyAlias) {
+            keyDescriptor.privateKeyAlias = privateKeyAlias;
+            return this;
+        }
+
+        public Builder publicKeyJwk(Map<String, Object> publicKeyJwk) {
+            keyDescriptor.publicKeyJwk = publicKeyJwk;
+            return this;
+        }
+
+        public Builder publicKeyPem(String publicKeyPem) {
+            keyDescriptor.publicKeyPem = publicKeyPem;
+            return this;
+        }
+
+        public Builder keyGeneratorParams(Map<String, String> keyGeneratorParams) {
+            keyDescriptor.keyGeneratorParams = keyGeneratorParams;
+            return this;
+        }
+
+        public KeyDescriptor build() {
+            return keyDescriptor;
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifest.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifest.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.iam.did.spi.document.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@JsonDeserialize(builder = ParticipantManifest.Builder.class)
+public class ParticipantManifest {
+    private Set<Service> serviceEndpoints = new HashSet<>();
+    private boolean isActive;
+    private boolean autoPublish;
+    private String participantId;
+    private KeyDescriptor key;
+
+    private ParticipantManifest() {
+    }
+
+    public Set<Service> getServiceEndpoints() {
+        return serviceEndpoints;
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+    public boolean isAutoPublish() {
+        return autoPublish;
+    }
+
+    public String getParticipantId() {
+        return participantId;
+    }
+
+    public KeyDescriptor getKey() {
+        return key;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+
+        private final ParticipantManifest manifest;
+
+        private Builder() {
+            manifest = new ParticipantManifest();
+        }
+
+        public Builder serviceEndpoints(Set<Service> serviceEndpoints) {
+            manifest.serviceEndpoints = serviceEndpoints;
+            return this;
+        }
+
+        public Builder serviceEndpoint(Service serviceEndpoint) {
+            manifest.serviceEndpoints.add(serviceEndpoint);
+            return this;
+        }
+
+        public Builder active(boolean isActive) {
+            manifest.isActive = isActive;
+            return this;
+        }
+
+        public Builder autoPublish(boolean autoPublish) {
+            manifest.autoPublish = autoPublish;
+            return this;
+        }
+
+        public Builder participantId(String participantId) {
+            manifest.participantId = participantId;
+            return this;
+        }
+
+        public Builder key(KeyDescriptor key) {
+            manifest.key = key;
+            return this;
+        }
+
+        public ParticipantManifest build() {
+            return manifest;
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidator.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidator.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
 
-import org.eclipse.edc.identityhub.api.participantcontext.v1.model.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.util.string.StringUtils;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidator.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidator.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
+
+import org.eclipse.edc.identityhub.api.participantcontext.v1.model.KeyDescriptor;
+import org.eclipse.edc.util.string.StringUtils;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.ValidationResult.success;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+/**
+ * Validates a {@link KeyDescriptor} by checking the following rules:
+ * <ul>
+ *     <li>the {@code keyId} must not be null</li>
+ *     <li>the {@code privateKeyAlias} must not be null</li>
+ *     <li>not all of {@code publicKeyPem}, {@code publicKeyJwk} and {@code keyGeneratorParams} must be null</li>
+ *     <li>not both  {@code publicKeyPem} and {@code publicKeyJwk} must be specified</li>
+ *     <li>if {@code keyGeneratorParams} are specified, {@code publicKeyPem} and {@code publicKeyJwk} must be null</li>
+ * </ul>
+ */
+public class KeyDescriptorValidator implements Validator<KeyDescriptor> {
+    @Override
+    public ValidationResult validate(KeyDescriptor input) {
+        if (input == null) {
+            return failure(violation("input was null", "."));
+        }
+
+        if (StringUtils.isNullOrBlank(input.getKeyId())) {
+            return failure(violation("keyId cannot be null.", "keyId"));
+        }
+
+        if (StringUtils.isNullOrBlank(input.getPrivateKeyAlias())) {
+            return failure(violation("privateKeyAlias cannot be null.", "privateKeyAlias"));
+        }
+
+        // either the public key or the key generator params are provided
+        if (allNull(input.getKeyGeneratorParams(), input.getPublicKeyJwk(), input.getPublicKeyPem())) {
+            return failure(violation("Either the public key is specified (PEM or JWK), or the generator parameters are provided.",
+                    "publicKeyJwk, publicKeyPem, keyGeneratorParams"));
+        }
+
+        if (input.getPublicKeyJwk() != null && input.getPublicKeyPem() != null) {
+            return failure(violation("The public key must either be provided in PEM or in JWK format, not both.", "publicKeyPem, publicKeyJwk"));
+        }
+
+        if (Stream.of(input.getPublicKeyJwk(), input.getPublicKeyPem()).anyMatch(Objects::nonNull) && input.getKeyGeneratorParams() != null) {
+            return failure(violation("Either the public key is specified (PEM or JWK), or the generator params are provided, not both.", "keyGeneratorPArams"));
+        }
+
+        return success();
+    }
+
+    private boolean allNull(Object... objects) {
+        return Stream.of(objects).allMatch(Objects::isNull);
+    }
+
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidator.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidator.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
 
-import org.eclipse.edc.identityhub.api.participantcontext.v1.model.ParticipantManifest;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidator.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidator.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
 
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
+import org.eclipse.edc.util.string.StringUtils;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
@@ -34,8 +35,11 @@ public class ParticipantManifestValidator implements Validator<ParticipantManife
         if (input.getKey() == null) {
             return failure(violation("key descriptor cannot be null.", "key"));
         }
-        if (input.getParticipantId() == null) {
-            return failure(violation("participantId cannot be null.", "participantId"));
+        if (StringUtils.isNullOrBlank(input.getParticipantId())) {
+            return failure(violation("participantId cannot be null or empty.", "participantId"));
+        }
+        if (StringUtils.isNullOrBlank(input.getDid())) {
+            return failure(violation("DID cannot be null or empty.", "did"));
         }
 
         var keyValidationResult = keyDescriptorValidator.validate(input.getKey());

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidator.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidator.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
+
+import org.eclipse.edc.identityhub.api.participantcontext.v1.model.ParticipantManifest;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.ValidationResult.success;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+public class ParticipantManifestValidator implements Validator<ParticipantManifest> {
+    private final KeyDescriptorValidator keyDescriptorValidator = new KeyDescriptorValidator();
+
+    @Override
+    public ValidationResult validate(ParticipantManifest input) {
+        if (input == null) {
+            return failure(violation("input was null.", "."));
+        }
+
+        if (input.getKey() == null) {
+            return failure(violation("key descriptor cannot be null.", "key"));
+        }
+        if (input.getParticipantId() == null) {
+            return failure(violation("participantId cannot be null.", "participantId"));
+        }
+
+        var keyValidationResult = keyDescriptorValidator.validate(input.getKey());
+        if (keyValidationResult.failed()) {
+            return failure(violation("key descriptor is invalid: %s".formatted(keyValidationResult.getFailureDetail()), "key"));
+        }
+
+
+        return success();
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/api/participant-context-mgmt-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.api.participantcontext.ParticipantContextManagementApiExtension

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
@@ -220,7 +220,8 @@ class ParticipantContextApiControllerTest extends RestControllerTestBase {
         return ParticipantManifest.Builder.newInstance()
                 .key(createKey().build())
                 .active(true)
-                .participantId("test-id");
+                .participantId("test-id")
+                .did("did:web:test-id");
     }
 
     @NotNull

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
@@ -1,0 +1,242 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.identityhub.api.participantcontext.v1.validation.ParticipantManifestValidator;
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContextState;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
+import org.eclipse.edc.junit.annotations.ApiTest;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ApiTest
+class ParticipantContextApiControllerTest extends RestControllerTestBase {
+
+    private final ParticipantContextService participantContextServiceMock = mock();
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void getById() {
+        var pc = createParticipantContext().build();
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(pc));
+
+        var participantContext = baseRequest()
+                .get("/%s".formatted(pc.getParticipantId()))
+                .then()
+                .statusCode(200)
+                .log().ifError()
+                .extract().body().as(ParticipantContext.class);
+
+        assertThat(participantContext).usingRecursiveComparison().isEqualTo(pc);
+        verify(participantContextServiceMock).getParticipantContext(any());
+    }
+
+    @Test
+    void getById_whenNotFound() {
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.notFound("foo bar"));
+
+        baseRequest()
+                .get("/not-exist")
+                .then()
+                .statusCode(404)
+                .log().ifError();
+    }
+
+    @Test
+    void createParticipant_success() {
+        when(participantContextServiceMock.createParticipantContext(any())).thenReturn(ServiceResult.success());
+        var manifest = createManifest().build();
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(manifest)
+                .post()
+                .then()
+                .statusCode(204);
+        verify(participantContextServiceMock).createParticipantContext(any(ParticipantManifest.class));
+    }
+
+    @Test
+    void createParticipant_invalidManifest() {
+        var manifest = createManifest()
+                .participantId(null)
+                .build();
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(manifest)
+                .post()
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(participantContextServiceMock);
+    }
+
+    @Test
+    void createParticipant_invalidKeyDescriptor() {
+        var manifest = createManifest()
+                .key(createKey().publicKeyPem(null).publicKeyJwk(null).keyGeneratorParams(null).build())
+                .build();
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(manifest)
+                .post()
+                .then()
+                .statusCode(400);
+        verifyNoInteractions(participantContextServiceMock);
+    }
+
+    @Test
+    void createParticipant_alreadyExists() {
+        when(participantContextServiceMock.createParticipantContext(any())).thenReturn(ServiceResult.conflict("already exists"));
+        var manifest = createManifest().build();
+        baseRequest()
+                .contentType(ContentType.JSON)
+                .body(manifest)
+                .post()
+                .then()
+                .statusCode(409);
+        verify(participantContextServiceMock).createParticipantContext(any(ParticipantManifest.class));
+    }
+
+    @Test
+    void regenerateToken() {
+        when(participantContextServiceMock.regenerateApiToken(any())).thenReturn(ServiceResult.success("new-api-token"));
+        baseRequest()
+                .post("/test-participant/token")
+                .then()
+                .statusCode(200)
+                .body(equalTo("new-api-token"));
+        verify(participantContextServiceMock).regenerateApiToken(eq("test-participant"));
+    }
+
+    @Test
+    void regenerateToken_notFound() {
+        when(participantContextServiceMock.regenerateApiToken(any())).thenReturn(ServiceResult.notFound("foo-bar"));
+        baseRequest()
+                .post("/test-participant/token")
+                .then()
+                .statusCode(404);
+        verify(participantContextServiceMock).regenerateApiToken(eq("test-participant"));
+    }
+
+    @Test
+    void activateParticipant() {
+        when(participantContextServiceMock.updateParticipant(any(), any())).thenReturn(ServiceResult.success());
+        baseRequest()
+                .post("/test-participant/state?isActive=true")
+                .then()
+                .statusCode(204);
+        verify(participantContextServiceMock).updateParticipant(eq("test-participant"), any());
+    }
+
+    @Test
+    void deactivateParticipant() {
+        when(participantContextServiceMock.updateParticipant(any(), any())).thenReturn(ServiceResult.success());
+        baseRequest()
+                .post("/test-participant/state?isActive=false")
+                .then()
+                .statusCode(204);
+        verify(participantContextServiceMock).updateParticipant(eq("test-participant"), any());
+    }
+
+    @Test
+    void delete() {
+        when(participantContextServiceMock.deleteParticipantContext(any())).thenReturn(ServiceResult.success());
+        baseRequest()
+                .delete("/test-participant")
+                .then()
+                .statusCode(204);
+        verify(participantContextServiceMock).deleteParticipantContext(eq("test-participant"));
+    }
+
+    @Test
+    void delete_notFound() {
+        when(participantContextServiceMock.deleteParticipantContext(any())).thenReturn(ServiceResult.notFound("foo bar"));
+        baseRequest()
+                .delete("/test-participant")
+                .then()
+                .statusCode(404);
+        verify(participantContextServiceMock).deleteParticipantContext(eq("test-participant"));
+    }
+
+    @Override
+    protected Object controller() {
+        return new ParticipantContextApiController(new ParticipantManifestValidator(), participantContextServiceMock);
+    }
+
+    private ParticipantContext.Builder createParticipantContext() {
+        return ParticipantContext.Builder.newInstance()
+                .participantId("test-id")
+                .createdAt(Instant.now().toEpochMilli())
+                .state(ParticipantContextState.ACTIVATED)
+                .apiTokenAlias("test-alias");
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .contentType("application/json")
+                .baseUri("http://localhost:" + port + "/v1/participants")
+                .when();
+    }
+
+    private ParticipantManifest.Builder createManifest() {
+        return ParticipantManifest.Builder.newInstance()
+                .key(createKey().build())
+                .active(true)
+                .participantId("test-id");
+    }
+
+    @NotNull
+    private KeyDescriptor.Builder createKey() {
+        return KeyDescriptor.Builder.newInstance().keyId("test-kie")
+                .privateKeyAlias("private-alias")
+                .publicKeyJwk(createJwk());
+    }
+
+    private Map<String, Object> createJwk() {
+        try {
+            return new OctetKeyPairGenerator(Curve.Ed25519)
+                    .generate()
+                    .toJSONObject();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/KeyDescriptorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/KeyDescriptorTest.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeyDescriptorTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void verify_serdes() throws JsonProcessingException {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("alias")
+                .publicKeyJwk(Map.of("foo", "bar"))
+                .publicKeyPem("pem formatted text")
+                .keyGeneratorParams(Map.of("bar", "baz"))
+                .build();
+
+        var json = mapper.writeValueAsString(descriptor);
+        assertThat(json).isNotNull();
+
+        var deser = mapper.readValue(json, KeyDescriptor.class);
+        assertThat(deser).usingRecursiveComparison().isEqualTo(descriptor);
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/KeyDescriptorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/KeyDescriptorTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifestTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifestTest.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifestTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifestTest.java
@@ -33,7 +33,6 @@ class ParticipantManifestTest {
     void verify_serdes() throws JsonProcessingException {
         var manifest = ParticipantManifest.Builder.newInstance()
                 .serviceEndpoint(new Service("id", "type", "foobar"))
-                .autoPublish(true)
                 .active(true)
                 .participantId("test-id")
                 .key(KeyDescriptor.Builder.newInstance()

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifestTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/model/ParticipantManifestTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParticipantManifestTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void verify_serdes() throws JsonProcessingException {
+        var manifest = ParticipantManifest.Builder.newInstance()
+                .serviceEndpoint(new Service("id", "type", "foobar"))
+                .autoPublish(true)
+                .active(true)
+                .participantId("test-id")
+                .key(KeyDescriptor.Builder.newInstance()
+                        .keyId("key-id")
+                        .privateKeyAlias("alias")
+                        .publicKeyJwk(Map.of("foo", "bar"))
+                        .publicKeyPem("pem formatted text")
+                        .keyGeneratorParams(Map.of("bar", "baz"))
+                        .build())
+                .build();
+
+        var json = mapper.writeValueAsString(manifest);
+        assertThat(json).isNotNull();
+
+        var deser = mapper.readValue(json, ParticipantManifest.class);
+        assertThat(deser).usingRecursiveComparison().isEqualTo(manifest);
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidatorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidatorTest.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
 
-import org.eclipse.edc.identityhub.api.participantcontext.v1.model.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidatorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/KeyDescriptorValidatorTest.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
+
+import org.eclipse.edc.identityhub.api.participantcontext.v1.model.KeyDescriptor;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class KeyDescriptorValidatorTest {
+
+    private final KeyDescriptorValidator validator = new KeyDescriptorValidator();
+
+    @Test
+    void validate_success() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("alias")
+                .keyGeneratorParams(Map.of("bar", "baz"))
+                .build();
+
+        assertThat(validator.validate(descriptor)).isSucceeded();
+    }
+
+    @Test
+    void validate_inputNull() {
+        assertThat(validator.validate(null)).isFailed()
+                .detail().isEqualTo("input was null");
+    }
+
+    @Test
+    void validate_keyIdNull() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .privateKeyAlias("alias")
+                .keyGeneratorParams(Map.of("bar", "baz"))
+                .build();
+
+        assertThat(validator.validate(descriptor)).isFailed()
+                .detail().isEqualTo("keyId cannot be null.");
+    }
+
+    @Test
+    void validate_privateKeyAliasNull() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .keyGeneratorParams(Map.of("bar", "baz"))
+                .build();
+
+        assertThat(validator.validate(descriptor)).isFailed()
+                .detail().isEqualTo("privateKeyAlias cannot be null.");
+    }
+
+    @Test
+    void validate_allNull() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("test-alias")
+                .build();
+        assertThat(validator.validate(descriptor)).isFailed()
+                .detail().isEqualTo("Either the public key is specified (PEM or JWK), or the generator parameters are provided.");
+    }
+
+    @Test
+    void validate_bothPublicKeyFormats() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("test-alias")
+                .publicKeyJwk(Map.of("foo", "bar"))
+                .publicKeyPem("pemstring")
+                .build();
+        assertThat(validator.validate(descriptor)).isFailed()
+                .detail().isEqualTo("The public key must either be provided in PEM or in JWK format, not both.");
+    }
+
+    @Test
+    void validate_publicKeyJwkAndGeneratorParams() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("test-alias")
+                .publicKeyJwk(Map.of("foo", "bar"))
+                .keyGeneratorParams(Map.of("bar", "baz"))
+                .build();
+        assertThat(validator.validate(descriptor)).isFailed()
+                .detail().isEqualTo("Either the public key is specified (PEM or JWK), or the generator params are provided, not both.");
+    }
+
+
+    @Test
+    void validate_publicKeyPemAndGeneratorParams() {
+        var descriptor = KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("test-alias")
+                .publicKeyPem("pemstring")
+                .keyGeneratorParams(Map.of("bar", "baz"))
+                .build();
+        assertThat(validator.validate(descriptor)).isFailed()
+                .detail().isEqualTo("Either the public key is specified (PEM or JWK), or the generator params are provided, not both.");
+    }
+
+
+}

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
@@ -66,7 +66,6 @@ class ParticipantManifestValidatorTest {
     private static ParticipantManifest.Builder createManifest() {
         return ParticipantManifest.Builder.newInstance()
                 .serviceEndpoint(new Service("id", "type", "foobar"))
-                .autoPublish(true)
                 .active(true)
                 .participantId("test-id")
                 .key(createKeyDescriptor().build());

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
+
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.identityhub.api.participantcontext.v1.model.KeyDescriptor;
+import org.eclipse.edc.identityhub.api.participantcontext.v1.model.ParticipantManifest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class ParticipantManifestValidatorTest {
+
+    private final ParticipantManifestValidator validator = new ParticipantManifestValidator();
+
+    @Test
+    void validate_success() {
+        var manifest = createManifest().build();
+        assertThat(validator.validate(manifest)).isSucceeded();
+    }
+
+    @Test
+    void validate_inputNull() {
+        assertThat(validator.validate(null)).isFailed()
+                .detail().isEqualTo("input was null.");
+    }
+
+    @Test
+    void validate_keyDescriptorNull() {
+        var manifest = createManifest().key(null).build();
+        assertThat(validator.validate(manifest)).isFailed()
+                .detail().isEqualTo("key descriptor cannot be null.");
+    }
+
+    @Test
+    void validate_keyDescriptorInvalid() {
+        var manifest = createManifest().key(createKeyDescriptor().publicKeyPem("pemstring").build()).build();
+
+        assertThat(validator.validate(manifest)).isFailed()
+                .detail().startsWith("key descriptor is invalid");
+    }
+
+    @Test
+    void validate_participantIdNull() {
+        var manifest = createManifest().participantId(null).build();
+        assertThat(validator.validate(manifest)).isFailed()
+                .detail().isEqualTo("participantId cannot be null.");
+    }
+
+    @NotNull
+    private static ParticipantManifest.Builder createManifest() {
+        return ParticipantManifest.Builder.newInstance()
+                .serviceEndpoint(new Service("id", "type", "foobar"))
+                .autoPublish(true)
+                .active(true)
+                .participantId("test-id")
+                .key(createKeyDescriptor().build());
+    }
+
+    @NotNull
+    private static KeyDescriptor.Builder createKeyDescriptor() {
+        return KeyDescriptor.Builder.newInstance()
+                .keyId("key-id")
+                .privateKeyAlias("alias")
+                .publicKeyJwk(Map.of("foo", "bar"));
+    }
+}

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
@@ -19,6 +19,9 @@ import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Map;
 
@@ -55,11 +58,22 @@ class ParticipantManifestValidatorTest {
                 .detail().startsWith("key descriptor is invalid");
     }
 
-    @Test
-    void validate_participantIdNull() {
-        var manifest = createManifest().participantId(null).build();
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "\n"})
+    @NullAndEmptySource
+    void validate_didInvalid(String did) {
+        var manifest = createManifest().did(did).build();
         assertThat(validator.validate(manifest)).isFailed()
-                .detail().isEqualTo("participantId cannot be null.");
+                .detail().isEqualTo("DID cannot be null or empty.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "  ", "\n"})
+    @NullAndEmptySource
+    void validate_participantIdNull(String participantId) {
+        var manifest = createManifest().participantId(participantId).build();
+        assertThat(validator.validate(manifest)).isFailed()
+                .detail().isEqualTo("participantId cannot be null or empty.");
     }
 
     @NotNull
@@ -67,6 +81,7 @@ class ParticipantManifestValidatorTest {
         return ParticipantManifest.Builder.newInstance()
                 .serviceEndpoint(new Service("id", "type", "foobar"))
                 .active(true)
+                .did("did:web:test-did")
                 .participantId("test-id")
                 .key(createKeyDescriptor().build());
     }

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/validation/ParticipantManifestValidatorTest.java
@@ -15,8 +15,8 @@
 package org.eclipse.edc.identityhub.api.participantcontext.v1.validation;
 
 import org.eclipse.edc.iam.did.spi.document.Service;
-import org.eclipse.edc.identityhub.api.participantcontext.v1.model.KeyDescriptor;
-import org.eclipse.edc.identityhub.api.participantcontext.v1.model.ParticipantManifest;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 

--- a/extensions/common/security/src/main/java/org/eclipse/edc/identityhub/security/KeyPairGenerator.java
+++ b/extensions/common/security/src/main/java/org/eclipse/edc/identityhub/security/KeyPairGenerator.java
@@ -48,15 +48,16 @@ public class KeyPairGenerator {
     private static final String RSA_PARAM_LENGTH = "length";
     private static final String EC_PARAM_CURVE = "curve";
     private static final String EC_DEFAULT_CURVE = "secp256r1";
+    private static final String ALGORITHM_ENTRY = "algorithm";
 
     /**
      * Generate a Java {@link KeyPair} from an algorithm identifier and generator parameters.
      *
-     * @param algorithm  One of [EC, RSA, EdDSA]. If null, defaults to "EdDSA".
      * @param parameters May contain specific paramters, such as "length" (RSA), or a "curve" (EC and EdDSA). May be empty, not null.
      * @return A {@link KeyPair}, or a failure indicating what went wrong.
      */
-    public static Result<KeyPair> generateKeyPair(String algorithm, Map<String, Object> parameters) {
+    public static Result<KeyPair> generateKeyPair(Map<String, Object> parameters) {
+        var algorithm = parameters.get(ALGORITHM_ENTRY).toString();
         if (StringUtils.isNullOrBlank(algorithm)) {
             return generateEdDsa(CURVE_ED25519);
         }

--- a/extensions/did/did-management-api/build.gradle.kts
+++ b/extensions/did/did-management-api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
     api(project(":spi:identity-hub-did-spi"))
+    implementation(project(":extensions:api:management-api-configuration"))
     implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
     implementation(libs.edc.core.jerseyproviders)

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -18,10 +18,12 @@ import org.eclipse.edc.identithub.did.spi.DidDocumentService;
 import org.eclipse.edc.identityhub.api.didmanagement.v1.DidManagementApiController;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
 import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
@@ -40,7 +42,7 @@ public class DidManagementApiExtension implements ServiceExtension {
             .defaultPath(DEFAULT_DID_PATH)
             .defaultPort(DEFAULT_DID_PORT)
             .useDefaultContext(false)
-            .name("DID Management Endpoint API")
+            .name("IdentityHub Management API")
             .build();
     @Inject
     private WebService webService;
@@ -58,10 +60,13 @@ public class DidManagementApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var webServiceConfiguration = configurer.configure(context, webServer, SETTINGS);
-
         var controller = new DidManagementApiController(didDocumentService);
-        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
+        webService.registerResource(createManagementApiConfiguration(context).getContextAlias(), controller);
     }
 
+    //todo: move to separate extension
+    @Provider
+    public WebServiceConfiguration createManagementApiConfiguration(ServiceExtensionContext context) {
+        return configurer.configure(context, webServer, SETTINGS);
+    }
 }

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -15,13 +15,13 @@
 package org.eclipse.edc.identityhub.api.didmanagement;
 
 import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identityhub.api.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.identityhub.api.didmanagement.v1.DidManagementApiController;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
 
 import static org.eclipse.edc.identityhub.api.didmanagement.DidManagementApiExtension.NAME;
 
@@ -35,7 +35,7 @@ public class DidManagementApiExtension implements ServiceExtension {
     @Inject
     private DidDocumentService didDocumentService;
     @Inject
-    private WebServiceConfiguration webServiceConfiguration;
+    private ManagementApiConfiguration webServiceConfiguration;
 
 
     @Override

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -18,14 +18,10 @@ import org.eclipse.edc.identithub.did.spi.DidDocumentService;
 import org.eclipse.edc.identityhub.api.didmanagement.v1.DidManagementApiController;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.web.spi.WebServer;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.WebServiceConfiguration;
-import org.eclipse.edc.web.spi.configuration.WebServiceConfigurer;
-import org.eclipse.edc.web.spi.configuration.WebServiceSettings;
 
 import static org.eclipse.edc.identityhub.api.didmanagement.DidManagementApiExtension.NAME;
 
@@ -33,25 +29,14 @@ import static org.eclipse.edc.identityhub.api.didmanagement.DidManagementApiExte
 public class DidManagementApiExtension implements ServiceExtension {
 
     public static final String NAME = "DID Management API Extension";
-    private static final String MGMT_CONTEXT_ALIAS = "management";
-    private static final String DEFAULT_DID_PATH = "/api/management";
-    private static final int DEFAULT_DID_PORT = 8182;
-    public static final WebServiceSettings SETTINGS = WebServiceSettings.Builder.newInstance()
-            .apiConfigKey("web.http." + MGMT_CONTEXT_ALIAS)
-            .contextAlias(MGMT_CONTEXT_ALIAS)
-            .defaultPath(DEFAULT_DID_PATH)
-            .defaultPort(DEFAULT_DID_PORT)
-            .useDefaultContext(false)
-            .name("IdentityHub Management API")
-            .build();
+
     @Inject
     private WebService webService;
     @Inject
     private DidDocumentService didDocumentService;
     @Inject
-    private WebServiceConfigurer configurer;
-    @Inject
-    private WebServer webServer;
+    private WebServiceConfiguration webServiceConfiguration;
+
 
     @Override
     public String name() {
@@ -61,12 +46,8 @@ public class DidManagementApiExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var controller = new DidManagementApiController(didDocumentService);
-        webService.registerResource(createManagementApiConfiguration(context).getContextAlias(), controller);
+        webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
     }
 
-    //todo: move to separate extension
-    @Provider
-    public WebServiceConfiguration createManagementApiConfiguration(ServiceExtensionContext context) {
-        return configurer.configure(context, webServer, SETTINGS);
-    }
+
 }

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -68,7 +68,7 @@ public interface DidManagementApi {
     @Operation(description = "Query for DID documents..",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "The DID document was successfully deleted.",
+                    @ApiResponse(responseCode = "200", description = "The list of DID Documents.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = DidDocument.class)))),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/docs/schema.sql
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/docs/schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE participant_context
     created_date       BIGINT              NOT NULL, -- POSIX timestamp of the creation of the PC
     last_modified_date BIGINT,                       -- POSIX timestamp of the last modified date
     state              INTEGER             NOT NULL, -- 0 = CREATED, 1 = ACTIVE, 2 = DEACTIVATED
-    api_token_alias    VARCHAR             NOT NULL  -- alias under which this PC's api token is stored in the vault
+    api_token_alias    VARCHAR             NOT NULL, -- alias under which this PC's api token is stored in the vault
+    did                VARCHAR                       -- the DID with which this participant is identified
 );
 CREATE UNIQUE INDEX participant_context_participant_id_uindex ON participant_context USING btree (participant_id);
 

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/BaseSqlDialectStatements.java
@@ -29,6 +29,7 @@ public class BaseSqlDialectStatements implements ParticipantContextStoreStatemen
                 .column(getLastModifiedTimestampColumn())
                 .column(getStateColumn())
                 .column(getApiTokenAliasColumn())
+                .column(getDidColumn())
                 .insertInto(getParticipantContextTable());
     }
 
@@ -40,6 +41,7 @@ public class BaseSqlDialectStatements implements ParticipantContextStoreStatemen
                 .column(getLastModifiedTimestampColumn())
                 .column(getStateColumn())
                 .column(getApiTokenAliasColumn())
+                .column(getDidColumn())
                 .update(getParticipantContextTable(), getIdColumn());
     }
 

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/ParticipantContextStoreStatements.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/ParticipantContextStoreStatements.java
@@ -47,6 +47,10 @@ public interface ParticipantContextStoreStatements extends SqlStatements {
         return "api_token_alias";
     }
 
+    default String getDidColumn() {
+        return "did";
+    }
+
     String getInsertTemplate();
 
     String getUpdateTemplate();

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/SqlParticipantContextStore.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/SqlParticipantContextStore.java
@@ -65,8 +65,8 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                 var stmt = statements.getInsertTemplate();
                 queryExecutor.execute(connection, stmt,
                         participantContext.getParticipantId(),
-                        participantContext.getCreatedDate(),
-                        participantContext.getLastModifiedDate(),
+                        participantContext.getCreatedAt(),
+                        participantContext.getLastModified(),
                         participantContext.getState(),
                         participantContext.getApiTokenAlias());
                 return success();
@@ -101,8 +101,8 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                     queryExecutor.execute(connection,
                             statements.getUpdateTemplate(),
                             id,
-                            participantContext.getCreatedDate(),
-                            participantContext.getLastModifiedDate(),
+                            participantContext.getCreatedAt(),
+                            participantContext.getLastModified(),
                             participantContext.getState(),
                             participantContext.getApiTokenAlias(),
                             id);

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/SqlParticipantContextStore.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/SqlParticipantContextStore.java
@@ -68,7 +68,9 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                         participantContext.getCreatedAt(),
                         participantContext.getLastModified(),
                         participantContext.getState(),
-                        participantContext.getApiTokenAlias());
+                        participantContext.getApiTokenAlias(),
+                        participantContext.getDid()
+                );
                 return success();
 
             } catch (SQLException e) {
@@ -105,6 +107,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                             participantContext.getLastModified(),
                             participantContext.getState(),
                             participantContext.getApiTokenAlias(),
+                            participantContext.getDid(),
                             id);
                     return StoreResult.success();
                 }
@@ -146,6 +149,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
         var lastmodified = resultSet.getLong(statements.getLastModifiedTimestampColumn());
         var state = resultSet.getInt(statements.getStateColumn());
         var tokenAliase = resultSet.getString(statements.getApiTokenAliasColumn());
+        var did = resultSet.getString(statements.getDidColumn());
 
         return ParticipantContext.Builder.newInstance()
                 .participantId(id)
@@ -153,6 +157,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                 .lastModified(lastmodified)
                 .state(ParticipantContextState.values()[state])
                 .apiTokenAlias(tokenAliase)
+                .did(did)
                 .build();
     }
 }

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/schema/postgres/ParticipantContextMapping.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/schema/postgres/ParticipantContextMapping.java
@@ -24,8 +24,8 @@ import org.eclipse.edc.sql.translation.TranslationMapping;
 public class ParticipantContextMapping extends TranslationMapping {
 
     public static final String FIELD_ID = "participantId";
-    public static final String FIELD_CREATE_TIMESTAMP = "createdDate";
-    public static final String FIELD_LASTMODIFIED_TIMESTAMP = "lastModifiedDate";
+    public static final String FIELD_CREATE_TIMESTAMP = "createdAt";
+    public static final String FIELD_LASTMODIFIED_TIMESTAMP = "lastModified";
     public static final String FIELD_STATE = "state";
     public static final String FIELD_API_TOKEN_ALIAS = "apiTokenAlias";
 

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/schema/postgres/ParticipantContextMapping.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/schema/postgres/ParticipantContextMapping.java
@@ -28,6 +28,7 @@ public class ParticipantContextMapping extends TranslationMapping {
     public static final String FIELD_LASTMODIFIED_TIMESTAMP = "lastModified";
     public static final String FIELD_STATE = "state";
     public static final String FIELD_API_TOKEN_ALIAS = "apiTokenAlias";
+    public static final String FIELD_DID = "did";
 
     public ParticipantContextMapping(ParticipantContextStoreStatements statements) {
         add(FIELD_ID, statements.getIdColumn());
@@ -35,5 +36,6 @@ public class ParticipantContextMapping extends TranslationMapping {
         add(FIELD_STATE, statements.getStateColumn());
         add(FIELD_LASTMODIFIED_TIMESTAMP, statements.getLastModifiedTimestampColumn());
         add(FIELD_API_TOKEN_ALIAS, statements.getApiTokenAliasColumn());
+        add(FIELD_DID, statements.getDidColumn());
     }
 }

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly(project(":extensions:did:local-did-publisher"))
     runtimeOnly(project(":extensions:did:did-management-api"))
     runtimeOnly(project(":extensions:api:participant-context-mgmt-api"))
+    runtimeOnly(project(":extensions:api:management-api-configuration"))
     runtimeOnly(libs.edc.identity.did.core)
     runtimeOnly(libs.edc.core.token)
 

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     runtimeOnly(project(":core:identity-hub-participants"))
     runtimeOnly(project(":extensions:did:local-did-publisher"))
     runtimeOnly(project(":extensions:did:did-management-api"))
+    runtimeOnly(project(":extensions:api:participant-context-mgmt-api"))
     runtimeOnly(libs.edc.identity.did.core)
     runtimeOnly(libs.edc.core.token)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,7 @@ include(":extensions:store:sql:identity-hub-credentials-store-sql")
 include(":extensions:store:sql:identity-hub-participantcontext-store-sql")
 include(":extensions:did:local-did-publisher")
 include(":extensions:did:did-management-api")
+include(":extensions:api:participant-context-mgmt-api")
 
 // other modules
 include(":launcher")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,8 +39,9 @@ include(":extensions:store:sql:identity-hub-did-store-sql")
 include(":extensions:store:sql:identity-hub-credentials-store-sql")
 include(":extensions:store:sql:identity-hub-participantcontext-store-sql")
 include(":extensions:did:local-did-publisher")
-include(":extensions:did:did-management-api")
+include(":extensions:api:management-api-configuration")
 include(":extensions:api:participant-context-mgmt-api")
+include(":extensions:did:did-management-api")
 
 // other modules
 include(":launcher")

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
@@ -27,6 +27,19 @@ import java.util.Collection;
  */
 public interface DidDocumentService {
 
+    /**
+     * Stores a DID document in persistent storage. * * @param document the {@link DidDocument} to store
+     *
+     * @return a {@link ServiceResult} to indicate success or failure.
+     */
+    ServiceResult<Void> store(DidDocument document);
+
+    /**
+     * Deletes a DID document if found. * * @param did The ID of the DID document to delete.
+     *
+     * @return A {@link ServiceResult} indicating success or failure.
+     */
+    ServiceResult<Void> deleteById(String did);
 
     /**
      * Publishes an already existing DID document. Returns a failure if the DID document was not found or cannot be published.

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/ParticipantContextService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/ParticipantContextService.java
@@ -15,20 +15,24 @@
 package org.eclipse.edc.identityhub.spi;
 
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.function.Consumer;
 
 /**
  * Handles {@link ParticipantContext} objects, their lifecycle and their authentication tokens.
  */
 public interface ParticipantContextService {
 
+
     /**
-     * Creates a new participant context. If one with the same ID exists, a failure is returned
+     * Creates a new participant context from a manifest. If one with the same ID exists, a failure is returned.
      *
-     * @param context The new participant context
+     * @param manifest The new participant context
      * @return success if created, or a failure if already exists.
      */
-    ServiceResult<Void> createParticipantContext(ParticipantContext context);
+    ServiceResult<Void> createParticipantContext(ParticipantManifest manifest);
 
     /**
      * Fetches the {@link ParticipantContext} by ID.
@@ -55,4 +59,13 @@ public interface ParticipantContextService {
      * @return the new API token, or a failure
      */
     ServiceResult<String> regenerateApiToken(String participantId);
+
+    /**
+     * Applies a modification function to the {@link ParticipantContext} and persists the changed object in the database.
+     *
+     * @param participantId        The ID of the participant to modify
+     * @param modificationFunction A modification function that is applied to the participant context
+     * @return success if the update could be performed, a failure otherwise
+     */
+    ServiceResult<Void> updateParticipant(String participantId, Consumer<ParticipantContext> modificationFunction);
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
+package org.eclipse.edc.identityhub.spi.model.participant;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -26,7 +26,7 @@ public class KeyDescriptor {
     private String privateKeyAlias;
     private Map<String, Object> publicKeyJwk;
     private String publicKeyPem;
-    private Map<String, String> keyGeneratorParams;
+    private Map<String, Object> keyGeneratorParams;
 
     private KeyDescriptor() {
     }
@@ -47,7 +47,7 @@ public class KeyDescriptor {
         return publicKeyPem;
     }
 
-    public Map<String, String> getKeyGeneratorParams() {
+    public Map<String, Object> getKeyGeneratorParams() {
         return keyGeneratorParams;
     }
 
@@ -80,7 +80,7 @@ public class KeyDescriptor {
             return this;
         }
 
-        public Builder keyGeneratorParams(Map<String, String> keyGeneratorParams) {
+        public Builder keyGeneratorParams(Map<String, Object> keyGeneratorParams) {
             keyDescriptor.keyGeneratorParams = keyGeneratorParams;
             return this;
         }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
@@ -20,6 +20,15 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.util.Map;
 
+/**
+ * Container object to describe, what security keys should be used when creating a {@link ParticipantContext}.
+ * There are two basic options:
+ * <ol>
+ *     <li>Keys already exist - the public key can be specified using PEM or JWK format. The private key is expected to exist in the {@link org.eclipse.edc.spi.security.Vault} under the alias {@link KeyDescriptor#getPrivateKeyAlias()}</li>
+ *     <li>Keys don't exist - keys are to be generated using the {@link KeyDescriptor#getKeyGeneratorParams()}.</li>
+ * </ol>
+ * Specifying both options - or none - is an error.
+ */
 @JsonDeserialize(builder = KeyDescriptor.Builder.class)
 public class KeyDescriptor {
     private String keyId;

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
@@ -41,22 +41,39 @@ public class KeyDescriptor {
     private KeyDescriptor() {
     }
 
+    /**
+     * The ID of the key. Will be used to reference the key that was used for signing, e.g. as "kid" header in JSON Web Tokens
+     */
     public String getKeyId() {
         return keyId;
     }
 
+    /**
+     * Alias under which the private key is stored in the vault. If keys are to be generated, the new private key will get stored
+     * under the that alias.
+     */
     public String getPrivateKeyAlias() {
         return privateKeyAlias;
     }
 
+    /**
+     * Public key in JWK format (JSON string). If this is specified, {@link KeyDescriptor#getPublicKeyPem()} and {@link KeyDescriptor#getKeyGeneratorParams()} MUST be null.
+     */
     public Map<String, Object> getPublicKeyJwk() {
         return publicKeyJwk;
     }
 
+    /**
+     * Public key in PEM format. If this is specified, {@link KeyDescriptor#getPublicKeyJwk()} ()} and {@link KeyDescriptor#getKeyGeneratorParams()} MUST be null.
+     */
     public String getPublicKeyPem() {
         return publicKeyPem;
     }
 
+    /**
+     * Specify only if keys are to be generated. Must contain an "algorithm -> [EC | RSA | EdDSA]" entry, possibly a "curve" parameter. If specified, {@link KeyDescriptor#getPublicKeyPem()} and {@link KeyDescriptor#getPublicKeyJwk()}
+     * MUST be null.
+     */
     public Map<String, Object> getKeyGeneratorParams() {
         return keyGeneratorParams;
     }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.identityhub.spi.model.participant;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.spi.security.Vault;
 
 import java.util.Map;
 
@@ -24,10 +25,10 @@ import java.util.Map;
  * Container object to describe, what security keys should be used when creating a {@link ParticipantContext}.
  * There are two basic options:
  * <ol>
- *     <li>Keys already exist - the public key can be specified using PEM or JWK format. The private key is expected to exist in the {@link org.eclipse.edc.spi.security.Vault} under the alias {@link KeyDescriptor#getPrivateKeyAlias()}</li>
- *     <li>Keys don't exist - keys are to be generated using the {@link KeyDescriptor#getKeyGeneratorParams()}.</li>
+ *     <li>Keys already exist - the public key can be specified using PEM or JWK format. The private key is expected to exist in the {@link Vault} under the alias {@link KeyDescriptor#getPrivateKeyAlias()}</li>
+ *     <li>Keys don't exist - keys are to be generated, in which case the the {@link KeyDescriptor#getKeyGeneratorParams()} have to be specified.</li>
  * </ol>
- * Specifying both options - or none - is an error.
+ * Specifying both options - or neither - is an error.
  */
 @JsonDeserialize(builder = KeyDescriptor.Builder.class)
 public class KeyDescriptor {

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.model.participant;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -24,8 +25,8 @@ import java.util.Objects;
 @JsonDeserialize(builder = ParticipantContext.Builder.class)
 public class ParticipantContext {
     private String participantId;
-    private long createdDate;
-    private long lastModifiedDate;
+    private long createdAt;
+    private long lastModified;
     private int state; // CREATED, ACTIVATED, DEACTIVATED
     private String apiTokenAlias; // or apiTokenAlias
 
@@ -42,15 +43,15 @@ public class ParticipantContext {
     /**
      * The POSIX timestamp in ms when this entry was created. Immutable
      */
-    public long getCreatedDate() {
-        return createdDate;
+    public long getCreatedAt() {
+        return createdAt;
     }
 
     /**
      * The POSIX timestamp in ms when this entry was last modified.
      */
-    public long getLastModifiedDate() {
-        return lastModifiedDate;
+    public long getLastModified() {
+        return lastModified;
     }
 
     /**
@@ -60,6 +61,7 @@ public class ParticipantContext {
         return state;
     }
 
+    @JsonIgnore
     public ParticipantContextState getStateAsEnum() {
         return ParticipantContextState.values()[state];
     }
@@ -76,7 +78,7 @@ public class ParticipantContext {
      * Updates the last-modified field.
      */
     public void updateLastModified() {
-        this.lastModifiedDate = Instant.now().toEpochMilli();
+        this.lastModified = Instant.now().toEpochMilli();
     }
 
     public void activate() {
@@ -93,16 +95,16 @@ public class ParticipantContext {
 
         private Builder() {
             participantContext = new ParticipantContext();
-            participantContext.createdDate = Instant.now().toEpochMilli();
+            participantContext.createdAt = Instant.now().toEpochMilli();
         }
 
         public Builder createdAt(long createdAt) {
-            this.participantContext.createdDate = createdAt;
+            this.participantContext.createdAt = createdAt;
             return this;
         }
 
         public Builder lastModified(long lastModified) {
-            this.participantContext.lastModifiedDate = lastModified;
+            this.participantContext.lastModified = lastModified;
             return this;
         }
 
@@ -125,8 +127,8 @@ public class ParticipantContext {
             Objects.requireNonNull(participantContext.participantId, "Participant ID cannot be null");
             Objects.requireNonNull(participantContext.apiTokenAlias, "API Token Alias cannot be null");
 
-            if (participantContext.getLastModifiedDate() == 0L) {
-                participantContext.lastModifiedDate = participantContext.getCreatedDate();
+            if (participantContext.getLastModified() == 0L) {
+                participantContext.lastModified = participantContext.getCreatedAt();
             }
             return participantContext;
         }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -22,6 +22,9 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.time.Instant;
 import java.util.Objects;
 
+/**
+ * Representation of a participant in Identity Hub.
+ */
 @JsonDeserialize(builder = ParticipantContext.Builder.class)
 public class ParticipantContext {
     private String participantId;

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -85,10 +85,16 @@ public class ParticipantContext {
         this.lastModified = Instant.now().toEpochMilli();
     }
 
+    /**
+     * Transitions this participant context to the {@link ParticipantContextState#ACTIVATED} state.
+     */
     public void activate() {
         this.state = ParticipantContextState.ACTIVATED.ordinal();
     }
 
+    /**
+     * Transitions this participant context to the {@link ParticipantContextState#DEACTIVATED} state.
+     */
     public void deactivate() {
         this.state = ParticipantContextState.DEACTIVATED.ordinal();
     }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -14,9 +14,14 @@
 
 package org.eclipse.edc.identityhub.spi.model.participant;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
 import java.time.Instant;
 import java.util.Objects;
 
+@JsonDeserialize(builder = ParticipantContext.Builder.class)
 public class ParticipantContext {
     private String participantId;
     private long createdDate;
@@ -74,6 +79,7 @@ public class ParticipantContext {
         this.lastModifiedDate = Instant.now().toEpochMilli();
     }
 
+    @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
         private final ParticipantContext participantContext;
 
@@ -117,6 +123,7 @@ public class ParticipantContext {
             return participantContext;
         }
 
+        @JsonCreator
         public static Builder newInstance() {
             return new Builder();
         }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 @JsonDeserialize(builder = ParticipantContext.Builder.class)
 public class ParticipantContext {
     private String participantId;
+    private String did;
     private long createdAt;
     private long lastModified;
     private int state; // CREATED, ACTIVATED, DEACTIVATED
@@ -92,6 +93,10 @@ public class ParticipantContext {
         this.state = ParticipantContextState.DEACTIVATED.ordinal();
     }
 
+    public String getDid() {
+        return did;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
         private final ParticipantContext participantContext;
@@ -123,6 +128,11 @@ public class ParticipantContext {
 
         public Builder apiTokenAlias(String apiToken) {
             this.participantContext.apiTokenAlias = apiToken;
+            return this;
+        }
+
+        public Builder did(String did) {
+            this.participantContext.did = did;
             return this;
         }
 

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -79,6 +79,14 @@ public class ParticipantContext {
         this.lastModifiedDate = Instant.now().toEpochMilli();
     }
 
+    public void activate() {
+        this.state = ParticipantContextState.ACTIVATED.ordinal();
+    }
+
+    public void deactivate() {
+        this.state = ParticipantContextState.DEACTIVATED.ordinal();
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
         private final ParticipantContext participantContext;

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
@@ -26,7 +26,6 @@ import java.util.Set;
 public class ParticipantManifest {
     private Set<Service> serviceEndpoints = new HashSet<>();
     private boolean isActive;
-    private boolean autoPublish;
     private String participantId;
     private KeyDescriptor key;
 
@@ -39,10 +38,6 @@ public class ParticipantManifest {
 
     public boolean isActive() {
         return isActive;
-    }
-
-    public boolean isAutoPublish() {
-        return autoPublish;
     }
 
     public String getParticipantId() {
@@ -74,11 +69,6 @@ public class ParticipantManifest {
 
         public Builder active(boolean isActive) {
             manifest.isActive = isActive;
-            return this;
-        }
-
-        public Builder autoPublish(boolean autoPublish) {
-            manifest.autoPublish = autoPublish;
             return this;
         }
 

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.identityhub.api.participantcontext.v1.model;
+package org.eclipse.edc.identityhub.spi.model.participant;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
@@ -30,6 +30,7 @@ public class ParticipantManifest {
     private Set<Service> serviceEndpoints = new HashSet<>();
     private boolean isActive;
     private String participantId;
+    private String did;
     private KeyDescriptor key;
 
     private ParticipantManifest() {
@@ -49,6 +50,10 @@ public class ParticipantManifest {
 
     public KeyDescriptor getKey() {
         return key;
+    }
+
+    public String getDid() {
+        return did;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -82,6 +87,11 @@ public class ParticipantManifest {
 
         public Builder key(KeyDescriptor key) {
             manifest.key = key;
+            return this;
+        }
+
+        public Builder did(String did) {
+            manifest.did = did;
             return this;
         }
 

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
@@ -36,22 +36,39 @@ public class ParticipantManifest {
     private ParticipantManifest() {
     }
 
+    /**
+     * An optional list of service endpoints that should get published in the DID document, e.g. resolution endpoints, storage endpoints, etc.
+     */
     public Set<Service> getServiceEndpoints() {
         return serviceEndpoints;
     }
 
+    /**
+     * Indicates whether the participant context should immediately transition to the {@link ParticipantContextState#ACTIVATED} state. This will include
+     * publishing the generated DID document.
+     */
     public boolean isActive() {
         return isActive;
     }
 
+    /**
+     * The DSP {@code participantId} of this participant. This must be a unique and stable ID.
+     */
     public String getParticipantId() {
         return participantId;
     }
 
+    /**
+     * Key material that is to be associated with this participant. May not be null.
+     */
     public KeyDescriptor getKey() {
         return key;
     }
 
+    /**
+     * The DID that is to be used when publishing the participant DID document. This must be specified because there is no reliable way to determine the DID
+     * automatically.
+     */
     public String getDid() {
         return did;
     }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
@@ -22,6 +22,9 @@ import org.eclipse.edc.iam.did.spi.document.Service;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Manifest (=recipe) for creating the {@link ParticipantContext}.
+ */
 @JsonDeserialize(builder = ParticipantManifest.Builder.class)
 public class ParticipantManifest {
     private Set<Service> serviceEndpoints = new HashSet<>();

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContextTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContextTest.java
@@ -29,7 +29,7 @@ class ParticipantContextTest {
                 .apiTokenAlias("foo-token")
                 .build();
 
-        assertThat(context.getCreatedDate()).isNotZero().isLessThanOrEqualTo(Instant.now().toEpochMilli());
+        assertThat(context.getCreatedAt()).isNotZero().isLessThanOrEqualTo(Instant.now().toEpochMilli());
 
         var context2 = ParticipantContext.Builder.newInstance()
                 .participantId("test-id")
@@ -37,7 +37,7 @@ class ParticipantContextTest {
                 .createdAt(42)
                 .build();
 
-        assertThat(context2.getCreatedDate()).isEqualTo(42);
+        assertThat(context2.getCreatedAt()).isEqualTo(42);
     }
 
     @Test
@@ -47,7 +47,7 @@ class ParticipantContextTest {
                 .apiTokenAlias("foo-token")
                 .build();
 
-        assertThat(context.getLastModifiedDate()).isNotZero().isEqualTo(context.getCreatedDate());
+        assertThat(context.getLastModified()).isNotZero().isEqualTo(context.getCreatedAt());
 
         var context2 = ParticipantContext.Builder.newInstance()
                 .participantId("test-id")
@@ -55,7 +55,7 @@ class ParticipantContextTest {
                 .lastModified(42)
                 .build();
 
-        assertThat(context2.getLastModifiedDate()).isEqualTo(42);
+        assertThat(context2.getLastModified()).isEqualTo(42);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds a `ParticipantContextManagementApi`, that allows for creating, modifying, reading and deleting PArticipantcontexts.

_While implementing the API, a few shortcomings of the `ParticipantContext` and `-Service` became apparent_

## Why it does that

Management/administration of the IdentityHub

## Further changes

- `ParticipantContextService`: `create` method now takes a `ParticipantManifest` (overlooked it earlier)
- `ParticipantContextService`: new method `update`, to modify the participant and persist again
- `ParticipantContextService`: Vault entries and DID documents are created during participant creation (and deleted during deletion)
- new module `management-api-configuration` introduced, to contain configuration for all Mgmt APIs
- `KeyPairGenerator`: algorithm is not a separate parameter anymore, but is put in the params map
- `ParticipantManifest`/`ParticipantContext`: both objects contain a field `did` to correlate the PC with the DID document
- `DidDocumentService`: brings back two previously deleted methods (`store` and `deleteById`)  - turns out we _do_ need them

_No eventing has yet been implemented. If needed, that can follow in a later PR._

## Linked Issue(s)

Closes #217

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
