### PR TITLE
feat: add participantId to all resources

### DIFF
--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.core;
 
+import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.identityhub.core.creators.JwtPresentationGenerator;
 import org.eclipse.edc.identityhub.core.creators.LdpPresentationGenerator;
 import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
@@ -31,7 +32,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.spi.iam.PublicKeyResolver;
 import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.PrivateKeyResolver;
 import org.eclipse.edc.spi.security.Vault;
@@ -83,7 +83,7 @@ public class CoreServicesExtension implements ServiceExtension {
     private PresentationCreatorRegistryImpl presentationCreatorRegistry;
 
     @Inject
-    private PublicKeyResolver publicKeyResolver;
+    private DidPublicKeyResolver publicKeyResolver;
     @Inject
     private JsonLd jsonLd;
     @Inject

--- a/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/CredentialQueryResolverImplTest.java
@@ -217,6 +217,7 @@ class CredentialQueryResolverImplTest {
                 .credential(new VerifiableCredentialContainer("foobar", CredentialFormat.JSON_LD, cred))
                 .holderId("test-holder")
                 .issuerId("test-issuer")
+                .participantId("test-participant")
                 .build();
     }
 }

--- a/extensions/store/sql/identity-hub-credentials-store-sql/docs/schema.sql
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/docs/schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE credential_resource
     reissuance_policy     JSON,
     raw_vc                VARCHAR             NOT NULL, -- Representation of the VC exactly as it was received by the issuer. Can be JWT or JSON(-LD)
     vc_format             INTEGER             NOT NULL, -- 0 = JSON-LD, 1 = JWT
-    verifiable_credential JSON                NOT NULL  -- JSON-representation of the verifiable credential
+    verifiable_credential JSON                NOT NULL, -- JSON-representation of the verifiable credential
+    participant_id        VARCHAR                       -- ID of the ParticipantContext that owns this credentisl
 );
 CREATE UNIQUE INDEX credential_resource_credential_id_uindex ON credential_resource USING btree (id);
 COMMENT ON COLUMN credential_resource.id IS 'ID of the VC, duplicated here for indexing purposes';

--- a/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/BaseSqlDialectStatements.java
@@ -35,6 +35,7 @@ public class BaseSqlDialectStatements implements CredentialStoreStatements {
                 .column(getVcFormatColumn())
                 .column(getRawVcColumn())
                 .jsonColumn(getVerifiableCredentialColumn())
+                .column(getParticipantIdColumn())
                 .insertInto(getCredentialResourceTable());
     }
 
@@ -51,6 +52,7 @@ public class BaseSqlDialectStatements implements CredentialStoreStatements {
                 .column(getVcFormatColumn())
                 .column(getRawVcColumn())
                 .jsonColumn(getVerifiableCredentialColumn())
+                .column(getParticipantIdColumn())
                 .update(getCredentialResourceTable(), getIdColumn());
     }
 

--- a/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/CredentialStoreStatements.java
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/CredentialStoreStatements.java
@@ -66,6 +66,10 @@ public interface CredentialStoreStatements extends SqlStatements {
         return "verifiable_credential";
     }
 
+    default String getParticipantIdColumn() {
+        return "participant_id";
+    }
+
     String getInsertTemplate();
 
     String getUpdateTemplate();

--- a/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/SqlCredentialStore.java
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/SqlCredentialStore.java
@@ -72,7 +72,8 @@ public class SqlCredentialStore extends AbstractSqlStore implements CredentialSt
                         toJson(credentialResource.getReissuancePolicy()),
                         credentialResource.getVerifiableCredential().format().ordinal(),
                         credentialResource.getVerifiableCredential().rawVc(),
-                        toJson(credentialResource.getVerifiableCredential().credential()));
+                        toJson(credentialResource.getVerifiableCredential().credential()),
+                        credentialResource.getParticipantId());
                 return success();
 
             } catch (SQLException e) {
@@ -113,6 +114,7 @@ public class SqlCredentialStore extends AbstractSqlStore implements CredentialSt
                             credentialResource.getVerifiableCredential().format().ordinal(),
                             credentialResource.getVerifiableCredential().rawVc(),
                             toJson(credentialResource.getVerifiableCredential().credential()),
+                            credentialResource.getParticipantId(),
                             id);
                     return StoreResult.success();
                 }
@@ -164,6 +166,7 @@ public class SqlCredentialStore extends AbstractSqlStore implements CredentialSt
                 .issuancePolicy(fromJson(resultSet.getString(statements.getIssuancePolicyColumn()), Policy.class))
                 .reissuancePolicy(fromJson(resultSet.getString(statements.getReissuancePolicyColumn()), Policy.class))
                 .credential(vcc)
+                .participantId(resultSet.getString(statements.getParticipantIdColumn()))
                 .build();
     }
 }

--- a/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/schema/postgres/VerifiableCredentialResourceMapping.java
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentials/schema/postgres/VerifiableCredentialResourceMapping.java
@@ -31,6 +31,7 @@ public class VerifiableCredentialResourceMapping extends TranslationMapping {
     public static final String FIELD_ISSUANCE_POLICY = "issuancePolicy";
     public static final String FIELD_REISSUANCE_POLICY = "reissuancePolicy";
     public static final String FIELD_VERIFIABLE_CREDENTIAL = "verifiableCredential";
+    public static final String FIELD_PARTICIPANT_ID = "participantId";
 
     public VerifiableCredentialResourceMapping(CredentialStoreStatements statements) {
         add(FIELD_ID, statements.getIdColumn());
@@ -41,5 +42,6 @@ public class VerifiableCredentialResourceMapping extends TranslationMapping {
         add(FIELD_ISSUANCE_POLICY, statements.getIssuancePolicyColumn());
         add(FIELD_REISSUANCE_POLICY, statements.getReissuancePolicyColumn());
         add(FIELD_VERIFIABLE_CREDENTIAL, new VerifiableCredentialContainerMapping(statements));
+        add(FIELD_PARTICIPANT_ID, statements.getParticipantIdColumn());
     }
 }

--- a/extensions/store/sql/identity-hub-did-store-sql/docs/schema.sql
+++ b/extensions/store/sql/identity-hub-did-store-sql/docs/schema.sql
@@ -20,5 +20,6 @@ CREATE TABLE IF NOT EXISTS did_resources
     state_timestamp  BIGINT  NOT NULL,
     state            INT     NOT NULL,
     did_document     JSON    NOT NULL,
+    participant_id   VARCHAR,
     PRIMARY KEY (did)
 );

--- a/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/BaseSqlDialectStatements.java
@@ -30,6 +30,7 @@ public class BaseSqlDialectStatements implements DidResourceStatements {
                 .column(getCreateTimestampColumn())
                 .column(getStateTimestampColumn())
                 .jsonColumn(getDidDocumentColumn())
+                .column(getParticipantId())
                 .insertInto(getDidResourceTableName());
     }
 
@@ -41,6 +42,7 @@ public class BaseSqlDialectStatements implements DidResourceStatements {
                 .column(getCreateTimestampColumn())
                 .column(getStateTimestampColumn())
                 .jsonColumn(getDidDocumentColumn())
+                .column(getParticipantId())
                 .update(getDidResourceTableName(), getIdColumn());
     }
 

--- a/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/DidResourceStatements.java
+++ b/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/DidResourceStatements.java
@@ -46,6 +46,10 @@ public interface DidResourceStatements extends SqlStatements {
         return "did_document";
     }
 
+    default String getParticipantId() {
+        return "participant_id";
+    }
+
     String getInsertTemplate();
 
     String getUpdateTemplate();

--- a/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/SqlDidResourceStore.java
+++ b/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/SqlDidResourceStore.java
@@ -61,7 +61,8 @@ public class SqlDidResourceStore extends AbstractSqlStore implements DidResource
                         resource.getState(),
                         resource.getCreateTimestamp(),
                         resource.getStateTimestamp(),
-                        toJson(resource.getDocument()));
+                        toJson(resource.getDocument()),
+                        resource.getParticipantId());
                 return StoreResult.success();
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
@@ -83,6 +84,7 @@ public class SqlDidResourceStore extends AbstractSqlStore implements DidResource
                             resource.getCreateTimestamp(),
                             resource.getStateTimestamp(),
                             toJson(resource.getDocument()),
+                            resource.getParticipantId(),
                             did);
                     return StoreResult.success();
                 }
@@ -142,6 +144,7 @@ public class SqlDidResourceStore extends AbstractSqlStore implements DidResource
                 .stateTimeStamp(resultSet.getLong(statements.getStateTimestampColumn()))
                 .document(fromJson(resultSet.getString(statements.getDidDocumentColumn()), DidDocument.class))
                 .state(resultSet.getInt(statements.getStateColumn()))
+                .participantId(resultSet.getString(statements.getParticipantId()))
                 .build();
     }
 }

--- a/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/schema/postgres/DidResourceMapping.java
+++ b/extensions/store/sql/identity-hub-did-store-sql/src/main/java/org/eclipse/edc/identityhub/did/store/sql/schema/postgres/DidResourceMapping.java
@@ -28,6 +28,8 @@ public class DidResourceMapping extends TranslationMapping {
     public static final String FIELD_CREATE_TIMESTAMP = "create_timestamp";
     public static final String FIELD_STATE_TIMESTAMP = "state_timestamp";
     public static final String FIELD_DOCUMENT = "document";
+    public static final String FIELD_PARTICIPANT_ID = "participantId";
+
 
     public DidResourceMapping(DidResourceStatements statements) {
         add(FIELD_DID, statements.getIdColumn());
@@ -35,5 +37,6 @@ public class DidResourceMapping extends TranslationMapping {
         add(FIELD_CREATE_TIMESTAMP, statements.getCreateTimestampColumn());
         add(FIELD_STATE_TIMESTAMP, statements.getStateTimestampColumn());
         add(FIELD_DOCUMENT, new DidDocumentMapping(statements));
+        add(FIELD_PARTICIPANT_ID, statements.getParticipantId());
     }
 }

--- a/spi/identity-hub-did-spi/build.gradle.kts
+++ b/spi/identity-hub-did-spi/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
 
     api(libs.edc.spi.identity.did)
+    api(project(":spi:identity-hub-store-spi"))
 
     testFixturesImplementation(libs.edc.spi.identity.did)
     testFixturesImplementation(libs.junit.jupiter.api)

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identithub.did.spi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identityhub.spi.store.model.ParticipantResource;
 
 import java.time.Clock;
 import java.util.Objects;
@@ -23,7 +24,7 @@ import java.util.Objects;
 /**
  * This class wraps a {@link org.eclipse.edc.iam.did.spi.document.DidDocument} and represents its lifecycle in the identity hub.
  */
-public class DidResource {
+public class DidResource extends ParticipantResource {
     @JsonIgnore
     private Clock clock = Clock.systemUTC();
     private String did;
@@ -65,56 +66,60 @@ public class DidResource {
         this.state = newState.code();
     }
 
-    public static final class Builder {
-        private final DidResource resource;
+    public static final class Builder extends ParticipantResource.Builder<DidResource, DidResource.Builder> {
 
         private Builder() {
-            resource = new DidResource();
+            super(new DidResource());
         }
 
         public Builder did(String did) {
-            this.resource.did = did;
+            this.entity.did = did;
             return this;
         }
 
         public Builder state(DidState state) {
-            this.resource.state = state.code();
+            this.entity.state = state.code();
             return this;
         }
 
         public Builder stateTimeStamp(long timestamp) {
-            this.resource.stateTimestamp = timestamp;
+            this.entity.stateTimestamp = timestamp;
             return this;
         }
 
         public Builder clock(Clock clock) {
-            this.resource.clock = clock;
+            this.entity.clock = clock;
             return this;
         }
 
         public Builder document(DidDocument document) {
-            this.resource.document = document;
+            this.entity.document = document;
             return this;
         }
 
         public Builder createTimestamp(long createdAt) {
-            this.resource.createTimestamp = createdAt;
+            this.entity.createTimestamp = createdAt;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
             return this;
         }
 
         public DidResource build() {
-            Objects.requireNonNull(resource.did, "Must have an identifier");
-            if (resource.stateTimestamp <= 0) {
-                resource.stateTimestamp = resource.clock.millis();
+            Objects.requireNonNull(entity.did, "Must have an identifier");
+            if (entity.stateTimestamp <= 0) {
+                entity.stateTimestamp = entity.clock.millis();
             }
-            if (resource.createTimestamp <= 0) {
-                resource.createTimestamp = resource.clock.millis();
+            if (entity.createTimestamp <= 0) {
+                entity.createTimestamp = entity.clock.millis();
             }
-            return resource;
+            return super.build();
         }
 
         public Builder state(int code) {
-            this.resource.state = code;
+            this.entity.state = code;
             return this;
         }
 

--- a/spi/identity-hub-did-spi/src/testFixtures/java/org/eclipse/edc/identityhub/did/store/test/DidResourceStoreTestBase.java
+++ b/spi/identity-hub-did-spi/src/testFixtures/java/org/eclipse/edc/identityhub/did/store/test/DidResourceStoreTestBase.java
@@ -149,6 +149,23 @@ public abstract class DidResourceStoreTestBase {
     }
 
     @Test
+    void query_byParticipantId() {
+        var dids = new ArrayList<>(range(0, 50)
+                .mapToObj(i -> createDidResource(DID + i).build())
+                .toList());
+
+        var expected = createDidResource(DID + "69").participantId("the-odd-one-out").build();
+        dids.add(expected);
+        dids.forEach(getStore()::save);
+
+        var q = QuerySpec.Builder.newInstance().filter(new Criterion("participantId", "=", expected.getParticipantId())).build();
+        Assertions.assertThat(getStore().query(q))
+                .hasSize(1)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(expected);
+    }
+
+    @Test
     void query_byComplexProperty_service() {
         var dids = new ArrayList<>(range(0, 50)
                 .mapToObj(i -> createDidResource(DID + i).build())
@@ -261,6 +278,7 @@ public abstract class DidResourceStoreTestBase {
     private DidResource.Builder createDidResource(String did) {
         return DidResource.Builder.newInstance()
                 .did(did)
+                .participantId("test-participant")
                 .document(DidDocument.Builder.newInstance()
                         .id(did)
                         .build())

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/IdentityResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/IdentityResource.java
@@ -22,10 +22,10 @@ import java.util.UUID;
 
 /**
  * Abstract class representing an Identity Resource.
- * Identity resources have an ID, a timestamp, an issuer ID, a holder ID, and a clock.
+ * Identity entitys have an ID, a timestamp, an issuer ID, a holder ID, and a clock.
  * They can be extended with custom properties and behaviors.
  */
-public abstract class IdentityResource {
+public abstract class IdentityResource extends ParticipantResource {
     protected String id;
     protected long timestamp;
     protected String issuerId;
@@ -53,53 +53,50 @@ public abstract class IdentityResource {
         return holderId;
     }
 
-    public abstract static class Builder<T extends IdentityResource, B extends Builder<T, B>> {
-        protected final T resource;
+    public abstract static class Builder<T extends IdentityResource, B extends Builder<T, B>> extends ParticipantResource.Builder<T, B> {
 
-        protected Builder(T resource) {
-            this.resource = resource;
+        protected Builder(T entity) {
+            super(entity);
         }
 
         public B id(String id) {
-            resource.id = id;
+            entity.id = id;
             return self();
         }
 
         public B timestamp(long timestamp) {
-            resource.timestamp = timestamp;
+            entity.timestamp = timestamp;
             return self();
         }
 
         public B issuerId(String issuerId) {
-            resource.issuerId = issuerId;
+            entity.issuerId = issuerId;
             return self();
         }
 
         public B clock(Clock clock) {
-            resource.clock = clock;
+            entity.clock = clock;
             return self();
         }
 
         public B holderId(String holderId) {
-            resource.holderId = holderId;
+            entity.holderId = holderId;
             return self();
         }
 
-        public abstract B self();
-
         protected T build() {
-            Objects.requireNonNull(resource.issuerId, "Must have an issuer.");
-            Objects.requireNonNull(resource.holderId, "Must have a holder.");
-            resource.clock = Objects.requireNonNullElse(resource.clock, Clock.systemUTC());
+            Objects.requireNonNull(entity.issuerId, "Must have an issuer.");
+            Objects.requireNonNull(entity.holderId, "Must have a holder.");
+            entity.clock = Objects.requireNonNullElse(entity.clock, Clock.systemUTC());
 
-            if (resource.id == null) {
-                resource.id = UUID.randomUUID().toString();
+            if (entity.id == null) {
+                entity.id = UUID.randomUUID().toString();
             }
 
-            if (resource.timestamp == 0) {
-                resource.timestamp = resource.clock.millis();
+            if (entity.timestamp == 0) {
+                entity.timestamp = entity.clock.millis();
             }
-            return resource;
+            return super.build();
         }
     }
 }

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/KeyPairResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/KeyPairResource.java
@@ -25,9 +25,8 @@ import java.time.Duration;
  * A {@link KeyPairResource} contains key material for a particular {@link ParticipantContext}. The public key is stored in the database in serialized form (JWK or PEM) and the private
  * key is referenced via an alias, it is actually stored in a {@link Vault}.
  */
-public class KeyPairResource {
+public class KeyPairResource extends ParticipantResource {
     private String id;
-    private String participantId;
     private long timestamp;
     private String keyId;
     private String groupName;
@@ -66,12 +65,6 @@ public class KeyPairResource {
         return keyId;
     }
 
-    /**
-     * The {@link ParticipantContext} that this KeyPair belongs to.
-     */
-    public String getParticipantId() {
-        return participantId;
-    }
 
     /**
      * The alias under which the private key is stored in the vault.
@@ -125,78 +118,77 @@ public class KeyPairResource {
         isDefaultPair = false;
     }
 
-    public static final class Builder {
-        private final KeyPairResource keyPairResource;
+    public static final class Builder extends ParticipantResource.Builder<KeyPairResource, KeyPairResource.Builder> {
 
         private Builder() {
-            keyPairResource = new KeyPairResource();
+            super(new KeyPairResource());
         }
 
         public Builder groupName(String groupName) {
-            keyPairResource.groupName = groupName;
+            entity.groupName = groupName;
             return this;
         }
 
         public Builder id(String id) {
-            keyPairResource.id = id;
+            entity.id = id;
             return this;
         }
 
-        public Builder participantId(String participantId) {
-            keyPairResource.participantId = participantId;
+        @Override
+        public Builder self() {
             return this;
         }
 
         public Builder timestamp(long timestamp) {
-            keyPairResource.timestamp = timestamp;
+            entity.timestamp = timestamp;
             return this;
         }
 
         public Builder keyId(String keyId) {
-            keyPairResource.keyId = keyId;
+            entity.keyId = keyId;
             return this;
         }
 
         public Builder isDefaultPair(boolean isDefaultPair) {
-            keyPairResource.isDefaultPair = isDefaultPair;
+            entity.isDefaultPair = isDefaultPair;
             return this;
         }
 
         public Builder useDuration(long useDuration) {
-            keyPairResource.useDuration = useDuration;
+            entity.useDuration = useDuration;
             return this;
         }
 
         public Builder rotationDuration(long rotationDuration) {
-            keyPairResource.rotationDuration = rotationDuration;
+            entity.rotationDuration = rotationDuration;
             return this;
         }
 
         public Builder serializedPublicKey(String serializedPublicKey) {
-            keyPairResource.serializedPublicKey = serializedPublicKey;
+            entity.serializedPublicKey = serializedPublicKey;
             return this;
         }
 
         public Builder privateKeyAlias(String privateKeyAlias) {
-            keyPairResource.privateKeyAlias = privateKeyAlias;
+            entity.privateKeyAlias = privateKeyAlias;
             return this;
         }
 
         public Builder state(int state) {
-            keyPairResource.state = state;
+            entity.state = state;
             return this;
         }
 
         public Builder state(KeyPairState state) {
-            keyPairResource.state = state.code();
+            entity.state = state.code();
             return this;
         }
 
         public KeyPairResource build() {
-            if (keyPairResource.useDuration == 0) {
-                keyPairResource.useDuration = Duration.ofDays(6 * 30).toMillis();
+            if (entity.useDuration == 0) {
+                entity.useDuration = Duration.ofDays(6 * 30).toMillis();
             }
-            return keyPairResource;
+            return super.build();
         }
 
         public static Builder newInstance() {

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/ParticipantResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/ParticipantResource.java
@@ -16,11 +16,14 @@ package org.eclipse.edc.identityhub.spi.store.model;
 
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 
+/**
+ * This is the base class for all resources that are owned by a {@link ParticipantContext}.
+ */
 public abstract class ParticipantResource {
     protected String participantId;
 
     /**
-     * The {@link ParticipantContext} that this KeyPair belongs to.
+     * The {@link ParticipantContext} that this resource belongs to.
      */
     public String getParticipantId() {
         return participantId;

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/ParticipantResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/ParticipantResource.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.store.model;
+
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+
+public abstract class ParticipantResource {
+    protected String participantId;
+
+    /**
+     * The {@link ParticipantContext} that this KeyPair belongs to.
+     */
+    public String getParticipantId() {
+        return participantId;
+    }
+
+    public abstract static class Builder<T extends ParticipantResource, B extends ParticipantResource.Builder<T, B>> {
+        protected final T entity;
+
+        protected Builder(T entity) {
+            this.entity = entity;
+        }
+
+        public abstract B self();
+
+        public B participantId(String participantId) {
+            entity.participantId = participantId;
+            return self();
+        }
+
+        protected T build() {
+            return entity;
+        }
+    }
+}

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/VerifiableCredentialResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/VerifiableCredentialResource.java
@@ -61,22 +61,22 @@ public class VerifiableCredentialResource extends IdentityResource {
         }
 
         public Builder state(VcState state) {
-            resource.state = state.code();
+            entity.state = state.code();
             return self();
         }
 
         public Builder issuancePolicy(Policy issuancePolicy) {
-            resource.issuancePolicy = issuancePolicy;
+            entity.issuancePolicy = issuancePolicy;
             return self();
         }
 
         public Builder reissuancePolicy(Policy reissuancePolicy) {
-            resource.reissuancePolicy = reissuancePolicy;
+            entity.reissuancePolicy = reissuancePolicy;
             return self();
         }
 
         public Builder credential(VerifiableCredentialContainer credential) {
-            resource.verifiableCredential = credential;
+            entity.verifiableCredential = credential;
             return self();
         }
 
@@ -87,8 +87,8 @@ public class VerifiableCredentialResource extends IdentityResource {
 
         @Override
         public VerifiableCredentialResource build() {
-            if (resource.state == 0) {
-                resource.state = VcState.INITIAL.code();
+            if (entity.state == 0) {
+                entity.state = VcState.INITIAL.code();
             }
             return super.build();
         }

--- a/spi/identity-hub-store-spi/src/test/java/org/eclipse/edc/identityhub/spi/store/model/VerifiableCredentialResourceTest.java
+++ b/spi/identity-hub-store-spi/src/test/java/org/eclipse/edc/identityhub/spi/store/model/VerifiableCredentialResourceTest.java
@@ -41,6 +41,7 @@ class VerifiableCredentialResourceTest {
         var vc = VerifiableCredentialResource.Builder.newInstance()
                 .issuerId("test-issuer")
                 .holderId("test-holder")
+                .participantId("test-participant")
                 .build();
 
         assertThat(vc.getClock()).isNotNull();

--- a/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/CredentialStoreTestBase.java
+++ b/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/CredentialStoreTestBase.java
@@ -123,6 +123,23 @@ public abstract class CredentialStoreTestBase {
     }
 
     @Test
+    void query_byParticipantId() {
+        range(0, 5)
+                .mapToObj(i -> createCredentialBuilder()
+                        .id("id" + i)
+                        .participantId("participant" + i)
+                        .build())
+                .forEach(getStore()::create);
+
+        var query = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("participantId", "=", "participant2"))
+                .build();
+
+        assertThat(getStore().query(query)).isSucceeded()
+                .satisfies(str -> Assertions.assertThat(str).hasSize(1));
+    }
+
+    @Test
     void query_byVcState() {
         var creds = createCredentials();
         var expectedCred = createCredentialBuilder().state(VcState.REISSUE_REQUESTED).id("id-test").build();
@@ -405,6 +422,7 @@ public abstract class CredentialStoreTestBase {
                 .issuerId("test-issuer")
                 .holderId("test-holder")
                 .state(VcState.ISSUED)
+                .participantId("test-participant")
                 .credential(new VerifiableCredentialContainer(EXAMPLE_VC, CredentialFormat.JSON_LD, createVerifiableCredential().build()))
                 .id("test-id");
     }


### PR DESCRIPTION
## What this PR changes/adds

Adds a `participantId` property to all resources, that are owned by a `ParticipantContext`

## Why it does that

to enable multi-user administration

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #240 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
