### PR TITLE
feat: add Authorization to the Management API

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -44,11 +44,12 @@ public class DidDocumentServiceImpl implements DidDocumentService {
     }
 
     @Override
-    public ServiceResult<Void> store(DidDocument document) {
+    public ServiceResult<Void> store(DidDocument document, String participantId) {
         return transactionContext.execute(() -> {
             var res = DidResource.Builder.newInstance()
                     .document(document)
                     .did(document.getId())
+                    .participantId(participantId)
                     .build();
             var result = didResourceStore.save(res);
             return result.succeeded() ?

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -60,14 +60,14 @@ class DidDocumentServiceImplTest {
     void store() {
         var doc = createDidDocument().build();
         when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.success());
-        assertThat(service.store(doc)).isSucceeded();
+        assertThat(service.store(doc, "test-participant")).isSucceeded();
     }
 
     @Test
     void store_alreadyExists() {
         var doc = createDidDocument().build();
         when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.alreadyExists("foo"));
-        assertThat(service.store(doc)).isFailed().detail().isEqualTo("foo");
+        assertThat(service.store(doc, "test-participant")).isFailed().detail().isEqualTo("foo");
         verify(storeMock).save(any());
         verifyNoInteractions(publisherMock);
     }

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -63,7 +63,7 @@ class ParticipantContextServiceImplTest {
     @BeforeEach
     void setUp() {
         didDocumentService = mock();
-        when(didDocumentService.store(any())).thenReturn(success());
+        when(didDocumentService.store(any(), anyString())).thenReturn(success());
         when(didDocumentService.publish(anyString())).thenReturn(success());
         var keyParserRegistry = new KeyParserRegistryImpl();
         keyParserRegistry.register(new PemParser(mock()));
@@ -93,7 +93,7 @@ class ParticipantContextServiceImplTest {
                 .isSucceeded();
 
         verify(participantContextStore).create(any());
-        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())));
+        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())), anyString());
         verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verify(vault).storeSecret(eq(ctx.getParticipantId() + "-apikey"), anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
@@ -111,7 +111,7 @@ class ParticipantContextServiceImplTest {
                 .isSucceeded();
 
         verify(participantContextStore).create(any());
-        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())));
+        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())), anyString());
         verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verify(vault).storeSecret(eq(ctx.getParticipantId() + "-apikey"), anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
@@ -135,7 +135,7 @@ class ParticipantContextServiceImplTest {
         verify(vault).storeSecret(eq(ctx.getKey().getPrivateKeyAlias()), anyString());
         verify(vault).storeSecret(eq(ctx.getParticipantId() + "-apikey"), anyString());
 
-        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())));
+        verify(didDocumentService).store(argThat(dd -> dd.getId().equals(ctx.getDid())), anyString());
         verify(didDocumentService, times(isActive ? 1 : 0)).publish(anyString());
         verifyNoMoreInteractions(vault, participantContextStore);
     }

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.tests;
+
+import io.restassured.http.Header;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.http.ContentType.JSON;
+
+@EndToEndTest
+public class DidManagementApiEndToEndTest extends ManagementApiEndToEndTest {
+
+    @Test
+    void publishDid_notOwner_expect403() {
+        var user1 = "user1";
+        createParticipant(user1);
+
+
+        // create second user
+        var user2 = "user2";
+        var user2Context = ParticipantContext.Builder.newInstance()
+                .participantId(user2)
+                .did("did:web:" + user2)
+                .apiTokenAlias(user2 + "-alias")
+                .build();
+        var user2Token = storeParticipant(user2Context);
+
+        // attempt to publish user1's DID document, which should fail
+        RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
+                .contentType(JSON)
+                .header(new Header("x-api-key", user2Token))
+                .body("""
+                        {
+                           "did": "did:web:user1"
+                        }
+                        """)
+                .post("/v1/dids/publish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(403)
+                .body(Matchers.notNullValue());
+    }
+
+    @Test
+    void publishDid() {
+
+        var user = "test-user";
+        var token = createParticipant(user);
+        RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
+                .contentType(JSON)
+                .header(new Header("x-api-key", token))
+                .body("""
+                        {
+                           "did": "did:web:test-user"
+                        }
+                        """)
+                .post("/v1/dids/publish")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(204)
+                .body(Matchers.notNullValue());
+    }
+
+    @Test
+    void getState_nowOwner_expect403() {
+        var user1 = "user1";
+        createParticipant(user1);
+
+        var user2 = "user2";
+        var token2 = createParticipant(user2);
+
+        RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
+                .header(new Header("x-api-key", token2))
+                .contentType(JSON)
+                .body(""" 
+                        {
+                           "did": "did:web:user1"
+                        }
+                        """)
+                .post("/v1/dids/state")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(403);
+    }
+
+}

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ManagementApiEndToEndTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.tests;
+
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.identityhub.participantcontext.ApiTokenGenerator;
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
+import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
+import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubRuntimeConfiguration;
+import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.security.Vault;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Map;
+
+/**
+ * Base class for all management API tests
+ */
+public abstract class ManagementApiEndToEndTest {
+    public static final String SUPER_USER = "super-user";
+    protected static final IdentityHubRuntimeConfiguration RUNTIME_CONFIGURATION = IdentityHubRuntimeConfiguration.Builder.newInstance()
+            .name("identity-hub")
+            .id("identity-hub")
+            .build();
+    @RegisterExtension
+    protected static final EdcRuntimeExtension RUNTIME = new EdcRuntimeExtension(":launcher", "identity-hub", RUNTIME_CONFIGURATION.controlPlaneConfiguration());
+
+    protected String getSuperUserApiKey() {
+        var vault = RUNTIME.getContext().getService(Vault.class);
+        return vault.resolveSecret("super-user-apikey");
+    }
+
+    protected String storeParticipant(ParticipantContext pc) {
+        var store = RUNTIME.getContext().getService(ParticipantContextStore.class);
+
+        var vault = RUNTIME.getContext().getService(Vault.class);
+        var token = createTokenFor(pc.getParticipantId());
+        vault.storeSecret(pc.getApiTokenAlias(), token);
+        store.create(pc).orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
+        return token;
+    }
+
+    protected String createParticipant(String participantId) {
+        var manifest = ParticipantManifest.Builder.newInstance()
+                .participantId(participantId)
+                .active(true)
+                .serviceEndpoint(new Service("test-service-id", "test-type", "http://foo.bar.com"))
+                .did("did:web:" + participantId)
+                .key(KeyDescriptor.Builder.newInstance()
+                        .privateKeyAlias(participantId + "-alias")
+                        .keyId(participantId + "-key")
+                        .keyGeneratorParams(Map.of("algorithm", "EC", "curve", "secp256r1"))
+                        .build())
+                .build();
+        var srv = RUNTIME.getContext().getService(ParticipantContextService.class);
+        return srv.createParticipantContext(manifest).orElseThrow(f -> new EdcException(f.getFailureDetail()));
+    }
+
+    protected String createTokenFor(String userId) {
+        return new ApiTokenGenerator().generate(userId);
+    }
+
+    protected static ParticipantManifest createNewParticipant() {
+        var manifest = ParticipantManifest.Builder.newInstance()
+                .participantId("another-participant")
+                .active(false)
+                .did("did:web:another:participant")
+                .serviceEndpoint(new Service("test-service", "test-service-type", "https://test.com"))
+                .key(KeyDescriptor.Builder.newInstance()
+                        .privateKeyAlias("another-alias")
+                        .keyGeneratorParams(Map.of("algorithm", "EdDSA", "curve", "Ed25519"))
+                        .keyId("another-keyid")
+                        .build())
+                .build();
+        return manifest;
+    }
+}

--- a/extensions/api/identityhub-api-auth/build.gradle.kts
+++ b/extensions/api/identityhub-api-auth/build.gradle.kts
@@ -28,5 +28,6 @@ dependencies {
     implementation(libs.edc.core.jerseyproviders)
     implementation(libs.jakarta.rsApi)
 
+    testImplementation(libs.edc.junit)
     testRuntimeOnly(libs.jersey.common) // needs the RuntimeDelegate
 }

--- a/extensions/api/identityhub-api-auth/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
+++ b/extensions/api/identityhub-api-auth/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.authorization;
+
+import org.eclipse.edc.identityhub.spi.AuthorizationService;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static java.util.Optional.ofNullable;
+
+public class AuthorizationServiceImpl implements AuthorizationService {
+    private final Map<Class<?>, Function<String, ParticipantResource>> authorizationCheckFunctions = new HashMap<>();
+
+    public Map<Class<?>, Function<String, ParticipantResource>> getAuthorizationCheckFunctions() {
+        return authorizationCheckFunctions;
+    }
+
+    @Override
+    public ServiceResult<Void> isAuthorized(Principal user, String resourceId, Class<?> resourceClass) {
+        var function = authorizationCheckFunctions.get(resourceClass);
+        if (function == null) {
+            return ServiceResult.success();
+        }
+
+        var isAuthorized = ofNullable(function.apply(resourceId))
+                .map(pr -> Objects.equals(pr.getParticipantId(), user.getName()))
+                .orElse(false);
+
+        return isAuthorized ? ServiceResult.success() : ServiceResult.unauthorized("User '%s' is not authorized to access resource of type %s with ID '%s'.".formatted(user.getName(), resourceClass, resourceId));
+
+    }
+}

--- a/extensions/api/identityhub-api-auth/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
+++ b/extensions/api/identityhub-api-auth/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
@@ -33,7 +33,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     public ServiceResult<Void> isAuthorized(Principal user, String resourceId, Class<?> resourceClass) {
         var function = authorizationCheckFunctions.get(resourceClass);
         if (function == null) {
-            return ServiceResult.success();
+            return ServiceResult.unauthorized("User access for '%s' to resource ID '%s' of type '%s' cannot be verified".formatted(user.getName(), resourceClass, resourceClass));
         }
 
         var isAuthorized = ofNullable(function.apply(resourceId))

--- a/extensions/api/identityhub-api-auth/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
+++ b/extensions/api/identityhub-api-auth/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
@@ -29,10 +29,6 @@ import static java.util.Optional.ofNullable;
 public class AuthorizationServiceImpl implements AuthorizationService {
     private final Map<Class<?>, Function<String, ParticipantResource>> authorizationCheckFunctions = new HashMap<>();
 
-    public Map<Class<?>, Function<String, ParticipantResource>> getAuthorizationCheckFunctions() {
-        return authorizationCheckFunctions;
-    }
-
     @Override
     public ServiceResult<Void> isAuthorized(Principal user, String resourceId, Class<?> resourceClass) {
         var function = authorizationCheckFunctions.get(resourceClass);
@@ -46,5 +42,10 @@ public class AuthorizationServiceImpl implements AuthorizationService {
 
         return isAuthorized ? ServiceResult.success() : ServiceResult.unauthorized("User '%s' is not authorized to access resource of type %s with ID '%s'.".formatted(user.getName(), resourceClass, resourceId));
 
+    }
+
+    @Override
+    public void addLoookupFunction(Class<?> resourceClass, Function<String, ParticipantResource> lookupFunction) {
+        authorizationCheckFunctions.put(resourceClass, lookupFunction);
     }
 }

--- a/extensions/api/identityhub-api-auth/src/test/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImplTest.java
+++ b/extensions/api/identityhub-api-auth/src/test/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImplTest.java
@@ -1,0 +1,52 @@
+package org.eclipse.edc.identityhub.api.authorization;
+
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthorizationServiceImplTest {
+
+    private final AuthorizationServiceImpl authorizationService = new AuthorizationServiceImpl();
+
+    @Test
+    void isAuthorized_whenAuthorized() {
+        authorizationService.addLoookupFunction(String.class, s -> new ParticipantResource() {
+            @Override
+            public String getParticipantId() {
+                return "test-id";
+            }
+        });
+
+        var principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("test-id");
+        assertThat(authorizationService.isAuthorized(principal, "test-resource-id", String.class))
+                .isSucceeded();
+    }
+
+    @Test
+    void isAuthorized_whenNoLookupFunction(){
+        var principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("test-id");
+        assertThat(authorizationService.isAuthorized(principal, "test-resource-id", String.class))
+                .isFailed();
+    }
+
+    @Test
+    void isAuthorized_whenNotAuthorized(){
+        authorizationService.addLoookupFunction(String.class, s -> new ParticipantResource() {
+            @Override
+            public String getParticipantId() {
+                return "another-test-id";
+            }
+        });
+        var principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("test-id");
+        assertThat(authorizationService.isAuthorized(principal, "test-resource-id", String.class))
+                .isFailed();
+    }
+}

--- a/extensions/api/identityhub-api-auth/src/test/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImplTest.java
+++ b/extensions/api/identityhub-api-auth/src/test/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImplTest.java
@@ -1,3 +1,17 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
 package org.eclipse.edc.identityhub.api.authorization;
 
 import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
@@ -29,7 +43,7 @@ class AuthorizationServiceImplTest {
     }
 
     @Test
-    void isAuthorized_whenNoLookupFunction(){
+    void isAuthorized_whenNoLookupFunction() {
         var principal = mock(Principal.class);
         when(principal.getName()).thenReturn("test-id");
         assertThat(authorizationService.isAuthorized(principal, "test-resource-id", String.class))
@@ -37,7 +51,7 @@ class AuthorizationServiceImplTest {
     }
 
     @Test
-    void isAuthorized_whenNotAuthorized(){
+    void isAuthorized_whenNotAuthorized() {
         authorizationService.addLoookupFunction(String.class, s -> new ParticipantResource() {
             @Override
             public String getParticipantId() {

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/ParticipantContextManagementApiExtension.java
@@ -49,7 +49,7 @@ public class ParticipantContextManagementApiExtension implements ServiceExtensio
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        authorizationService.getAuthorizationCheckFunctions().put(ParticipantContext.class, s -> participantContextService.getParticipantContext(s).orElseThrow(exceptionMapper(ParticipantContext.class, s)));
+        authorizationService.addLoookupFunction(ParticipantContext.class, s -> participantContextService.getParticipantContext(s).orElseThrow(exceptionMapper(ParticipantContext.class, s)));
         var controller = new ParticipantContextApiController(new ParticipantManifestValidator(), participantContextService, authorizationService);
         webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
     }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
@@ -61,7 +62,7 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    ParticipantContext getParticipant(String participantId);
+    ParticipantContext getParticipant(String participantId, SecurityContext securityContext);
 
     @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Regenerates the API token for a ParticipantContext and returns the new token.",
@@ -76,7 +77,7 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    String regenerateToken(String participantId);
+    String regenerateToken(String participantId, SecurityContext securityContext);
 
     @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Activates a ParticipantContext. This operation is idempotent, i.e. activating an already active ParticipantContext is a NOOP.",
@@ -107,5 +108,5 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void deleteParticipant(String participantId);
+    void deleteParticipant(String participantId, SecurityContext securityContext);
 }

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
@@ -20,6 +20,7 @@ import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.edc.identityhub.api.participantcontext.v1.validation.ParticipantManifestValidator;
+import org.eclipse.edc.identityhub.spi.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
@@ -29,6 +30,7 @@ import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -38,6 +40,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -48,6 +51,12 @@ import static org.mockito.Mockito.when;
 class ParticipantContextApiControllerTest extends RestControllerTestBase {
 
     private final ParticipantContextService participantContextServiceMock = mock();
+    private final AuthorizationService authService = mock();
+
+    @BeforeEach
+    void setUp() {
+        when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+    }
 
     @Test
     void getById() {
@@ -193,7 +202,7 @@ class ParticipantContextApiControllerTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new ParticipantContextApiController(new ParticipantManifestValidator(), participantContextServiceMock);
+        return new ParticipantContextApiController(new ParticipantManifestValidator(), participantContextServiceMock, authService);
     }
 
     private ParticipantContext.Builder createParticipantContext() {

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/VerifiableCredentialApiExtension.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/VerifiableCredentialApiExtension.java
@@ -46,7 +46,7 @@ public class VerifiableCredentialApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        authorizationService.getAuthorizationCheckFunctions().put(VerifiableCredentialResource.class, this::queryById);
+        authorizationService.addLoookupFunction(VerifiableCredentialResource.class, this::queryById);
         var controller = new VerifiableCredentialsApiController(credentialStore, authorizationService);
         webService.registerResource(apiConfiguration.getContextAlias(), controller);
     }

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/VerifiableCredentialsApi.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/VerifiableCredentialsApi.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
@@ -47,7 +48,7 @@ public interface VerifiableCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    VerifiableCredentialResource findById(String id);
+    VerifiableCredentialResource findById(String id, SecurityContext securityContext);
 
 
     @Tag(name = "VerifiableCredentials Management API")
@@ -61,7 +62,7 @@ public interface VerifiableCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<VerifiableCredentialResource> findByType(String type);
+    Collection<VerifiableCredentialResource> findByType(String type, SecurityContext securityContext);
 
     @Tag(name = "VerifiableCredentials Management API")
     @Operation(description = "Delete a VerifiableCredential.",
@@ -76,5 +77,5 @@ public interface VerifiableCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void deleteCredential(String id);
+    void deleteCredential(String id, SecurityContext securityContext);
 }

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -15,8 +15,10 @@
 package org.eclipse.edc.identityhub.api.didmanagement;
 
 import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
 import org.eclipse.edc.identityhub.api.configuration.ManagementApiConfiguration;
 import org.eclipse.edc.identityhub.api.didmanagement.v1.DidManagementApiController;
+import org.eclipse.edc.identityhub.spi.AuthorizationService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -36,7 +38,8 @@ public class DidManagementApiExtension implements ServiceExtension {
     private DidDocumentService didDocumentService;
     @Inject
     private ManagementApiConfiguration webServiceConfiguration;
-
+    @Inject
+    private AuthorizationService authorizationService;
 
     @Override
     public String name() {
@@ -45,8 +48,10 @@ public class DidManagementApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var controller = new DidManagementApiController(didDocumentService);
+        authorizationService.getAuthorizationCheckFunctions().put(DidResource.class, s -> didDocumentService.findById(s));
+        var controller = new DidManagementApiController(didDocumentService, authorizationService);
         webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
+
     }
 
 

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -48,7 +48,7 @@ public class DidManagementApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        authorizationService.getAuthorizationCheckFunctions().put(DidResource.class, s -> didDocumentService.findById(s));
+        authorizationService.addLoookupFunction(DidResource.class, s -> didDocumentService.findById(s));
         var controller = new DidManagementApiController(didDocumentService, authorizationService);
         webService.registerResource(webServiceConfiguration.getContextAlias(), controller);
 

--- a/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/did/did-management-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -47,7 +48,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void publishDidFromBody(DidRequestPayload didRequestPayload);
+    void publishDidFromBody(DidRequestPayload didRequestPayload, SecurityContext securityContext);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Un-Publish an (existing) DID document. The DID is expected to exist in the database.",
@@ -62,7 +63,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void unpublishDidFromBody(DidRequestPayload didRequestPayload);
+    void unpublishDidFromBody(DidRequestPayload didRequestPayload, SecurityContext securityContext);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Query for DID documents..",
@@ -76,7 +77,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<DidDocument> queryDid(QuerySpec querySpec);
+    Collection<DidDocument> queryDid(QuerySpec querySpec, SecurityContext securityContext);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Get state of a DID document",
@@ -89,7 +90,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    String getState(DidRequestPayload request);
+    String getState(DidRequestPayload request, SecurityContext securityContext);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Adds a service endpoint to a particular DID document.",
@@ -105,7 +106,7 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void addEndpoint(String did, Service service, boolean autoPublish);
+    void addEndpoint(String did, Service service, boolean autoPublish, SecurityContext securityContext);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Replaces a service endpoint of a particular DID document.",
@@ -121,13 +122,13 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void replaceEndpoint(String did, Service service, boolean autoPublish);
+    void replaceEndpoint(String did, Service service, boolean autoPublish, SecurityContext securityContext);
 
     @Tag(name = "DID Management API")
     @Operation(description = "Removes a service endpoint from a particular DID document.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
             parameters = {@Parameter(name = "serviceId", description = "The ID of the service that should get removed"), @Parameter(name = "autoPublish", description = "Whether the DID should " +
-                    "get republished after the removal. Defaults to false.")},
+                                                                                                                                                                        "get republished after the removal. Defaults to false.")},
             responses = {
                     @ApiResponse(responseCode = "200", description = "The DID document was successfully updated."),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
@@ -138,5 +139,5 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void removeEndpoint(String did, String serviceId, boolean autoPublish);
+    void removeEndpoint(String did, String serviceId, boolean autoPublish, SecurityContext securityContext);
 }

--- a/extensions/did/did-management-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiControllerTest.java
+++ b/extensions/did/did-management-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiControllerTest.java
@@ -20,11 +20,15 @@ import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
 import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identithub.did.spi.model.DidResource;
+import org.eclipse.edc.identityhub.spi.AuthorizationService;
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -46,349 +50,16 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
     public static final String TEST_DID = "did:web:host%3A1234:test-did";
     private final DidDocumentService didDocumentServiceMock = mock();
+    private final AuthorizationService authService = mock();
 
-
-    @Test
-    void publish_success() {
-
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/publish")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-    }
-
-    @Test
-    void publish_whenNotExist_expect404() {
-
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/publish")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(equalTo(404));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void publish_whenAlreadyPublished_expect200() {
-
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/publish")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void unpublish_success() {
-
-        when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.success());
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/unpublish")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void unpublish_whenNotExist_expect404() {
-        when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/unpublish")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(404);
-        verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void unpublish_whenNotPublished_expect200() {
-        // not needed - test setup is identical to publish_success
-    }
-
-    @Test
-    void unpublish_whenAlreadyUnpublished_expect200() {
-        // not needed - test setup is identical to publish_success
-    }
-
-    @Test
-    void unpublish_whenNotSupported_expect400() {
-        when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("test-message"));
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/unpublish")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-        verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void query_withSimpleField() {
-        var resultList = List.of(createDidDocument().build());
-        when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.success(resultList));
-        var q = QuerySpec.Builder.newInstance().filter(new Criterion("id", "=", "foobar")).build();
-
-        var docListType = new TypeRef<List<DidDocument>>() {
-        };
-        var docList = baseRequest()
-                .body(q)
-                .post("/query")
-                .then()
-                .log().ifError()
-                .statusCode(200)
-                .extract().body().as(docListType);
-
-        assertThat(docList).isNotEmpty().hasSize(1)
-                .usingRecursiveFieldByFieldElementComparator()
-                .isEqualTo(resultList);
-        verify(didDocumentServiceMock).queryDocuments(eq(q));
-    }
-
-    @Test
-    void query_invalidQuery_expect400() {
-        when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.badRequest("test-message"));
-        var q = QuerySpec.Builder.newInstance().build();
-        baseRequest()
-                .body(q)
-                .post("/query")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-
-        verify(didDocumentServiceMock).queryDocuments(eq(q));
-    }
-
-    @Test
-    void addEndpoint() {
-        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/%s/endpoints".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void addEndpoint_withAutoPublish() {
-        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void addEndpoint_whenAutoPublishFails_expect400() {
-        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not working"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void addEndpoint_alreadyExists() {
-        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.conflict("exists"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/%s/endpoints".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(409);
-        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
-    }
-
-    @Test
-    void addEndpoint_didNotFound() {
-        when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.notFound("did not found"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .post("/%s/endpoints".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(404);
-        verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
-    }
-
-    @Test
-    void replaceEndpoint() {
-        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .patch("/%s/endpoints".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void replaceEndpoint_withAutoPublish() {
-        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .patch("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void replaceEndpoint_whenAutoPublishFails_expect400() {
-        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not working"));
-
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .patch("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void replaceEndpoint_doesNotExist() {
-        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.badRequest("service not found"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .patch("/%s/endpoints".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
-    }
-
-    @Test
-    void replaceEndpoint_didNotFound() {
-        when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.notFound("did not found"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .patch("/%s/endpoints".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(404);
-        verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
-    }
-
-    @Test
-    void removeEndpoint() {
-        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void removeEndpoint_withAutoPublish() {
-        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .delete("/%s/endpoints?serviceId=test-service-id&autoPublish=true".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void removeEndpoint_whenAutoPublishFails_expect400() {
-        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
-        when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not reachable"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .delete("/%s/endpoints?serviceId=test-service-id&autoPublish=true".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
-        verify(didDocumentServiceMock).publish(eq(TEST_DID));
-
-        verifyNoMoreInteractions(didDocumentServiceMock);
-    }
-
-    @Test
-    void removeEndpoint_doesNotExist() {
-        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.badRequest("service not found"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(400);
-        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
-    }
-
-    @Test
-    void removeEndpoint_didNotFound() {
-        when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.notFound("did not found"));
-        baseRequest()
-                .body(new DidRequestPayload(TEST_DID))
-                .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(404);
-        verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+    @BeforeEach
+    void setUp() {
+        when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Override
     protected DidManagementApiController controller() {
-        return new DidManagementApiController(didDocumentServiceMock);
+        return new DidManagementApiController(didDocumentServiceMock, authService);
     }
 
     private DidDocument.Builder createDidDocument() {
@@ -406,5 +77,451 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
                 .contentType("application/json")
                 .baseUri("http://localhost:" + port + "/v1/dids")
                 .when();
+    }
+
+    @Nested
+    class RemoveEndpoint {
+        @Test
+        void removeEndpoint() {
+            when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void removeEndpoint_unauthorized403() {
+            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403);
+            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verifyNoMoreInteractions(didDocumentServiceMock, authService);
+        }
+
+        @Test
+        void removeEndpoint_withAutoPublish() {
+            when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .delete("/%s/endpoints?serviceId=test-service-id&autoPublish=true".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void removeEndpoint_whenAutoPublishFails_expect400() {
+            when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.success());
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not reachable"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .delete("/%s/endpoints?serviceId=test-service-id&autoPublish=true".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+            verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void removeEndpoint_doesNotExist() {
+            when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.badRequest("service not found"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+            verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+        }
+
+        @Test
+        void removeEndpoint_didNotFound() {
+            when(didDocumentServiceMock.removeService(eq(TEST_DID), anyString())).thenReturn(ServiceResult.notFound("did not found"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .delete("/%s/endpoints?serviceId=test-service-id".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(404);
+            verify(didDocumentServiceMock).removeService(eq(TEST_DID), eq("test-service-id"));
+        }
+    }
+
+    @Nested
+    class ReplaceEndpoint {
+        @Test
+        void replaceEndpoint() {
+            when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .patch("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void replaceEndpoint_unauthorized403() {
+            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .patch("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403);
+            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verifyNoMoreInteractions(didDocumentServiceMock, authService);
+        }
+
+        @Test
+        void replaceEndpoint_withAutoPublish() {
+            when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .patch("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void replaceEndpoint_whenAutoPublishFails_expect400() {
+            when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not working"));
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .patch("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+            verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void replaceEndpoint_doesNotExist() {
+            when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.badRequest("service not found"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .patch("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+            verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+        }
+
+        @Test
+        void replaceEndpoint_didNotFound() {
+            when(didDocumentServiceMock.replaceService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.notFound("did not found"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .patch("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(404);
+            verify(didDocumentServiceMock).replaceService(eq(TEST_DID), any(Service.class));
+        }
+    }
+
+    @Nested
+    class AddEndpoint {
+        @Test
+        void addEndpoint() {
+            when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void addEndpoint_unauthorized403() {
+            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403);
+            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verifyNoMoreInteractions(didDocumentServiceMock, authService);
+        }
+
+        @Test
+        void addEndpoint_withAutoPublish() {
+            when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void addEndpoint_whenAutoPublishFails_expect400() {
+            when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.success());
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("publisher not working"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/%s/endpoints?autoPublish=true".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+            verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void addEndpoint_alreadyExists() {
+            when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.conflict("exists"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(409);
+            verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+        }
+
+        @Test
+        void addEndpoint_didNotFound() {
+            when(didDocumentServiceMock.addService(eq(TEST_DID), any(Service.class))).thenReturn(ServiceResult.notFound("did not found"));
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/%s/endpoints".formatted(TEST_DID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(404);
+            verify(didDocumentServiceMock).addService(eq(TEST_DID), any(Service.class));
+        }
+    }
+
+    @Nested
+    class Query {
+        @Test
+        void query_withSimpleField() {
+            var resultList = List.of(createDidDocument().build());
+            when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.success(resultList));
+            var q = QuerySpec.Builder.newInstance().filter(new Criterion("id", "=", "foobar")).build();
+
+            var docListType = new TypeRef<List<DidDocument>>() {
+            };
+            var docList = baseRequest()
+                    .body(q)
+                    .post("/query")
+                    .then()
+                    .log().ifError()
+                    .statusCode(200)
+                    .extract().body().as(docListType);
+
+            assertThat(docList).isNotEmpty().hasSize(1)
+                    .usingRecursiveFieldByFieldElementComparator()
+                    .isEqualTo(resultList);
+            verify(didDocumentServiceMock).queryDocuments(eq(q));
+        }
+
+        @Test
+        void query_invalidQuery_expect400() {
+            when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.badRequest("test-message"));
+            var q = QuerySpec.Builder.newInstance().build();
+            baseRequest()
+                    .body(q)
+                    .post("/query")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+
+            verify(didDocumentServiceMock).queryDocuments(eq(q));
+        }
+
+        @Test
+        void query_unauthorized403() {
+            var resultList = List.of(createDidDocument().build());
+            when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.success(resultList));
+            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test-message"));
+            var q = QuerySpec.Builder.newInstance().build();
+
+            var result = baseRequest()
+                    .body(q)
+                    .post("/query")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .extract().body().as(DidDocument[].class);
+
+            assertThat(result).isEmpty();
+
+            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(didDocumentServiceMock).queryDocuments(eq(q));
+            verifyNoMoreInteractions(didDocumentServiceMock, authService);
+        }
+    }
+
+    @Nested
+    class Unpublish {
+        @Test
+        void unpublish_success() {
+
+            when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/unpublish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void unpublish_unauthorized403() {
+            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/unpublish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403);
+
+            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verifyNoMoreInteractions(didDocumentServiceMock, authService);
+        }
+
+        @Test
+        void unpublish_whenNotExist_expect404() {
+            when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/unpublish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(404);
+            verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void unpublish_whenNotPublished_expect200() {
+            // not needed - test setup is identical to publish_success
+        }
+
+        @Test
+        void unpublish_whenAlreadyUnpublished_expect200() {
+            // not needed - test setup is identical to publish_success
+        }
+
+        @Test
+        void unpublish_whenNotSupported_expect400() {
+            when(didDocumentServiceMock.unpublish(eq(TEST_DID))).thenReturn(ServiceResult.badRequest("test-message"));
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/unpublish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(400);
+            verify(didDocumentServiceMock).unpublish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+    }
+
+    @Nested
+    class Publish {
+        @Test
+        void publish_success() {
+
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/publish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+        }
+
+        @Test
+        void publish_unauthorized403() {
+            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test-msg"));
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/publish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(403);
+            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verifyNoMoreInteractions(didDocumentServiceMock, authService);
+        }
+
+        @Test
+        void publish_whenNotExist_expect404() {
+
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.notFound("test-message"));
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/publish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(equalTo(404));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
+
+        @Test
+        void publish_whenAlreadyPublished_expect200() {
+
+            when(didDocumentServiceMock.publish(eq(TEST_DID))).thenReturn(ServiceResult.success());
+
+            baseRequest()
+                    .body(new DidRequestPayload(TEST_DID))
+                    .post("/publish")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+            verify(didDocumentServiceMock).publish(eq(TEST_DID));
+            verifyNoMoreInteractions(didDocumentServiceMock);
+        }
     }
 }

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/DidDocumentService.java
@@ -32,7 +32,7 @@ public interface DidDocumentService {
      *
      * @return a {@link ServiceResult} to indicate success or failure.
      */
-    ServiceResult<Void> store(DidDocument document);
+    ServiceResult<Void> store(DidDocument document, String participantId);
 
     /**
      * Deletes a DID document if found. * * @param did The ID of the DID document to delete.

--- a/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
+++ b/spi/identity-hub-did-spi/src/main/java/org/eclipse/edc/identithub/did/spi/model/DidResource.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.identithub.did.spi.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
-import org.eclipse.edc.identityhub.spi.store.model.ParticipantResource;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 
 import java.time.Clock;
 import java.util.Objects;

--- a/spi/identity-hub-spi/build.gradle.kts
+++ b/spi/identity-hub-spi/build.gradle.kts
@@ -23,6 +23,7 @@ val swagger: String by project
 dependencies {
 
     api(libs.edc.spi.identitytrust)
+    api(libs.edc.spi.web)
     implementation(libs.jackson.databind)
     implementation(libs.nimbus.jwt)
     implementation(libs.edc.spi.identity.did)

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationResultHandler.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationResultHandler.java
@@ -22,6 +22,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 
+/**
+ * Extension of the {@link ServiceResultHandler} which also can handle {@link ServiceFailure.Reason#UNAUTHORIZED} failures. All other
+ * failures are delegated back to the {@link ServiceResultHandler}.
+ */
 public class AuthorizationResultHandler {
     public static Function<ServiceFailure, EdcException> exceptionMapper(@NotNull Class<?> clazz, String id) {
         return failure -> {

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationResultHandler.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationResultHandler.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi;
+
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.result.ServiceFailure;
+import org.eclipse.edc.web.spi.exception.NotAuthorizedException;
+import org.eclipse.edc.web.spi.exception.ServiceResultHandler;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+
+public class AuthorizationResultHandler {
+    public static Function<ServiceFailure, EdcException> exceptionMapper(@NotNull Class<?> clazz, String id) {
+        return failure -> {
+            if (failure.getReason() == ServiceFailure.Reason.UNAUTHORIZED) {
+                return new NotAuthorizedException(failure.getFailureDetail());
+            }
+            return ServiceResultHandler.exceptionMapper(clazz, id).apply(failure);
+        };
+    }
+}

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationService.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi;
+
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.function.Function;
+
+public interface AuthorizationService {
+    ServiceResult<Void> isAuthorized(Principal user, String resourceId, Class<?> resourceClass);
+
+    Map<Class<?>, Function<String, ParticipantResource>> getAuthorizationCheckFunctions();
+}

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/AuthorizationService.java
@@ -14,15 +14,31 @@
 
 package org.eclipse.edc.identityhub.spi;
 
+import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.security.Principal;
-import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * This service takes a {@link Principal}, that is typically obtained from the {@link jakarta.ws.rs.core.SecurityContext} of an incoming
+ * HTTP request, and checks whether this principal is authorized to access a particular resource, identified by ID and by object class.
+ */
 public interface AuthorizationService {
+    /**
+     * Checks whether the principal is authorized to access a particular resource.
+     *
+     * @param user          The {@link Principal}, typically obtained via {@link SecurityContext#getUserPrincipal()}.
+     * @param resourceId    The database ID of the resource. The resource must be of type {@link ParticipantResource}.
+     * @param resourceClass The concrete type of the resource.
+     * @return success if authorized, {@link ServiceResult#unauthorized(String)} if not authorized
+     */
     ServiceResult<Void> isAuthorized(Principal user, String resourceId, Class<?> resourceClass);
 
-    Map<Class<?>, Function<String, ParticipantResource>> getAuthorizationCheckFunctions();
+    /**
+     * Register a function, that can lookup a particular resource type by ID. Typically, every resource that should be protected with
+     * authorization, registers a lookup function for the type of resource.
+     */
+    void addLoookupFunction(Class<?> resourceClass, Function<String, ParticipantResource> checkFunction);
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/ParticipantResource.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/ParticipantResource.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.identityhub.spi.store.model;
+package org.eclipse.edc.identityhub.spi.model;
 
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -28,9 +29,8 @@ import java.util.Objects;
  * Representation of a participant in Identity Hub.
  */
 @JsonDeserialize(builder = ParticipantContext.Builder.class)
-public class ParticipantContext {
+public class ParticipantContext extends ParticipantResource {
     private List<String> roles = new ArrayList<>();
-    private String participantId;
     private String did;
     private long createdAt;
     private long lastModified;
@@ -38,13 +38,6 @@ public class ParticipantContext {
     private String apiTokenAlias;
 
     private ParticipantContext() {
-    }
-
-    /**
-     * Participant IDs must be stable and globally unique (i.e. per dataspace). They will be visible in contracts, negotiations, etc.
-     */
-    public String getParticipantId() {
-        return participantId;
     }
 
     /**
@@ -111,57 +104,61 @@ public class ParticipantContext {
     }
 
     @JsonPOJOBuilder(withPrefix = "")
-    public static final class Builder {
-        private final ParticipantContext participantContext;
+    public static final class Builder extends ParticipantResource.Builder<ParticipantContext, Builder> {
 
         private Builder() {
-            participantContext = new ParticipantContext();
-            participantContext.createdAt = Instant.now().toEpochMilli();
+            super(new ParticipantContext());
+            entity.createdAt = Instant.now().toEpochMilli();
         }
 
         public Builder createdAt(long createdAt) {
-            this.participantContext.createdAt = createdAt;
+            this.entity.createdAt = createdAt;
             return this;
         }
 
         public Builder lastModified(long lastModified) {
-            this.participantContext.lastModified = lastModified;
+            this.entity.lastModified = lastModified;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
             return this;
         }
 
         public Builder participantId(String participantId) {
-            this.participantContext.participantId = participantId;
+            this.entity.participantId = participantId;
             return this;
         }
 
         public Builder state(ParticipantContextState state) {
-            this.participantContext.state = state.ordinal();
+            this.entity.state = state.ordinal();
             return this;
         }
 
         public Builder roles(List<String> roles) {
-            this.participantContext.roles = roles;
+            this.entity.roles = roles;
             return this;
         }
 
         public Builder apiTokenAlias(String apiToken) {
-            this.participantContext.apiTokenAlias = apiToken;
+            this.entity.apiTokenAlias = apiToken;
             return this;
         }
 
         public Builder did(String did) {
-            this.participantContext.did = did;
+            this.entity.did = did;
             return this;
         }
 
         public ParticipantContext build() {
-            Objects.requireNonNull(participantContext.participantId, "Participant ID cannot be null");
-            Objects.requireNonNull(participantContext.apiTokenAlias, "API Token Alias cannot be null");
+            Objects.requireNonNull(entity.participantId, "Participant ID cannot be null");
+            Objects.requireNonNull(entity.apiTokenAlias, "API Token Alias cannot be null");
 
-            if (participantContext.getLastModified() == 0L) {
-                participantContext.lastModified = participantContext.getCreatedAt();
+            if (entity.getLastModified() == 0L) {
+                entity.lastModified = entity.getCreatedAt();
             }
-            return participantContext;
+            return super.build();
         }
 
         @JsonCreator

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantManifest.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.iam.did.spi.document.Service;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -27,6 +29,7 @@ import java.util.Set;
  */
 @JsonDeserialize(builder = ParticipantManifest.Builder.class)
 public class ParticipantManifest {
+    private List<String> roles = new ArrayList<>();
     private Set<Service> serviceEndpoints = new HashSet<>();
     private boolean isActive;
     private String participantId;
@@ -73,6 +76,10 @@ public class ParticipantManifest {
         return did;
     }
 
+    public List<String> getRoles() {
+        return roles;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
 
@@ -104,6 +111,11 @@ public class ParticipantManifest {
 
         public Builder key(KeyDescriptor key) {
             manifest.key = key;
+            return this;
+        }
+
+        public Builder roles(List<String> roles) {
+            manifest.roles = roles;
             return this;
         }
 

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/IdentityResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/IdentityResource.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.store.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 
 import java.time.Clock;
 import java.util.Objects;

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/KeyPairResource.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/model/KeyPairResource.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.store.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.Vault;


### PR DESCRIPTION
## What this PR changes/adds

Adds an `AuthorizationService` interface, which allows controllers to check whether a user (identified by a `Principal`) is allowed
to have access to a particular resource (identified by ID and its type).

Controllers can inject a `SecurityContext`, and from it obtain the `Principal`.

As a precondition, the respective extension must register a lookup function for any particular resource type.


## Why it does that

User authorization

## Further notes

- Endpoints which require elevated access (`@RolesAllowed`) are not subjected to authorization
- I did not yet put any major focus on extensibility, that could come in a subsequent improvement pr
- 

## Linked Issue(s)

Closes #216
Closes #219

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
