### PR TITLE
chore: fixes after IATP changes

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -184,6 +184,7 @@ maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
 maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
 maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
+maven/mavencentral/org.apache.commons/commons-compress/1.25.0, Apache-2.0, approved, #11600
 maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.10, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
@@ -202,6 +203,7 @@ maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, app
 maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
+maven/mavencentral/org.assertj/assertj-core/3.25.2, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
@@ -351,11 +353,13 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.5, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.6, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/database-commons/1.19.3, Apache-2.0, approved, #10345
-maven/mavencentral/org.testcontainers/jdbc/1.19.3, Apache-2.0, approved, #10348
+maven/mavencentral/org.testcontainers/database-commons/1.19.4, Apache-2.0, approved, #10345
+maven/mavencentral/org.testcontainers/jdbc/1.19.4, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.3, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/postgresql/1.19.3, MIT, approved, #10350
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.4, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/postgresql/1.19.4, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.3, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/testcontainers/1.19.4, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.web.jersey.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
 
 import static org.eclipse.edc.identityhub.api.PresentationApiExtension.NAME;
+import static org.eclipse.edc.identitytrust.VcConstants.IATP_CONTEXT_URL;
 import static org.eclipse.edc.spi.CoreConstants.JSON_LD;
 
 @Extension(value = NAME)
@@ -77,6 +78,8 @@ public class PresentationApiExtension implements ServiceExtension {
         webService.registerResource(RESOLUTION_CONTEXT, new ObjectMapperProvider(jsonLdMapper));
         webService.registerResource(RESOLUTION_CONTEXT, new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, RESOLUTION_SCOPE));
         webService.registerResource(RESOLUTION_CONTEXT, controller);
+
+        jsonLd.registerContext(IATP_CONTEXT_URL, RESOLUTION_SCOPE);
 
         // register transformer -- remove once registration is handled in EDC
         typeTransformer.register(new JsonObjectToPresentationQueryTransformer(jsonLdMapper));

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/ApiSchema.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/ApiSchema.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.api.v1;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.json.JsonObject;
 
 import java.util.List;
 
@@ -41,7 +42,7 @@ public interface ApiSchema {
                 """;
     }
 
-    @Schema(name = "PresentationQuerySchema", example = PresentationQuerySchema.PRESENTATION_QUERY_EXAMPLE)
+    @Schema(name = "PresentationQueryMessage", example = PresentationQuerySchema.PRESENTATION_QUERY_EXAMPLE)
     record PresentationQuerySchema(
             @Schema(name = CONTEXT, requiredMode = REQUIRED)
             Object context,
@@ -56,10 +57,10 @@ public interface ApiSchema {
         public static final String PRESENTATION_QUERY_EXAMPLE = """
                 {
                   "@context": [
-                    "https://w3id.org/yourdataspace/2023/cs/v1",
+                    "https://w3id.org/tractusx-trust/v0.8",
                     "https://identity.foundation/presentation-exchange/submission/v1"
                   ],
-                  "@type": "Query",
+                  "@type": "PresentationQueryMessage",
                   "presentationDefinition": null,
                   "scope": [
                     "org.eclipse.edc.vc.type:SomeCredential_0.3.5:write,
@@ -70,10 +71,22 @@ public interface ApiSchema {
                 """;
     }
 
-    @Schema(name = "PresentationResponse", example = PresentationResponse.RESPONSE_EXAMPLE)
-    record PresentationResponse() {
+    @Schema(name = "PresentationResponseMessage", example = PresentationResponseSchema.RESPONSE_EXAMPLE)
+    record PresentationResponseSchema(
+            @Schema(name = CONTEXT, requiredMode = REQUIRED)
+            Object context,
+            @Schema(name = "presentation", requiredMode = REQUIRED, anyOf = { String.class, JsonObject.class })
+            List<Object> presentation
+    ) {
 
         public static final String RESPONSE_EXAMPLE = """
+                {
+                  "@context": [
+                    "https://w3id.org/tractusx-trust/v0.8"
+                  ],
+                  "@type": "PresentationResponseMessage",
+                  "presentation": ["dsJdh...UMetV"]
+                }
                 """;
     }
 

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApi.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApi.java
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.Response;
-import org.eclipse.edc.identitytrust.model.credentialservice.PresentationResponseMessage;
 
 @OpenAPIDefinition(
         info = @Info(description = "This represents the Presentation API as per IATP specification. It serves endpoints to query for specific VerifiablePresentations.", title = "Resolution API",
@@ -45,13 +44,13 @@ public interface PresentationApi {
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiSchema.PresentationQuerySchema.class), mediaType = "application/ld+json")),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The query was successfully processed, the response contains the VerifiablePresentation",
-                            content = @Content(schema = @Schema(implementation = PresentationResponseMessage.class), mediaType = "application/ld+json")),
+                            content = @Content(schema = @Schema(implementation = ApiSchema.PresentationResponseSchema.class), mediaType = "application/ld+json")),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, for example when both scope and presentationDefinition are given",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "No Authorization header was given.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "403", description = "The given authentication token could not be validated. This can happen, when the request body " +
-                                                                     "calls for a broader query scope than the granted scope in the auth token",
+                            "calls for a broader query scope than the granted scope in the auth token",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "501", description = "When the request contained a presentationDefinition object, but the implementation does not support it.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)), mediaType = "application/json"))

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
@@ -92,6 +92,7 @@ public class PresentationApiController implements PresentationApi {
         // package the credentials in a VP and sign
         var audience = getAudience(token);
         var presentationResponse = verifiablePresentationService.createPresentation(credentials.toList(), presentationQuery.getPresentationDefinition(), audience)
+                .compose(presentation -> transformerRegistry.transform(presentation, JsonObject.class))
                 .orElseThrow(failure -> new EdcException("Error creating VerifiablePresentation: %s".formatted(failure.getFailureDetail())));
         return Response.ok()
                 .entity(presentationResponse)

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityservice.api.v1;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.identityhub.api.v1.PresentationApiController;
 import org.eclipse.edc.identityhub.spi.generator.VerifiablePresentationService;
@@ -172,12 +173,15 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         var pres = PresentationResponseMessage.Builder.newinstance().presentation(List.of(generateJwt()))
                 .presentationSubmission(new PresentationSubmission("id", "def-id", List.of(new InputDescriptorMapping("id", "ldp_vp", "$.verifiableCredentials[0]"))))
                 .build();
+
+        var jsonResponse = Json.createObjectBuilder().build();
+        when(typeTransformerRegistry.transform(eq(pres), eq(JsonObject.class))).thenReturn(Result.success(jsonResponse));
         when(generator.createPresentation(anyList(), any(), any())).thenReturn(Result.success(pres));
 
         var response = controller().queryPresentation(createObjectBuilder().build(), generateJwt());
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getEntity()).isEqualTo(pres);
+        assertThat(response.getEntity()).isEqualTo(jsonResponse);
 
     }
 

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -14,29 +14,23 @@
 
 package org.eclipse.edc.identityhub;
 
-import com.apicatalog.ld.signature.SignatureSuite;
 import org.eclipse.edc.identityhub.defaults.EdcScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.defaults.InMemoryCredentialStore;
 import org.eclipse.edc.identityhub.defaults.InMemoryKeyPairResourceStore;
 import org.eclipse.edc.identityhub.defaults.InMemoryParticipantContextStore;
+import org.eclipse.edc.identityhub.defaults.InMemorySignatureSuiteRegistry;
 import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
-import org.eclipse.edc.identityhub.spi.model.IdentityHubConstants;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.identityhub.token.rules.ClaimIsPresentRule;
 import org.eclipse.edc.identitytrust.verification.SignatureSuiteRegistry;
-import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.security.signature.jws2020.JwsSignature2020Suite;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
-
-import java.util.Collection;
-import java.util.Map;
 
 import static org.eclipse.edc.identityhub.DefaultServicesExtension.NAME;
 
@@ -65,6 +59,7 @@ public class DefaultServicesExtension implements ServiceExtension {
 
         var scopeIsPresentRule = new ClaimIsPresentRule(ACCESS_TOKEN_SCOPE_CLAIM);
         registry.addRule(IATP_ACCESS_TOKEN_CONTEXT, scopeIsPresentRule);
+
     }
 
     @Provider(isDefault = true)
@@ -91,23 +86,6 @@ public class DefaultServicesExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public SignatureSuiteRegistry createSignatureSuiteRegistry() {
-        return new SignatureSuiteRegistry() {
-            private final Map<String, SignatureSuite> registry = Map.of(IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, new JwsSignature2020Suite(JacksonJsonLd.createObjectMapper()));
-
-            @Override
-            public void register(String w3cIdentifier, SignatureSuite suite) {
-
-            }
-
-            @Override
-            public SignatureSuite getForId(String w3cIdentifier) {
-                return registry.get(w3cIdentifier);
-            }
-
-            @Override
-            public Collection<SignatureSuite> getAllSuites() {
-                return registry.values();
-            }
-        };
+        return new InMemorySignatureSuiteRegistry();
     }
 }

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -28,10 +28,12 @@ import org.eclipse.edc.identityhub.token.verification.AccessTokenVerifierImpl;
 import org.eclipse.edc.identitytrust.model.CredentialFormat;
 import org.eclipse.edc.identitytrust.verification.SignatureSuiteRegistry;
 import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.security.signature.jws2020.JwsSignature2020Suite;
 import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.PrivateKeyResolver;
 import org.eclipse.edc.spi.security.Vault;
@@ -74,7 +76,7 @@ public class CoreServicesExtension implements ServiceExtension {
     @Setting(value = "Public key in PEM format")
     public static final String PUBLIC_KEY_PEM = "edc.ih.iam.publickey.pem";
     public static final String PRESENTATION_EXCHANGE_V_1_JSON = "presentation-exchange.v1.json";
-    public static final String PRESENTATION_QUERY_V_08_JSON = "presentation-query.v08.json";
+    public static final String PRESENTATION_QUERY_V_08_JSON = "iatp.v08.json";
     public static final String PRESENTATION_SUBMISSION_V1_JSON = "presentation-submission.v1.json";
     public static final String DID_JSON = "did.json";
     public static final String JWS_2020_JSON = "jws2020.json";
@@ -107,6 +109,9 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private KeyParserRegistry keyParserRegistry;
 
+    @Inject
+    private SignatureSuiteRegistry suiteRegistry;
+
     @Override
     public String name() {
         return NAME;
@@ -116,6 +121,8 @@ public class CoreServicesExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         // Setup API
         cacheContextDocuments(getClass().getClassLoader());
+        suiteRegistry.register(IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, new JwsSignature2020Suite(JacksonJsonLd.createObjectMapper()));
+
     }
 
     @Provider

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/InMemorySignatureSuiteRegistry.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/InMemorySignatureSuiteRegistry.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.defaults;
+
+import com.apicatalog.ld.signature.SignatureSuite;
+import org.eclipse.edc.identitytrust.verification.SignatureSuiteRegistry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemorySignatureSuiteRegistry implements SignatureSuiteRegistry {
+    private final Map<String, SignatureSuite> registry = new HashMap<>();
+
+    @Override
+    public void register(String w3cIdentifier, SignatureSuite suite) {
+        registry.put(w3cIdentifier, suite);
+        registry.put(suite.getId().uri(), suite);
+    }
+
+    @Override
+    public SignatureSuite getForId(String w3cIdentifier) {
+        return registry.get(w3cIdentifier);
+    }
+
+    @Override
+    public Collection<SignatureSuite> getAllSuites() {
+        return registry.values();
+    }
+}

--- a/core/identity-hub-credentials/src/main/resources/iatp.v08.json
+++ b/core/identity-hub-credentials/src/main/resources/iatp.v08.json
@@ -86,8 +86,28 @@
     "PresentationQueryMessage": {
       "@id": "iatp:PresentationQueryMessage",
       "@context": {
-        "presentationDefinition": "iatp:presentationDefinition",
-        "scope": "iatp:scope"
+        "presentationDefinition": {
+          "@id": "iatp:presentationDefinition",
+          "@type": "@json"
+        },
+        "scope": {
+          "@id": "iatp:scope",
+          "@type": "xsd:string",
+          "@container": "@set"
+        }
+      }
+    },
+    "PresentationResponseMessage": {
+      "@id": "iatp:PresentationResponseMessage",
+      "@context": {
+        "presentation": {
+          "@id": "iatp:presentation",
+          "@type": "@json"
+        },
+        "presentationSubmission": {
+          "@id": "iatp:presentationSubmission",
+          "@type": "@json"
+        }
       }
     },
     "credentials": {
@@ -101,15 +121,6 @@
     "format": {
       "@id": "iatp:format",
       "@type": "xsd:string"
-    },
-    "presentationDefinition": {
-      "@id": "iatp:presentationDefinition",
-      "@type": "@json"
-    },
-    "scope": {
-      "@id": "iatp:scope",
-      "@type": "xsd:string",
-      "@container": "@set"
     },
     "type": "@type"
   }

--- a/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/creators/LdpPresentationGeneratorTest.java
+++ b/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/creators/LdpPresentationGeneratorTest.java
@@ -148,7 +148,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         jld.registerCachedDocument(DID_CONTEXT_URL, TestUtils.getResource("did.json"));
         jld.registerCachedDocument(JWS_2020_URL, TestUtils.getResource("jws2020.json"));
         jld.registerCachedDocument(W3C_CREDENTIALS_URL, TestUtils.getResource("credentials.v1.json"));
-        jld.registerCachedDocument(IATP_CONTEXT_URL, TestUtils.getResource("presentation-query.v08.json"));
+        jld.registerCachedDocument(IATP_CONTEXT_URL, TestUtils.getResource("iatp.v08.json"));
         jld.registerCachedDocument(PRESENTATION_EXCHANGE_URL, TestUtils.getResource("presentation-exchange.v1.json"));
         jld.registerCachedDocument("https://www.w3.org/2018/credentials/examples/v1", TestUtils.getResource("examples.v1.json"));
         return jld;

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/CredentialQueryResolver.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/resolution/CredentialQueryResolver.java
@@ -16,12 +16,11 @@ package org.eclipse.edc.identityhub.spi.resolution;
 
 import org.eclipse.edc.identitytrust.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identitytrust.model.credentialservice.PresentationQueryMessage;
-import org.eclipse.edc.identitytrust.model.credentialservice.PresentationResponseMessage;
 
 import java.util.List;
 
 /**
- * Resolves a list of {@link VerifiableCredentialContainer} objects based on an incoming {@link PresentationResponseMessage} and a list of scope strings.
+ * Resolves a list of {@link VerifiableCredentialContainer} objects based on an incoming {@link PresentationQueryMessage} and a list of scope strings.
  */
 public interface CredentialQueryResolver {
 


### PR DESCRIPTION
## What this PR changes/adds

Adapt after iatp changes in https://github.com/eclipse-edc/Connector/pull/3808:

- presentation query endpoint now speaks JSON-LD
- enriched the openapi definition
