### PR TITLE
feat: add permission override for super-user/admin role

### DIFF
--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
@@ -24,11 +24,13 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static io.restassured.http.ContentType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -81,27 +83,34 @@ public class DidManagementApiEndToEndTest extends ManagementApiEndToEndTest {
 
         var user = "test-user";
         var token = createParticipant(user);
-        RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
-                .contentType(JSON)
-                .header(new Header("x-api-key", token))
-                .body("""
-                        {
-                           "did": "did:web:test-user"
-                        }
-                        """)
-                .post("/v1/participants/%s/dids/publish".formatted(user))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(204)
-                .body(Matchers.notNullValue());
 
-        // verify that the publish event was fired twice
-        verify(subscriber, times(2)).on(argThat(env -> {
-            if (env.getPayload() instanceof DidDocumentPublished event) {
-                return event.getDid().equals("did:web:test-user");
-            }
-            return false;
-        }));
+        assertThat(Arrays.asList(token, getSuperUserApiKey()))
+                .allSatisfy(t -> {
+                    reset(subscriber);
+                    RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
+                            .contentType(JSON)
+                            .header(new Header("x-api-key", t))
+                            .body("""
+                                    {
+                                       "did": "did:web:test-user"
+                                    }
+                                    """)
+                            .post("/v1/participants/%s/dids/publish".formatted(user))
+                            .then()
+                            .log().ifValidationFails()
+                            .statusCode(204)
+                            .body(Matchers.notNullValue());
+
+                    // verify that the publish event was fired twice
+                    verify(subscriber).on(argThat(env -> {
+                        if (env.getPayload() instanceof DidDocumentPublished event) {
+                            return event.getDid().equals("did:web:test-user");
+                        }
+                        return false;
+                    }));
+
+                });
+
     }
 
     @Test
@@ -150,27 +159,33 @@ public class DidManagementApiEndToEndTest extends ManagementApiEndToEndTest {
 
         var user = "test-user";
         var token = createParticipant(user);
-        RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
-                .contentType(JSON)
-                .header(new Header("x-api-key", token))
-                .body("""
-                        {
-                           "did": "did:web:test-user"
-                        }
-                        """)
-                .post("/v1/participants/%s/dids/unpublish".formatted(user))
-                .then()
-                .log().ifValidationFails()
-                .statusCode(204)
-                .body(Matchers.notNullValue());
 
-        // verify that the publish event was fired twice
-        verify(subscriber).on(argThat(env -> {
-            if (env.getPayload() instanceof DidDocumentUnpublished event) {
-                return event.getDid().equals("did:web:test-user");
-            }
-            return false;
-        }));
+        assertThat(Arrays.asList(token, getSuperUserApiKey()))
+                .allSatisfy(t -> {
+                    reset(subscriber);
+                    RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
+                            .contentType(JSON)
+                            .header(new Header("x-api-key", t))
+                            .body("""
+                                    {
+                                       "did": "did:web:test-user"
+                                    }
+                                    """)
+                            .post("/v1/participants/%s/dids/unpublish".formatted(user))
+                            .then()
+                            .log().ifValidationFails()
+                            .statusCode(204)
+                            .body(Matchers.notNullValue());
+
+                    // verify that the publish event was fired twice
+                    verify(subscriber).on(argThat(env -> {
+                        if (env.getPayload() instanceof DidDocumentUnpublished event) {
+                            return event.getDid().equals("did:web:test-user");
+                        }
+                        return false;
+                    }));
+                });
+
     }
 
     @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -27,6 +27,8 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -203,6 +205,23 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
                 .statusCode(204);
 
         assertThat(getDidForParticipant(participantId)).isEmpty();
+    }
+
+    @Test
+    void regenerateToken() {
+
+        var participantId = "another-user";
+        var userToken = createParticipant(participantId);
+
+        assertThat(Arrays.asList(userToken, getSuperUserApiKey()))
+                .allSatisfy(t -> RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
+                        .header(new Header("x-api-key", t))
+                        .contentType(ContentType.JSON)
+                        .post("/v1/participants/%s/token".formatted(participantId))
+                        .then()
+                        .log().ifError()
+                        .statusCode(200)
+                        .body(notNullValue()));
     }
 
 }

--- a/extensions/api/identityhub-api-authorization/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
+++ b/extensions/api/identityhub-api-authorization/src/main/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.api.authorization;
 
 import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.identityhub.spi.AuthorizationService;
+import org.eclipse.edc.identityhub.spi.authentication.ServicePrincipal;
 import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.spi.result.ServiceResult;
 
@@ -31,6 +32,11 @@ public class AuthorizationServiceImpl implements AuthorizationService {
 
     @Override
     public ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceId, Class<? extends ParticipantResource> resourceClass) {
+
+        if (securityContext.isUserInRole(ServicePrincipal.ROLE_ADMIN)) {
+            return ServiceResult.success();
+        }
+
         var function = resourceLookupFunctions.get(resourceClass);
         var name = securityContext.getUserPrincipal().getName();
         if (function == null) {

--- a/extensions/api/identityhub-api-authorization/src/test/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImplTest.java
+++ b/extensions/api/identityhub-api-authorization/src/test/java/org/eclipse/edc/identityhub/api/authorization/AuthorizationServiceImplTest.java
@@ -21,7 +21,10 @@ import org.junit.jupiter.api.Test;
 import java.security.Principal;
 
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class AuthorizationServiceImplTest {
@@ -69,6 +72,19 @@ class AuthorizationServiceImplTest {
         when(securityContext.getUserPrincipal()).thenReturn(principal);
         assertThat(authorizationService.isAuthorized(securityContext, "test-resource-id", TestResource.class))
                 .isFailed();
+    }
+
+    @Test
+    void isAuthorized_whenSuperUser() {
+
+        var securityContext = mock(SecurityContext.class);
+        when(securityContext.isUserInRole(eq("admin"))).thenReturn(true);
+
+        assertThat(authorizationService.isAuthorized(securityContext, "test-resource-id", TestResource.class))
+                .isSucceeded();
+
+        verify(securityContext).isUserInRole(eq("admin"));
+        verifyNoMoreInteractions(securityContext);
     }
 
     private static class TestResource extends ParticipantResource {


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an override to the `AuthorizationService` which grants access to all resources to the `"admin"` role.
In practice, this gives all permissions to the super-user.

## Why it does that

In managed situations this is needed, e.g. as a rescue measure when the credentials of a service principal are compromised or lost, or as 
deployment feature when certain data is to be pre-seeded on behalf of the participant.

## Further notes

Ultimately, we could think about a more elaborate/more complicated role/permission scheme that allows impersonation, but for now
this seems good enough.

## Linked Issue(s)

Closes #247

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
