### PR TITLE
feat: add API key override for Super-User

### DIFF
--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -59,7 +59,7 @@ public class ParticipantContextExtension implements ServiceExtension {
 
     @Provider
     public ParticipantContextService createParticipantService() {
-        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, keyParserRegistry, participantContextObservable());
+        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, participantContextObservable());
     }
 
     @Provider

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
-import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -48,17 +47,14 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     private final Vault vault;
     private final TransactionContext transactionContext;
     private final ApiTokenGenerator tokenGenerator;
-    private final KeyParserRegistry keyParserRegistry;
     private final ParticipantContextObservable observable;
 
-    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, Vault vault, TransactionContext transactionContext,
-                                         KeyParserRegistry registry, ParticipantContextObservable observable) {
+    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, Vault vault, TransactionContext transactionContext, ParticipantContextObservable observable) {
         this.participantContextStore = participantContextStore;
         this.vault = vault;
         this.transactionContext = transactionContext;
         this.observable = observable;
         this.tokenGenerator = new ApiTokenGenerator();
-        this.keyParserRegistry = registry;
     }
 
     @Override

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -61,7 +61,7 @@ class ParticipantContextServiceImplTest {
     void setUp() {
         var keyParserRegistry = new KeyParserRegistryImpl();
         keyParserRegistry.register(new PemParser(mock()));
-        participantContextService = new ParticipantContextServiceImpl(participantContextStore, vault, new NoopTransactionContext(), keyParserRegistry, observableMock);
+        participantContextService = new ParticipantContextServiceImpl(participantContextStore, vault, new NoopTransactionContext(), observableMock);
     }
 
     @ParameterizedTest(name = "isActive: {0}")

--- a/extensions/api/identityhub-management-api-configuration/build.gradle.kts
+++ b/extensions/api/identityhub-management-api-configuration/build.gradle.kts
@@ -27,4 +27,6 @@ dependencies {
     implementation(libs.edc.core.jerseyproviders)
     implementation(libs.jakarta.rsApi)
 
+    testImplementation(libs.edc.junit)
+
 }

--- a/extensions/api/identityhub-management-api-configuration/src/test/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfigurationExtensionTest.java
+++ b/extensions/api/identityhub-management-api-configuration/src/test/java/org/eclipse/edc/identityhub/api/configuration/ManagementApiConfigurationExtensionTest.java
@@ -1,0 +1,148 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.configuration;
+
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(DependencyInjectionExtension.class)
+class ManagementApiConfigurationExtensionTest {
+
+    private final ParticipantContextService participantContextService = mock();
+    private final Vault vault = mock();
+    private final Monitor monitor = mock();
+
+    @BeforeEach
+    void setup(ServiceExtensionContext context) {
+        context.registerService(ParticipantContextService.class, participantContextService);
+        context.registerService(Vault.class, vault);
+        context.registerService(Monitor.class, monitor);
+    }
+
+    @Test
+    void initialize_verifySuperUser(ManagementApiConfigurationExtension ext,
+                                    ServiceExtensionContext context) {
+
+        when(participantContextService.createParticipantContext(any())).thenReturn(ServiceResult.success("some-key"));
+
+        ext.initialize(context);
+        verify(participantContextService).createParticipantContext(any());
+        verifyNoMoreInteractions(participantContextService);
+    }
+
+    @Test
+    void initialize_failsToCreate(ManagementApiConfigurationExtension ext, ServiceExtensionContext context) {
+
+        when(participantContextService.createParticipantContext(any()))
+                .thenReturn(ServiceResult.badRequest("test-message"));
+        assertThatThrownBy(() -> ext.initialize(context)).isInstanceOf(EdcException.class);
+        verify(participantContextService).createParticipantContext(any());
+        verifyNoMoreInteractions(participantContextService);
+    }
+
+    @Test
+    void initialize_withApiKeyOverride(ManagementApiConfigurationExtension ext,
+                                       ServiceExtensionContext context) {
+
+
+        when(vault.storeSecret(any(), any())).thenReturn(Result.success());
+
+        var apiKeyOverride = "c3VwZXItdXNlcgo=.asdfl;jkasdfl;kasdf";
+        when(context.getSetting(eq(ManagementApiConfigurationExtension.SUPERUSER_APIKEY_PROPERTY), eq(null)))
+                .thenReturn(apiKeyOverride);
+
+        when(participantContextService.createParticipantContext(any()))
+                .thenReturn(ServiceResult.success("generated-api-key"));
+        when(participantContextService.getParticipantContext(eq("super-user")))
+                .thenReturn(ServiceResult.success(superUserContext().build()));
+
+        ext.initialize(context);
+        verify(participantContextService).createParticipantContext(any());
+        verify(participantContextService).getParticipantContext(eq("super-user"));
+        verify(vault).storeSecret(eq("super-user-apikey"), eq(apiKeyOverride));
+        verifyNoMoreInteractions(participantContextService, vault);
+    }
+
+    @Test
+    void initialize_withInvalidKeyOverride(ManagementApiConfigurationExtension ext,
+                                           ServiceExtensionContext context) {
+        when(vault.storeSecret(any(), any())).thenReturn(Result.success());
+
+        var apiKeyOverride = "some-invalid-key";
+        when(context.getSetting(eq(ManagementApiConfigurationExtension.SUPERUSER_APIKEY_PROPERTY), eq(null)))
+                .thenReturn(apiKeyOverride);
+
+        when(participantContextService.createParticipantContext(any()))
+                .thenReturn(ServiceResult.success("generated-api-key"));
+        when(participantContextService.getParticipantContext(eq("super-user")))
+                .thenReturn(ServiceResult.success(superUserContext().build()));
+
+        ext.initialize(context);
+        verify(participantContextService).createParticipantContext(any());
+        verify(participantContextService).getParticipantContext(eq("super-user"));
+        verify(vault).storeSecret(eq("super-user-apikey"), eq(apiKeyOverride));
+        verify(monitor).warning(contains("this key appears to have an invalid format"));
+        verifyNoMoreInteractions(participantContextService, vault);
+    }
+
+    @Test
+    void initialize_whenVaultReturnsFailure(ManagementApiConfigurationExtension ext,
+                                            ServiceExtensionContext context) {
+        when(vault.storeSecret(any(), any())).thenReturn(Result.failure("test-failure"));
+
+        var apiKeyOverride = "c3VwZXItdXNlcgo=.asdfl;jkasdfl;kasdf";
+        when(context.getSetting(eq(ManagementApiConfigurationExtension.SUPERUSER_APIKEY_PROPERTY), eq(null)))
+                .thenReturn(apiKeyOverride);
+
+        when(participantContextService.createParticipantContext(any()))
+                .thenReturn(ServiceResult.success("generated-api-key"));
+        when(participantContextService.getParticipantContext(eq("super-user")))
+                .thenReturn(ServiceResult.success(superUserContext().build()));
+
+        ext.initialize(context);
+        verify(participantContextService).createParticipantContext(any());
+        verify(participantContextService).getParticipantContext(eq("super-user"));
+        verify(vault).storeSecret(eq("super-user-apikey"), eq(apiKeyOverride));
+        verify(monitor).warning(eq("Error storing API key in vault: test-failure"));
+        verifyNoMoreInteractions(participantContextService, vault);
+    }
+
+    private ParticipantContext.Builder superUserContext() {
+        return ParticipantContext.Builder.newInstance()
+                .participantId("super-user")
+                .apiTokenAlias("super-user-apikey");
+
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a config parameter `edc.ih.api.superuser.key` that allows to override the
automatically generated API key for the SuperUser

## Why it does that

In automated deployment scenarios it may be virtually impossible to `grep` the log output of a container/pod
to obtain the API key. Therefor a way to explicitly set / override it is very helpful.

## Further notes

- API keys must still follow the format `base64("super-user").<random-string>`, otherwise a warning is logged

## Linked Issue(s)

Closes #249

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
