### PR TITLE
feat: add endpoint to update roles of a ParticipantContext

### DIFF
--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ManagementApiEndToEndTest.java
@@ -99,6 +99,12 @@ public abstract class ManagementApiEndToEndTest {
                 .build()).getContent();
     }
 
+    protected ParticipantContext getParticipant(String participantId) {
+        return getService(ParticipantContextService.class)
+                .getParticipantContext(participantId)
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()));
+    }
+
     protected static ParticipantManifest createNewParticipant() {
         var manifest = ParticipantManifest.Builder.newInstance()
                 .participantId("another-participant")

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
@@ -29,6 +29,8 @@ import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
+import java.util.List;
+
 @OpenAPIDefinition(info = @Info(description = "This is the Management API for ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
 public interface ParticipantContextApi {
 
@@ -109,4 +111,19 @@ public interface ParticipantContextApi {
             }
     )
     void deleteParticipant(String participantId, SecurityContext securityContext);
+
+    @Tag(name = "ParticipantContext Management API")
+    @Operation(description = "Updates a ParticipantContext's roles. Note that this is an absolute update, that means all roles that the Participant should have must be submitted in the body. Requires elevated privileges.",
+            requestBody = @RequestBody(content = @Content(array = @ArraySchema(schema = @Schema(implementation = List.class)))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The ParticipantContext was updated successfully"),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A ParticipantContext with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void updateRoles(String participantId, List<String> roles);
 }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -32,6 +33,8 @@ import org.eclipse.edc.identityhub.spi.authentication.ServicePrincipal;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+
+import java.util.List;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.identityhub.spi.AuthorizationResultHandler.exceptionMapper;
@@ -98,6 +101,17 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     public void deleteParticipant(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
         participantContextService.deleteParticipantContext(participantId)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
+    }
+
+    @Override
+    @PUT
+    @Path("/{participantId}/roles")
+    @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
+    public void updateRoles(@PathParam("participantId") String participantId, List<String> roles) {
+        participantContextService.updateParticipant(participantId, participantContext -> {
+            participantContext.getRoles().clear();
+            participantContext.getRoles().addAll(roles);
+        }).orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an endpoint `PUT /v1/participants/<participantId>/roles` that allows the super-user
to update the roles of a participant

## Why it does that

Extensibility of the RBAC concept

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #252

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
