### PR TITLE
fix: explicit modification of roles

### DIFF
--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
@@ -108,10 +108,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Path("/{participantId}/roles")
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     public void updateRoles(@PathParam("participantId") String participantId, List<String> roles) {
-        participantContextService.updateParticipant(participantId, participantContext -> {
-            participantContext.getRoles().clear();
-            participantContext.getRoles().addAll(roles);
-        }).orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
+        participantContextService.updateParticipant(participantId, participantContext -> participantContext.setRoles(roles)).orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
     }
 
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/ParticipantContext.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -100,7 +101,11 @@ public class ParticipantContext extends ParticipantResource {
     }
 
     public List<String> getRoles() {
-        return roles;
+        return Collections.unmodifiableList(roles);
+    }
+
+    public void setRoles(List<String> roles) {
+        this.roles = roles;
     }
 
     @JsonPOJOBuilder(withPrefix = "")


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a method to explicitly set the roles of a `ParticipantContext`

## Why it does that

updating roles with `getRoles().clear()` and `getRoles().addAll()` will fail on immutable lists.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
