### PR TITLE
feat: implement ParticipantContextEventCoordinator

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -56,18 +56,20 @@ maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, 
 maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY-2.5 AND LGPL-2.1+, approved, CQ13390
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
+maven/mavencentral/com.google.collections/google-collections/1.0, Apache-2.0, approved, CQ3285
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/28.1-android, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/28.2-android, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ22437
 maven/mavencentral/com.google.guava/guava/31.0.1-android, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/guava/31.1-jre, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.guava/guava/32.0.1-jre, Apache-2.0 AND CC0-1.0 AND CC-PDDC, approved, #8772
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/1.3, Apache-2.0, approved, CQ21195
+maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.protobuf/protobuf-java/3.24.3, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.googlecode.libphonenumber/libphonenumber/8.11.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.jayway.jsonpath/json-path/2.7.0, Apache-2.0, approved, clearlydefined
@@ -76,7 +78,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.0, LGPL-2.1-or-later, approved, #7936
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.12.3, LGPL-2.1+, restricted, clearlydefined
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -98,7 +100,7 @@ maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, 
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/dev.failsafe/failsafe-okhttp/3.3.2, Apache-2.0, approved, #9178
 maven/mavencentral/dev.failsafe/failsafe/3.3.2, Apache-2.0, approved, #9268
-maven/mavencentral/info.picocli/picocli/4.6.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/info.picocli/picocli/4.7.4, Apache-2.0, approved, #4365
 maven/mavencentral/io.github.classgraph/classgraph/4.8.154, MIT, approved, CQ22530
 maven/mavencentral/io.github.classgraph/classgraph/4.8.162, MIT, approved, CQ22530
 maven/mavencentral/io.netty/netty-buffer/4.1.86.Final, Apache-2.0, approved, CQ21842
@@ -181,8 +183,8 @@ maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, a
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
 maven/mavencentral/net.minidev/json-smart/2.4.7, Apache-2.0, approved, #3288
 maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
-maven/mavencentral/net.sf.saxon/Saxon-HE/10.6, MPL-2.0 AND W3C, approved, #7945
-maven/mavencentral/org.antlr/antlr4-runtime/4.9.3, BSD-3-Clause, approved, #322
+maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.antlr/antlr4-runtime/4.11.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-compress/1.25.0, Apache-2.0, approved, #11600
 maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined
@@ -190,17 +192,29 @@ maven/mavencentral/org.apache.commons/commons-lang3/3.10, Apache-2.0, approved, 
 maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
 maven/mavencentral/org.apache.commons/commons-lang3/3.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.13.0, Apache-2.0, approved, #9820
+maven/mavencentral/org.apache.commons/commons-lang3/3.7, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-lang3/3.8.1, Apache-2.0, approved, #815
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-text/1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.groovy/groovy-bom/4.0.16, Apache-2.0, approved, #9266
 maven/mavencentral/org.apache.groovy/groovy-json/4.0.16, Apache-2.0, approved, #7411
 maven/mavencentral/org.apache.groovy/groovy-xml/4.0.16, Apache-2.0, approved, #10179
 maven/mavencentral/org.apache.groovy/groovy/4.0.16, Apache-2.0 AND BSD-3-Clause AND MIT, approved, #1742
+maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.1.3, Apache-2.0, approved, #6276
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5-h2/5.1.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.httpcomponents.core5/httpcore5/5.1.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.13, Apache-2.0 AND LicenseRef-Public-Domain, approved, CQ23527
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13, Apache-2.0, approved, CQ23528
+maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.14, Apache-2.0, approved, CQ23528
 maven/mavencentral/org.apache.httpcomponents/httpmime/4.5.13, Apache-2.0, approved, CQ11718
+maven/mavencentral/org.apache.maven.doxia/doxia-core/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-logging-api/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-module-xdoc/1.12.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.maven.doxia/doxia-sink-api/1.12.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.velocity.tools/velocity-tools-generic/3.1, Apache-2.0, approved, #9331
 maven/mavencentral/org.apache.velocity/velocity-engine-core/2.3, Apache-2.0, approved, #2478
 maven/mavencentral/org.apache.velocity/velocity-engine-scripting/2.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.xbean/xbean-reflect/3.7, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.assertj/assertj-core/3.25.1, Apache-2.0, approved, #12585
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
@@ -213,7 +227,13 @@ maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.27.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.41.0, MIT, approved, #12032
+maven/mavencentral/org.codehaus.plexus/plexus-classworlds/2.6.0, Apache-2.0 AND Plexus, approved, CQ22821
+maven/mavencentral/org.codehaus.plexus/plexus-component-annotations/2.1.0, Apache-2.0, approved, #809
+maven/mavencentral/org.codehaus.plexus/plexus-container-default/2.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.1.1, , approved, CQ16492
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/api-observability/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.5.1-SNAPSHOT, Apache-2.0, approved, technology.edc
@@ -365,6 +385,7 @@ maven/mavencentral/org.testcontainers/junit-jupiter/1.19.4, MIT, approved, #1034
 maven/mavencentral/org.testcontainers/postgresql/1.19.4, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.3, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.testcontainers/testcontainers/1.19.4, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.xmlresolver/xmlresolver/5.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.identithub.did.spi.DidDocumentService;
 import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.events.keypair.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.events.keypair.KeyPairRevoked;
-import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextCreated;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextUpdated;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -64,8 +63,7 @@ public class DidServicesExtension implements ServiceExtension {
 
     @Provider
     public DidDocumentService createDidDocumentService(ServiceExtensionContext context) {
-        var service = new DidDocumentServiceImpl(transactionContext, didResourceStore, getDidPublisherRegistry(), context.getMonitor(), keyParserRegistry);
-        eventRouter.registerSync(ParticipantContextCreated.class, service);
+        var service = new DidDocumentServiceImpl(transactionContext, didResourceStore, getDidPublisherRegistry(), context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
         eventRouter.registerSync(ParticipantContextUpdated.class, service);
         eventRouter.registerSync(ParticipantContextDeleted.class, service);
         eventRouter.registerSync(KeyPairAdded.class, service);

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
@@ -25,11 +25,11 @@ import org.eclipse.edc.spi.event.EventRouter;
 
 import java.time.Clock;
 
-public class KeyPairEventListenerImpl implements KeyPairEventListener {
+public class KeyPairEventPublisher implements KeyPairEventListener {
     private final Clock clock;
     private final EventRouter eventRouter;
 
-    public KeyPairEventListenerImpl(Clock clock, EventRouter eventRouter) {
+    public KeyPairEventPublisher(Clock clock, EventRouter eventRouter) {
         this.clock = clock;
         this.eventRouter = eventRouter;
     }

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
@@ -65,7 +65,7 @@ public class KeyPairServiceExtension implements ServiceExtension {
     public KeyPairObservable keyPairObservable() {
         if (observable == null) {
             observable = new KeyPairObservableImpl();
-            observable.registerListener(new KeyPairEventListenerImpl(clock, eventRouter));
+            observable.registerListener(new KeyPairEventPublisher(clock, eventRouter));
         }
         return observable;
     }

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
@@ -15,9 +15,7 @@
 package org.eclipse.edc.identityhub.keypairs;
 
 import org.eclipse.edc.identityhub.spi.KeyPairService;
-import org.eclipse.edc.identityhub.spi.events.diddocument.DidDocumentPublished;
 import org.eclipse.edc.identityhub.spi.events.keypair.KeyPairObservable;
-import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextCreated;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -54,10 +52,8 @@ public class KeyPairServiceExtension implements ServiceExtension {
 
     @Provider
     public KeyPairService createParticipantService(ServiceExtensionContext context) {
-        var service = new KeyPairServiceImpl(keyPairResourceStore, vault, context.getMonitor(), keyPairObservable());
-        eventRouter.registerSync(ParticipantContextCreated.class, service);
+        var service = new KeyPairServiceImpl(keyPairResourceStore, vault, context.getMonitor().withPrefix("KeyPairService"), keyPairObservable());
         eventRouter.registerSync(ParticipantContextDeleted.class, service);
-        eventRouter.registerSync(DidDocumentPublished.class, service);
         return service;
     }
 

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -134,12 +134,11 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
     @Override
     public <E extends Event> void on(EventEnvelope<E> eventEnvelope) {
         var payload = eventEnvelope.getPayload();
-        if (payload instanceof ParticipantContextCreated created) {
-            created(created);
-        } else if (payload instanceof ParticipantContextDeleted deleted) {
+        monitor.debug("Received a [%s] event".formatted(payload.getClass().getSimpleName()));
+        if (payload instanceof ParticipantContextDeleted deleted) {
             deleted(deleted);
         } else {
-            monitor.warning("KeyPairServiceImpl Received event with unexpected payload type: %s".formatted(payload.getClass()));
+            monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
         }
     }
 
@@ -180,7 +179,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
             if (keyPair.failed()) {
                 return keyPair.mapTo();
             }
-            var privateJwk = CryptoConverter.createJwk(keyPair.getContent());
+            var privateJwk = CryptoConverter.createJwk(keyPair.getContent(), keyDescriptor.getKeyId());
             publicKeySerialized = privateJwk.toPublicJWK().toJSONString();
             vault.storeSecret(keyDescriptor.getPrivateKeyAlias(), privateJwk.toJSONString());
         } else {

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.participantcontext;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identityhub.spi.KeyPairService;
+import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextCreated;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.monitor.Monitor;
+
+import static org.eclipse.edc.spi.result.ServiceResult.success;
+
+/**
+ * Coordinates {@link ParticipantContextCreated} events. More specifically, it coordinates the sequence, in which the following actions are performed:
+ * <ul>
+ *     <li>Create DID Document</li>
+ *     <li>Optional: publish DID document</li>
+ *     <li>Add a KeyPair</li>
+ * </ul>
+ * To that end, the {@link ParticipantContextEventCoordinator} directly collaborates with the {@link KeyPairService} and the {@link DidDocumentService}.
+ * <p>
+ * Please note that once this initial sequence is executed, every collaborator service emits their events as per their event contract.
+ * For example, once a KeyPair is added, the {@link KeyPairService} will emit a {@link org.eclipse.edc.identityhub.spi.events.keypair.KeyPairAdded} event. The {@link DidDocumentService}
+ * can then react to this event by updating the DID Document.
+ */
+public class ParticipantContextEventCoordinator implements EventSubscriber {
+    private final Monitor monitor;
+    private final DidDocumentService didDocumentService;
+    private final KeyPairService keyPairService;
+
+    public ParticipantContextEventCoordinator(Monitor monitor, DidDocumentService didDocumentService, KeyPairService keyPairService) {
+        this.monitor = monitor;
+        this.didDocumentService = didDocumentService;
+        this.keyPairService = keyPairService;
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> event) {
+        var payload = event.getPayload();
+        if (payload instanceof ParticipantContextCreated createdEvent) {
+            var manifest = createdEvent.getManifest();
+            var doc = DidDocument.Builder.newInstance()
+                    .id(manifest.getDid())
+                    .service(manifest.getServiceEndpoints().stream().toList())
+                    // updating and adding a verification method happens as a result of the KeyPairAddedEvent
+                    .build();
+
+            didDocumentService.store(doc, manifest.getParticipantId())
+                    .compose(u -> manifest.isActive() ? didDocumentService.publish(doc.getId()) : success())
+                    // adding the keypair event will cause the DidDocumentService to update the DID.
+                    .compose(u -> keyPairService.addKeyPair(createdEvent.getParticipantId(), createdEvent.getManifest().getKey(), true))
+                    .onFailure(f -> monitor.warning("%s".formatted(f.getFailureDetail())));
+
+        } else {
+            monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
+        }
+    }
+}

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventPublisher.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventPublisher.java
@@ -26,11 +26,11 @@ import org.eclipse.edc.spi.event.EventRouter;
 
 import java.time.Clock;
 
-public class ParticipantContextListenerImpl implements ParticipantContextListener {
+public class ParticipantContextEventPublisher implements ParticipantContextListener {
     private final Clock clock;
     private final EventRouter eventRouter;
 
-    public ParticipantContextListenerImpl(Clock clock, EventRouter eventRouter) {
+    public ParticipantContextEventPublisher(Clock clock, EventRouter eventRouter) {
         this.clock = clock;
         this.eventRouter = eventRouter;
     }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -15,7 +15,9 @@
 package org.eclipse.edc.identityhub.participantcontext;
 
 import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identityhub.spi.KeyPairService;
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextCreated;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextObservable;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -25,6 +27,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.security.KeyParserRegistry;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
@@ -46,6 +49,8 @@ public class ParticipantContextExtension implements ServiceExtension {
     @Inject
     private DidDocumentService didDocumentService;
     @Inject
+    private KeyPairService keyPairService;
+    @Inject
     private Clock clock;
     @Inject
     private EventRouter eventRouter;
@@ -55,6 +60,14 @@ public class ParticipantContextExtension implements ServiceExtension {
     @Override
     public String name() {
         return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var coordinator = new ParticipantContextEventCoordinator(context.getMonitor().withPrefix("ParticipantContextEventCoordinator"),
+                didDocumentService, keyPairService);
+
+        eventRouter.registerSync(ParticipantContextCreated.class, coordinator);
     }
 
     @Provider

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -66,7 +66,7 @@ public class ParticipantContextExtension implements ServiceExtension {
     public ParticipantContextObservable participantContextObservable() {
         if (participantContextObservable == null) {
             participantContextObservable = new ParticipantContextObservableImpl();
-            participantContextObservable.registerListener(new ParticipantContextListenerImpl(clock, eventRouter));
+            participantContextObservable.registerListener(new ParticipantContextEventPublisher(clock, eventRouter));
         }
         return participantContextObservable;
     }

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinatorTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinatorTest.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.participantcontext;
+
+import org.eclipse.edc.identithub.did.spi.DidDocumentService;
+import org.eclipse.edc.identityhub.spi.KeyPairService;
+import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class ParticipantContextEventCoordinatorTest {
+    private final Monitor monitor = mock();
+    private final DidDocumentService didDocumentService = mock();
+    private final KeyPairService keyPairService = mock();
+    private final ParticipantContextEventCoordinator coordinator = new ParticipantContextEventCoordinator(monitor, didDocumentService, keyPairService);
+
+    @Test
+    void onParticipantCreated() {
+        var participantId = "test-id";
+        when(didDocumentService.store(any(), eq(participantId))).thenReturn(ServiceResult.success());
+        when(didDocumentService.publish(anyString())).thenReturn(ServiceResult.success());
+        when(keyPairService.addKeyPair(eq(participantId), any(), anyBoolean())).thenReturn(ServiceResult.success());
+
+        coordinator.on(envelope(ParticipantContextCreated.Builder.newInstance()
+                .participantId(participantId)
+                .manifest(createManifest().build())
+                .build()));
+
+        verify(didDocumentService).store(any(), eq(participantId));
+        verify(didDocumentService).publish(eq("did:web:" + participantId));
+        verify(keyPairService).addKeyPair(eq(participantId), any(), eq(true));
+        verifyNoMoreInteractions(keyPairService, didDocumentService, monitor);
+    }
+
+    @Test
+    void onParticipantCreated_didDocumentServiceStoreFailure() {
+        var participantId = "test-id";
+        when(didDocumentService.store(any(), eq(participantId))).thenReturn(ServiceResult.badRequest("foobar"));
+
+        coordinator.on(envelope(ParticipantContextCreated.Builder.newInstance()
+                .participantId(participantId)
+                .manifest(createManifest().build())
+                .build()));
+
+        verify(didDocumentService).store(any(), eq(participantId));
+        verify(monitor).warning("foobar");
+        verifyNoMoreInteractions(keyPairService, didDocumentService);
+    }
+
+    @Test
+    void onParticipantCreated_didDocumentServicePublishFailure() {
+        var participantId = "test-id";
+        when(didDocumentService.store(any(), eq(participantId))).thenReturn(ServiceResult.success());
+        when(didDocumentService.publish(anyString())).thenReturn(ServiceResult.badRequest("foobar"));
+
+        coordinator.on(envelope(ParticipantContextCreated.Builder.newInstance()
+                .participantId(participantId)
+                .manifest(createManifest().build())
+                .build()));
+
+        verify(didDocumentService).store(any(), eq(participantId));
+        verify(didDocumentService).publish(anyString());
+        verify(monitor).warning("foobar");
+        verifyNoMoreInteractions(keyPairService, didDocumentService);
+    }
+
+    @Test
+    void onParticipantCreated_keyPairServiceFailure() {
+        var participantId = "test-id";
+        when(didDocumentService.store(any(), eq(participantId))).thenReturn(ServiceResult.success());
+        when(didDocumentService.publish(anyString())).thenReturn(ServiceResult.success());
+        when(keyPairService.addKeyPair(eq(participantId), any(), anyBoolean())).thenReturn(ServiceResult.notFound("foobar"));
+
+        coordinator.on(envelope(ParticipantContextCreated.Builder.newInstance()
+                .participantId(participantId)
+                .manifest(createManifest().build())
+                .build()));
+
+        verify(didDocumentService).store(any(), eq(participantId));
+        verify(didDocumentService).publish(eq("did:web:" + participantId));
+        verify(keyPairService).addKeyPair(eq(participantId), any(), eq(true));
+        verify(monitor).warning("foobar");
+        verifyNoMoreInteractions(keyPairService, didDocumentService);
+    }
+
+    @Test
+    void onOtherEvent_expectWarning() {
+        coordinator.on(envelope(new Event() {
+            @Override
+            public String name() {
+                return "another.event";
+            }
+        }));
+
+        verify(monitor).warning(startsWith("Received event with unexpected payload type:"));
+        verifyNoMoreInteractions(monitor, didDocumentService, keyPairService);
+    }
+
+    @SuppressWarnings("unchecked")
+    private EventEnvelope<Event> envelope(Event event) {
+        return EventEnvelope.Builder.newInstance()
+                .at(Instant.now().toEpochMilli())
+                .payload(event)
+                .build();
+    }
+
+    private ParticipantManifest.Builder createManifest() {
+        return ParticipantManifest.Builder.newInstance()
+                .key(createKey().build())
+                .active(true)
+                .did("did:web:test-id")
+                .participantId("test-id");
+    }
+
+    @NotNull
+    private KeyDescriptor.Builder createKey() {
+        return KeyDescriptor.Builder.newInstance().keyId("test-kie")
+                .privateKeyAlias("private-alias")
+                .keyGeneratorParams(Map.of("algorithm", "EC"));
+    }
+}

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -112,7 +112,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
 
 
     @Test
-    void createNewUser_principalIsNotSuperser_expect403() {
+    void createNewUser_principalIsNotSuperuser_expect403() {
         var subscriber = mock(EventSubscriber.class);
         getService(EventRouter.class).registerSync(ParticipantContextCreated.class, subscriber);
 

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextCreated.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextCreated.java
@@ -26,6 +26,9 @@ import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 public class ParticipantContextCreated extends ParticipantContextEvent {
     private ParticipantManifest manifest;
 
+    private ParticipantContextCreated() {
+    }
+
     @Override
     public String name() {
         return "participantcontext.created";

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextEvent.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextEvent.java
@@ -38,8 +38,8 @@ public abstract class ParticipantContextEvent extends Event {
 
         public abstract B self();
 
-        public B participantId(String assetId) {
-            event.participantId = assetId;
+        public B participantId(String participantId) {
+            event.participantId = participantId;
             return self();
         }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR implements the `ParticipantContextEventCoordinator`, whos job it is to handle `ParticipantContextCreated` events in a coordinated (= linear) way.
First, the DID document is created, and then the KeyPair is added, causing the DID Document to get updated.

## Why it does that

The current implementation of the `EventRouter` does not lend itself well to handling dependent events.
## Further notes

- An alternative route, i.e. an `EventQueue` was explored, but while it most likely would have also solved this problem, it was deemed impractical and hard to debug. 
- requires https://github.com/eclipse-edc/Connector/pull/3833
- renamed all the `*ListenerImpl`s to `*Publisher`

## Linked Issue(s)

Closes #

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
