### PR TITLE
chore: audience check with participant id or did

### DIFF
--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -18,7 +18,6 @@ import org.eclipse.edc.core.transform.transformer.to.JsonValueToGenericTypeTrans
 import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToPresentationQueryTransformer;
 import org.eclipse.edc.identityhub.api.v1.PresentationApiController;
 import org.eclipse.edc.identityhub.api.validation.PresentationQueryValidator;
-import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.generator.VerifiablePresentationService;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
@@ -61,8 +60,6 @@ public class PresentationApiExtension implements ServiceExtension {
     private JsonLd jsonLd;
     @Inject
     private TypeManager typeManager;
-    @Inject
-    private ParticipantContextService participantContextService;
 
     @Override
     public String name() {
@@ -75,7 +72,7 @@ public class PresentationApiExtension implements ServiceExtension {
         validatorRegistry.register(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TYPE_PROPERTY, new PresentationQueryValidator());
 
 
-        var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, accessTokenVerifier, verifiablePresentationService, context.getMonitor(), participantContextService);
+        var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, accessTokenVerifier, verifiablePresentationService, context.getMonitor());
 
         var jsonLdMapper = typeManager.getMapper(JSON_LD);
         webService.registerResource(RESOLUTION_CONTEXT, new ObjectMapperProvider(jsonLdMapper));

--- a/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/core/identity-hub-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -18,9 +18,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.identityhub.api.v1.PresentationApiController;
-import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.generator.VerifiablePresentationService;
-import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.resolution.QueryResult;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
@@ -32,7 +30,6 @@ import org.eclipse.edc.identitytrust.model.presentationdefinition.PresentationDe
 import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -78,10 +75,6 @@ class PresentationApiControllerTest extends RestControllerTestBase {
     private final CredentialQueryResolver queryResolver = mock();
     private final AccessTokenVerifier accessTokenVerifier = mock();
     private final VerifiablePresentationService generator = mock();
-    private final ParticipantContextService participantContextService = mock(a -> ServiceResult.success(ParticipantContext.Builder.newInstance()
-            .participantId(a.getArgument(0).toString())
-            .apiTokenAlias("test-alias")
-            .build()));
 
     @Test
     void query_tokenNotPresent_shouldReturn401() {
@@ -194,7 +187,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
 
     @Override
     protected PresentationApiController controller() {
-        return new PresentationApiController(validatorRegistryMock, typeTransformerRegistry, queryResolver, accessTokenVerifier, generator, mock(), participantContextService);
+        return new PresentationApiController(validatorRegistryMock, typeTransformerRegistry, queryResolver, accessTokenVerifier, generator, mock());
     }
 
     private String generateJwt() {

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.identityhub.core.creators.JwtPresentationGenerator;
 import org.eclipse.edc.identityhub.core.creators.LdpPresentationGenerator;
 import org.eclipse.edc.identityhub.spi.KeyPairService;
+import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.spi.generator.PresentationCreatorRegistry;
 import org.eclipse.edc.identityhub.spi.generator.VerifiablePresentationService;
@@ -114,6 +115,9 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private KeyPairService keyPairService;
 
+    @Inject
+    private ParticipantContextService participantContextService;
+
     @Override
     public String name() {
         return NAME;
@@ -129,7 +133,7 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Provider
     public AccessTokenVerifier createAccessTokenVerifier(ServiceExtensionContext context) {
-        return new AccessTokenVerifierImpl(tokenValidationService, createPublicKey(context), tokenValidationRulesRegistry, context.getMonitor(), publicKeyResolver);
+        return new AccessTokenVerifierImpl(tokenValidationService, createPublicKey(context), tokenValidationRulesRegistry, participantContextService, context.getMonitor(), publicKeyResolver);
     }
 
 

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -158,6 +158,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     private ParticipantContext convert(ParticipantManifest manifest) {
         return ParticipantContext.Builder.newInstance()
                 .participantId(manifest.getParticipantId())
+                .did(manifest.getDid())
                 .roles(manifest.getRoles())
                 .apiTokenAlias("%s-%s".formatted(manifest.getParticipantId(), API_KEY_ALIAS_SUFFIX))
                 .state(manifest.isActive() ? ParticipantContextState.ACTIVATED : ParticipantContextState.CREATED)


### PR DESCRIPTION
## What this PR changes/adds

Changes the checks on participant id

- Moves the check for the participantContextId presence in the `AccessTokenVerifier`
- The `aud` check is tested against the participant id or the participant did


