### PR TITLE
feat: base64-url encoded `participantId` in API controllers

### DIFF
--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.identityhub.spi.ParticipantContextId.onEncoded;
 import static org.eclipse.edc.identitytrust.model.credentialservice.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TYPE_PROPERTY;
 import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMapper;
 
@@ -82,6 +83,7 @@ public class PresentationApiController implements PresentationApi {
         }
         validatorRegistry.validate(PRESENTATION_QUERY_MESSAGE_TYPE_PROPERTY, query).orElseThrow(ValidationFailureException::new);
 
+        participantContextId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);
         var presentationQuery = transformerRegistry.transform(query, PresentationQueryMessage.class).orElseThrow(InvalidRequestException::new);
 
         if (presentationQuery.getPresentationDefinition() != null) {

--- a/docs/developer/architecture/mgmt-api.security.md
+++ b/docs/developer/architecture/mgmt-api.security.md
@@ -2,11 +2,12 @@
 
 ## 1. Definition of terms
 
-- _Service principal_: the identifier for the entity that owns a resource. In IdentityHub, this is the ID of
-  the `ParticipantContext`. Not that this is **not** a user! Also referred to as: principal
+- _Service principal_ (also referred as _principal_): the identifier for the entity that owns a resource. In
+  IdentityHub, this is the ID of
+  the `ParticipantContext`. Note that this is **not** a user!
 - _User_: a physical entity that may be able to perform different operations on a resource belonging to a service
   principal. While a participant (context) would be analogous to a company or an organization, a user would be one
-  single individual within that company / participant. Invidual users don't exist as first-level concept in
+  single individual within that company / participant. **Individual users don't exist as first-level concept in
   IdentityHub!**
 - _Participant context_: this is the unit of management, that owns all resources. Its identifier must be equal to
   the `participantId` that is defined

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -53,7 +54,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
 
         var su = RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
                 .header(new Header("x-api-key", apikey))
-                .get("/v1/participants/" + SUPER_USER)
+                .get("/v1/participants/" + toBase64(SUPER_USER))
                 .then()
                 .statusCode(200)
                 .extract().body().as(ParticipantContext.class);
@@ -82,7 +83,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
         RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
                 .header(new Header("x-api-key", apiToken1))
                 .contentType(ContentType.JSON)
-                .get("/v1/participants/" + user2)
+                .get("/v1/participants/" + toBase64(user2))
                 .then()
                 .log().ifValidationFails()
                 .statusCode(403);
@@ -180,7 +181,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
         RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
                 .header(new Header("x-api-key", getSuperUserApiKey()))
                 .contentType(ContentType.JSON)
-                .post("/v1/participants/%s/state?isActive=true".formatted(participantId))
+                .post("/v1/participants/%s/state?isActive=true".formatted(toBase64(participantId)))
                 .then()
                 .log().ifError()
                 .statusCode(204);
@@ -205,7 +206,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
         RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
                 .header(new Header("x-api-key", getSuperUserApiKey()))
                 .contentType(ContentType.JSON)
-                .delete("/v1/participants/%s".formatted(participantId))
+                .delete("/v1/participants/%s".formatted(toBase64(participantId)))
                 .then()
                 .log().ifError()
                 .statusCode(204);
@@ -215,7 +216,6 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
 
     @Test
     void regenerateToken() {
-
         var participantId = "another-user";
         var userToken = createParticipant(participantId);
 
@@ -223,7 +223,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
                 .allSatisfy(t -> RUNTIME_CONFIGURATION.getManagementEndpoint().baseRequest()
                         .header(new Header("x-api-key", t))
                         .contentType(ContentType.JSON)
-                        .post("/v1/participants/%s/token".formatted(participantId))
+                        .post("/v1/participants/%s/token".formatted(toBase64(participantId)))
                         .then()
                         .log().ifError()
                         .statusCode(200)
@@ -239,7 +239,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
                 .header(new Header("x-api-key", getSuperUserApiKey()))
                 .contentType(ContentType.JSON)
                 .body(List.of("role1", "role2", "admin"))
-                .put("/v1/participants/%s/roles".formatted(participantId))
+                .put("/v1/participants/%s/roles".formatted(toBase64(participantId)))
                 .then()
                 .log().ifError()
                 .statusCode(204);
@@ -257,7 +257,7 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
                 .header(new Header("x-api-key", userToken))
                 .contentType(ContentType.JSON)
                 .body(List.of(role))
-                .put("/v1/participants/%s/roles".formatted(participantId))
+                .put("/v1/participants/%s/roles".formatted(toBase64(participantId)))
                 .then()
                 .log().ifError()
                 .statusCode(403);
@@ -333,5 +333,9 @@ public class ParticipantContextApiEndToEndTest extends ManagementApiEndToEndTest
                 .then()
                 .log().ifValidationFails()
                 .statusCode(403);
+    }
+
+    private String toBase64(String s) {
+        return Base64.getUrlEncoder().encodeToString(s.getBytes());
     }
 }

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiComponentTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiComponentTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatchers;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -57,7 +58,8 @@ import static org.mockito.Mockito.when;
 
 @ComponentTest
 public class PresentationApiComponentTest {
-    public static final String VALID_QUERY_WITH_SCOPE = """
+
+    private static final String VALID_QUERY_WITH_SCOPE = """
             {
               "@context": [
                 "https://identity.foundation/presentation-exchange/submission/v1",
@@ -74,6 +76,7 @@ public class PresentationApiComponentTest {
             .id("identity-hub")
             .build();
     private static final String TEST_PARTICIPANT_CONTEXT_ID = "test-participant";
+    private static final String TEST_PARTICIPANT_CONTEXT_ID_ENCODED = Base64.getUrlEncoder().encodeToString(TEST_PARTICIPANT_CONTEXT_ID.getBytes());
     // todo: these mocks should be replaced, once their respective implementations exist!
     private static final CredentialQueryResolver CREDENTIAL_QUERY_RESOLVER = mock();
     private static final VerifiablePresentationService PRESENTATION_GENERATOR = mock();
@@ -97,7 +100,7 @@ public class PresentationApiComponentTest {
         createParticipant(TEST_PARTICIPANT_CONTEXT_ID);
         IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType("application/json")
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(401)
                 .extract().body().asString();
@@ -119,7 +122,7 @@ public class PresentationApiComponentTest {
                 .contentType(JSON)
                 .header(AUTHORIZATION, generateSiToken())
                 .body(query)
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(400)
                 .extract().body().asString();
@@ -144,7 +147,7 @@ public class PresentationApiComponentTest {
                 .contentType(JSON)
                 .header(AUTHORIZATION, generateSiToken())
                 .body(query)
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(503)
                 .extract().body().asString();
@@ -160,7 +163,7 @@ public class PresentationApiComponentTest {
                 .contentType(JSON)
                 .header(AUTHORIZATION, token)
                 .body(VALID_QUERY_WITH_SCOPE)
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(401)
                 .log().ifValidationFails()
@@ -179,7 +182,7 @@ public class PresentationApiComponentTest {
                 .contentType(JSON)
                 .header(AUTHORIZATION, token)
                 .body(VALID_QUERY_WITH_SCOPE)
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(403)
                 .log().ifValidationFails()
@@ -199,7 +202,7 @@ public class PresentationApiComponentTest {
                 .contentType(JSON)
                 .header(AUTHORIZATION, token)
                 .body(VALID_QUERY_WITH_SCOPE)
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(500)
                 .log().ifValidationFails();
@@ -220,7 +223,7 @@ public class PresentationApiComponentTest {
                 .contentType(JSON)
                 .header(AUTHORIZATION, token)
                 .body(VALID_QUERY_WITH_SCOPE)
-                .post("/v1/participants/test-participant/presentation/query")
+                .post("/v1/participants/%s/presentation/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                 .then()
                 .statusCode(200)
                 .log().ifValidationFails()

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
@@ -34,6 +34,7 @@ import org.eclipse.edc.identityhub.spi.authentication.ServicePrincipal;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
 import java.util.Collection;
@@ -41,6 +42,7 @@ import java.util.List;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.identityhub.spi.AuthorizationResultHandler.exceptionMapper;
+import static org.eclipse.edc.identityhub.spi.ParticipantContextId.onEncoded;
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
@@ -70,18 +72,22 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @GET
     @Path("/{participantId}")
     public ParticipantContext getParticipant(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
-        return authorizationService.isAuthorized(securityContext, participantId, ParticipantContext.class)
-                .compose(u -> participantContextService.getParticipantContext(participantId))
-                .orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
+        return onEncoded(participantId)
+                .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, ParticipantContext.class)
+                        .compose(u -> participantContextService.getParticipantContext(decoded))
+                        .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
+                .orElseThrow(InvalidRequestException::new);
     }
 
     @Override
     @POST
     @Path("/{participantId}/token")
     public String regenerateToken(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
-        return authorizationService.isAuthorized(securityContext, participantId, ParticipantContext.class)
-                .compose(u -> participantContextService.regenerateApiToken(participantId))
-                .orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
+        return onEncoded(participantId)
+                .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, ParticipantContext.class)
+                        .compose(u -> participantContextService.regenerateApiToken(decoded))
+                        .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
+                .orElseThrow(InvalidRequestException::new);
     }
 
     @Override
@@ -89,12 +95,10 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Path("/{participantId}/state")
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     public void activateParticipant(@PathParam("participantId") String participantId, @QueryParam("isActive") boolean isActive) {
-        if (isActive) {
-            participantContextService.updateParticipant(participantId, ParticipantContext::activate);
-        } else {
-            participantContextService.updateParticipant(participantId, ParticipantContext::deactivate);
-        }
-
+        onEncoded(participantId)
+                .onSuccess(decoded -> participantContextService.updateParticipant(decoded, isActive ? ParticipantContext::activate : ParticipantContext::deactivate)
+                        .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
+                .orElseThrow(InvalidRequestException::new);
     }
 
     @Override
@@ -102,8 +106,10 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Path("/{participantId}")
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     public void deleteParticipant(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
-        participantContextService.deleteParticipantContext(participantId)
-                .orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
+        onEncoded(participantId)
+                .onSuccess(decoded -> participantContextService.deleteParticipantContext(decoded)
+                        .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
+                .orElseThrow(InvalidRequestException::new);
     }
 
     @Override
@@ -111,7 +117,10 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Path("/{participantId}/roles")
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     public void updateRoles(@PathParam("participantId") String participantId, List<String> roles) {
-        participantContextService.updateParticipant(participantId, participantContext -> participantContext.setRoles(roles)).orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
+        onEncoded(participantId)
+                .onSuccess(decoded -> participantContextService.updateParticipant(decoded, participantContext -> participantContext.setRoles(roles))
+                        .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
+                .orElseThrow(InvalidRequestException::new);
     }
 
     @GET

--- a/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
+++ b/extensions/api/participant-context-mgmt-api/src/test/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiControllerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -54,6 +55,9 @@ import static org.mockito.Mockito.when;
 
 @ApiTest
 class ParticipantContextApiControllerTest extends RestControllerTestBase {
+
+    private static final String PARTICIPANT_ID = "test-participant";
+    private static final String PARTICIPANT_ID_ENCODED = Base64.getUrlEncoder().encodeToString(PARTICIPANT_ID.getBytes());
 
     private final ParticipantContextService participantContextServiceMock = mock();
     private final AuthorizationService authService = mock();
@@ -85,7 +89,7 @@ class ParticipantContextApiControllerTest extends RestControllerTestBase {
         when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.notFound("foo bar"));
 
         baseRequest()
-                .get("/not-exist")
+                .get("/unknown")
                 .then()
                 .statusCode(404)
                 .log().ifError();
@@ -160,61 +164,61 @@ class ParticipantContextApiControllerTest extends RestControllerTestBase {
     void regenerateToken() {
         when(participantContextServiceMock.regenerateApiToken(any())).thenReturn(ServiceResult.success("new-api-token"));
         baseRequest()
-                .post("/test-participant/token")
+                .post("/%s/token".formatted(PARTICIPANT_ID_ENCODED))
                 .then()
                 .statusCode(200)
                 .body(equalTo("new-api-token"));
-        verify(participantContextServiceMock).regenerateApiToken(eq("test-participant"));
+        verify(participantContextServiceMock).regenerateApiToken(PARTICIPANT_ID);
     }
 
     @Test
     void regenerateToken_notFound() {
         when(participantContextServiceMock.regenerateApiToken(any())).thenReturn(ServiceResult.notFound("foo-bar"));
         baseRequest()
-                .post("/test-participant/token")
+                .post("/%s/token".formatted(PARTICIPANT_ID_ENCODED))
                 .then()
                 .statusCode(404);
-        verify(participantContextServiceMock).regenerateApiToken(eq("test-participant"));
+        verify(participantContextServiceMock).regenerateApiToken(PARTICIPANT_ID);
     }
 
     @Test
     void activateParticipant() {
         when(participantContextServiceMock.updateParticipant(any(), any())).thenReturn(ServiceResult.success());
         baseRequest()
-                .post("/test-participant/state?isActive=true")
+                .post("/%s/state?isActive=true".formatted(PARTICIPANT_ID_ENCODED))
                 .then()
                 .statusCode(204);
-        verify(participantContextServiceMock).updateParticipant(eq("test-participant"), any());
+        verify(participantContextServiceMock).updateParticipant(eq(PARTICIPANT_ID), any());
     }
 
     @Test
     void deactivateParticipant() {
         when(participantContextServiceMock.updateParticipant(any(), any())).thenReturn(ServiceResult.success());
         baseRequest()
-                .post("/test-participant/state?isActive=false")
+                .post("/%s/state?isActive=false".formatted(PARTICIPANT_ID_ENCODED))
                 .then()
                 .statusCode(204);
-        verify(participantContextServiceMock).updateParticipant(eq("test-participant"), any());
+        verify(participantContextServiceMock).updateParticipant(eq(PARTICIPANT_ID), any());
     }
 
     @Test
     void delete() {
         when(participantContextServiceMock.deleteParticipantContext(any())).thenReturn(ServiceResult.success());
         baseRequest()
-                .delete("/test-participant")
+                .delete("/%s".formatted(PARTICIPANT_ID_ENCODED))
                 .then()
                 .statusCode(204);
-        verify(participantContextServiceMock).deleteParticipantContext(eq("test-participant"));
+        verify(participantContextServiceMock).deleteParticipantContext(PARTICIPANT_ID);
     }
 
     @Test
     void delete_notFound() {
         when(participantContextServiceMock.deleteParticipantContext(any())).thenReturn(ServiceResult.notFound("foo bar"));
         baseRequest()
-                .delete("/test-participant")
+                .delete("/%s".formatted(PARTICIPANT_ID_ENCODED))
                 .then()
                 .statusCode(404);
-        verify(participantContextServiceMock).deleteParticipantContext(eq("test-participant"));
+        verify(participantContextServiceMock).deleteParticipantContext(PARTICIPANT_ID);
     }
 
     @Test

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/ParticipantContextId.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/ParticipantContextId.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2024 Amadeus.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi;
+
+import org.eclipse.edc.spi.result.Result;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class ParticipantContextId {
+
+    private ParticipantContextId() {
+    }
+
+    /**
+     * Decode a base64-url encoded participantId.
+     *
+     * @param encoded base64-url encoded participantId.
+     * @return human-readable participantId.
+     */
+    public static Result<String> onEncoded(String encoded) {
+        var bytes = Base64.getUrlDecoder().decode(encoded.getBytes());
+        return Result.success(new String(bytes, StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR changes behavior of the controllers to that the `participantId` passed in the request path segment is now assumed to be base64-url encoded. 

## Why it does that

Avoid collision when the actual `participantId` contains characters that should not be encoded when calling the APIs. 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
