### PR TITLE
fix: register VC get-all controller

### DIFF
--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/VerifiableCredentialApiExtension.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/VerifiableCredentialApiExtension.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.api.verifiablecredentials;
 
+import org.eclipse.edc.identityhub.api.verifiablecredentials.v1.GetAllCredentialsApiController;
 import org.eclipse.edc.identityhub.api.verifiablecredentials.v1.VerifiableCredentialsApiController;
 import org.eclipse.edc.identityhub.spi.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.ManagementApiConfiguration;
@@ -53,7 +54,9 @@ public class VerifiableCredentialApiExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         authorizationService.addLookupFunction(VerifiableCredentialResource.class, this::queryById);
         var controller = new VerifiableCredentialsApiController(credentialStore, authorizationService);
+        var getAllController = new GetAllCredentialsApiController(credentialStore);
         webService.registerResource(managementApiConfiguration.getContextAlias(), controller);
+        webService.registerResource(managementApiConfiguration.getContextAlias(), getAllController);
     }
 
     private ParticipantResource queryById(String credentialId) {

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/GetAllCredentialsApiController.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/GetAllCredentialsApiController.java
@@ -16,9 +16,11 @@ package org.eclipse.edc.identityhub.api.verifiablecredentials.v1;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import org.eclipse.edc.identityhub.spi.authentication.ServicePrincipal;
 import org.eclipse.edc.identityhub.spi.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
@@ -43,7 +45,8 @@ public class GetAllCredentialsApiController implements GetAllCredentialsApi {
     @GET
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     @Override
-    public Collection<VerifiableCredentialResource> getAll(Integer offset, Integer limit) {
+    public Collection<VerifiableCredentialResource> getAll(@DefaultValue("0") @QueryParam("offset") Integer offset,
+                                                           @DefaultValue("50") @QueryParam("limit") Integer limit) {
         var res = credentialStore.query(QuerySpec.Builder.newInstance().limit(limit).offset(offset).build());
         return ServiceResult.from(res).orElseThrow(exceptionMapper(VerifiableCredentialResource.class));
     }


### PR DESCRIPTION
## What this PR changes/adds

this PR correctly registers the "get-all" controller for VCs

## Why it does that

previously it had been forgotten.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
