### PR TITLE
fix: get audience from 'iss' claim instead of deprecated 'client_id'

### DIFF
--- a/core/identity-hub-api/build.gradle.kts
+++ b/core/identity-hub-api/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 
 dependencies {
     api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.jwt)
     api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
     implementation(libs.edc.spi.validator)

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApiController.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.resolution.CredentialQueryResolver;
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
 import org.eclipse.edc.identitytrust.model.credentialservice.PresentationQueryMessage;
+import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
@@ -114,7 +115,9 @@ public class PresentationApiController implements PresentationApi {
 
     private @Nullable String getAudience(String token) {
         try {
-            return Optional.ofNullable(SignedJWT.parse(token).getJWTClaimsSet().getClaim("client_id")).map(Object::toString).orElse(null);
+            return Optional.ofNullable(SignedJWT.parse(token).getJWTClaimsSet().getClaim(JwtRegisteredClaimNames.ISSUER))
+                    .map(Object::toString)
+                    .orElse(null);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ edc-jws2020 = { module = "org.eclipse.edc:jws2020", version.ref = "edc" }
 edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-common-crypto = { module = "org.eclipse.edc:crypto-common", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
+edc-spi-jwt = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-spi-policy-engine = { module = "org.eclipse.edc:policy-engine-spi", version.ref = "edc" }
 edc-spi-transaction = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }


### PR DESCRIPTION
## What this PR changes/adds

Read audience from `iss` claim instead of deprecated `client_id`.

## Why it does that

`client_id` is not used anymore.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #276 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
