### PR TITLE
fix: add missing `kid` header in `JwtPresentationGenerator`

### DIFF
--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/PresentationCreatorRegistryImpl.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/PresentationCreatorRegistryImpl.java
@@ -65,6 +65,6 @@ public class PresentationCreatorRegistryImpl implements PresentationCreatorRegis
             throw new EdcException("No active key pair found for participant '%s'".formatted(participantContextId));
         }
 
-        return (T) creator.generatePresentation(credentials, keyPair.getKeyId(), additionalData);
+        return (T) creator.generatePresentation(credentials, keyPair.getPrivateKeyAlias(), keyPair.getKeyId(), additionalData);
     }
 }

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/VerifiablePresentationServiceImpl.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/VerifiablePresentationServiceImpl.java
@@ -26,11 +26,16 @@ import org.eclipse.edc.spi.result.Result;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.nimbusds.jwt.JWTClaimNames.AUDIENCE;
 import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.identityhub.core.creators.LdpPresentationGenerator.TYPE_ADDITIONAL_DATA;
+import static org.eclipse.edc.identityhub.core.creators.PresentationGeneratorConstants.CONTROLLER_ADDITIONAL_DATA;
+import static org.eclipse.edc.identitytrust.VcConstants.VERIFIABLE_PRESENTATION_TYPE;
 import static org.eclipse.edc.identitytrust.model.CredentialFormat.JSON_LD;
 
 public class VerifiablePresentationServiceImpl implements VerifiablePresentationService {
@@ -73,15 +78,17 @@ public class VerifiablePresentationServiceImpl implements VerifiablePresentation
 
         var vpToken = new ArrayList<>();
 
-        Map<String, Object> additionalDataJwt = audience != null ? Map.of("aud", audience) : Map.of();
+        var additionalDataJwt = new HashMap<String, Object>();
+        ofNullable(audience).ifPresent(aud -> additionalDataJwt.put(AUDIENCE, audience));
+        additionalDataJwt.put(CONTROLLER_ADDITIONAL_DATA, participantContextId);
 
         if (defaultFormatVp == JSON_LD) { // LDP-VPs cannot contain JWT VCs
             if (!ldpVcs.isEmpty()) {
 
                 // todo: once we support PresentationDefinition, the types list could be dynamic
                 JsonObject ldpVp = registry.createPresentation(participantContextId, ldpVcs, CredentialFormat.JSON_LD, Map.of(
-                        "types", List.of("VerifiablePresentation"),
-                        "controller", participantContextId));
+                        TYPE_ADDITIONAL_DATA, List.of(VERIFIABLE_PRESENTATION_TYPE),
+                        CONTROLLER_ADDITIONAL_DATA, participantContextId));
                 vpToken.add(ldpVp);
             }
 

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/creators/JwtPresentationGenerator.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/creators/JwtPresentationGenerator.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.security.PrivateKeyResolver;
+import org.eclipse.edc.token.spi.KeyIdDecorator;
 import org.eclipse.edc.token.spi.TokenDecorator;
 import org.eclipse.edc.token.spi.TokenGenerationService;
 
@@ -36,10 +37,14 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static org.eclipse.edc.identityhub.core.creators.PresentationGeneratorConstants.CONTROLLER_ADDITIONAL_DATA;
+import static org.eclipse.edc.identityhub.core.creators.PresentationGeneratorConstants.VERIFIABLE_CREDENTIAL_PROPERTY;
+import static org.eclipse.edc.identityhub.core.creators.PresentationGeneratorConstants.VP_TYPE_PROPERTY;
 import static org.eclipse.edc.identityhub.spi.model.IdentityHubConstants.IATP_CONTEXT_URL;
 import static org.eclipse.edc.identityhub.spi.model.IdentityHubConstants.PRESENTATION_EXCHANGE_URL;
 import static org.eclipse.edc.identityhub.spi.model.IdentityHubConstants.VERIFIABLE_PRESENTATION_TYPE;
 import static org.eclipse.edc.identityhub.spi.model.IdentityHubConstants.W3C_CREDENTIALS_URL;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
@@ -74,38 +79,43 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
 
     /**
      * Will always throw an {@link UnsupportedOperationException}.
-     * Please use {@link JwtPresentationGenerator#generatePresentation(List, String, Map)} instead.
+     * Please use {@link JwtPresentationGenerator#generatePresentation(List, String, String, Map)} instead.
      */
     @Override
-    public String generatePresentation(List<VerifiableCredentialContainer> credentials, String keyId) {
-        throw new UnsupportedOperationException("Must provide additional data: 'aud'");
+    public String generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId) {
+        throw new UnsupportedOperationException("Must provide additional data: '%s' and '%s'".formatted(AUDIENCE, CONTROLLER_ADDITIONAL_DATA));
     }
 
     /**
      * Creates a presentation using the given Verifiable Credential Containers and additional data.
      *
-     * @param credentials    The list of Verifiable Credential Containers to include in the presentation.
-     * @param privateKeyId   The key ID of the private key to be used for generating the presentation.
-     * @param additionalData Additional data to include in the presentation. Must contain an entry 'aud'. Every entry in the map is added as a claim to the token.
+     * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
+     * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
+     * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
+     * @param additionalData  Additional data to include in the presentation. Must contain an entry 'aud'. Every entry in the map is added as a claim to the token.
      * @return The serialized JWT presentation.
      * @throws IllegalArgumentException      If the additional data does not contain the required 'aud' value or if no private key could be resolved for the key ID.
      * @throws UnsupportedOperationException If the private key does not provide any supported JWS algorithms.
      * @throws EdcException                  If signing the JWT fails.
      */
     @Override
-    public String generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyId, Map<String, Object> additionalData) {
+    public String generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, Map<String, Object> additionalData) {
 
         // check if expected data is there
-        if (!additionalData.containsKey("aud")) {
-            throw new IllegalArgumentException("Must provide additional data: 'aud'");
+        if (!additionalData.containsKey(AUDIENCE)) {
+            throw new IllegalArgumentException("Must provide additional data: '%s'".formatted(AUDIENCE));
+        }
+
+        if (!additionalData.containsKey(CONTROLLER_ADDITIONAL_DATA)) {
+            throw new IllegalArgumentException("Must provide additional data: '%s'".formatted(CONTROLLER_ADDITIONAL_DATA));
         }
 
         var rawVcs = credentials.stream().map(VerifiableCredentialContainer::rawVc);
-        Supplier<PrivateKey> privateKeySupplier = () -> privateKeyResolver.resolvePrivateKey(privateKeyId).orElseThrow(f -> new IllegalArgumentException(f.getFailureDetail()));
+        Supplier<PrivateKey> privateKeySupplier = () -> privateKeyResolver.resolvePrivateKey(privateKeyAlias).orElseThrow(f -> new IllegalArgumentException(f.getFailureDetail()));
         var tokenResult = tokenGenerationService.generate(privateKeySupplier, vpDecorator(rawVcs), tp -> {
             additionalData.forEach(tp::claims);
             return tp;
-        });
+        }, new KeyIdDecorator(additionalData.get(CONTROLLER_ADDITIONAL_DATA) + "#" + publicKeyId));
 
         return tokenResult.map(TokenRepresentation::getToken).orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
@@ -126,8 +136,8 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
 
         return Json.createObjectBuilder()
                 .add(JsonLdKeywords.CONTEXT, stringArray(List.of(IATP_CONTEXT_URL, W3C_CREDENTIALS_URL, PRESENTATION_EXCHANGE_URL)))
-                .add("type", VERIFIABLE_PRESENTATION_TYPE) // todo: add more types here?
-                .add("verifiableCredential", vcArray.build())
+                .add(VP_TYPE_PROPERTY, VERIFIABLE_PRESENTATION_TYPE) // todo: add more types here?
+                .add(VERIFIABLE_CREDENTIAL_PROPERTY, vcArray.build())
                 .build()
                 .toString();
     }

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/creators/PresentationGeneratorConstants.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/creators/PresentationGeneratorConstants.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.core.creators;
+
+/**
+ * Contains common constants for {@link LdpPresentationGenerator} and {@link JwtPresentationGenerator}.
+ */
+public interface PresentationGeneratorConstants {
+
+    String CONTROLLER_ADDITIONAL_DATA = "controller";
+
+    String VP_TYPE_PROPERTY = "type";
+
+    String VERIFIABLE_CREDENTIAL_PROPERTY = "verifiableCredential";
+
+}

--- a/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/PresentationCreatorRegistryImplTest.java
+++ b/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/PresentationCreatorRegistryImplTest.java
@@ -54,7 +54,7 @@ class PresentationCreatorRegistryImplTest {
         var generator = mock(PresentationGenerator.class);
         registry.addCreator(generator, CredentialFormat.JWT);
         assertThatNoException().isThrownBy(() -> registry.createPresentation(TEST_PARTICIPANT, List.of(), CredentialFormat.JWT, Map.of()));
-        verify(generator).generatePresentation(anyList(), eq(keyPair.getKeyId()), anyMap());
+        verify(generator).generatePresentation(anyList(), eq(keyPair.getPrivateKeyAlias()), eq(keyPair.getKeyId()), anyMap());
     }
 
     @Test
@@ -78,7 +78,10 @@ class PresentationCreatorRegistryImplTest {
         var generator = mock(PresentationGenerator.class);
         registry.addCreator(generator, CredentialFormat.JWT);
         assertThatNoException().isThrownBy(() -> registry.createPresentation(TEST_PARTICIPANT, List.of(), CredentialFormat.JWT, Map.of()));
-        verify(generator).generatePresentation(anyList(), argThat(s -> s.equals("key-1") || s.equals("key-2")), anyMap());
+        verify(generator).generatePresentation(anyList(),
+                argThat(s -> s.equals(keyPair1.getPrivateKeyAlias()) || s.equals(keyPair2.getPrivateKeyAlias())),
+                argThat(s -> s.equals(keyPair1.getKeyId()) || s.equals(keyPair2.getKeyId())),
+                anyMap());
     }
 
 
@@ -92,7 +95,7 @@ class PresentationCreatorRegistryImplTest {
         var generator = mock(PresentationGenerator.class);
         registry.addCreator(generator, CredentialFormat.JWT);
         assertThatNoException().isThrownBy(() -> registry.createPresentation(TEST_PARTICIPANT, List.of(), CredentialFormat.JWT, Map.of()));
-        verify(generator).generatePresentation(anyList(), eq("key-2"), anyMap());
+        verify(generator).generatePresentation(anyList(), eq(keyPair2.getPrivateKeyAlias()), eq(keyPair2.getKeyId()), anyMap());
     }
 
     @Test
@@ -113,6 +116,6 @@ class PresentationCreatorRegistryImplTest {
                 .keyId(keyId)
                 .state(KeyPairState.ACTIVE)
                 .isDefaultPair(true)
-                .privateKeyAlias(participantId + "-alias");
+                .privateKeyAlias("%s-%s-alias".formatted(participantId, keyId));
     }
 }

--- a/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/creators/PresentationGeneratorTest.java
+++ b/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/creators/PresentationGeneratorTest.java
@@ -29,7 +29,8 @@ import java.util.Map;
 
 abstract class PresentationGeneratorTest {
 
-    public static final String KEY_ID = "key-1";
+    public static final String PRIVATE_KEY_ALIAS = "private-key";
+    public static final String PUBLIC_KEY_ID = "key-1";
 
     @Test
     @DisplayName("Verify succesful creation of a JWT_VP")
@@ -45,7 +46,7 @@ abstract class PresentationGeneratorTest {
 
     @Test
     @DisplayName("Should throw an exception if no key is found for a key-id")
-    abstract void create_whenKeyNotFound();
+    abstract void create_whenPrivateKeyNotFound();
 
     @Test
     @DisplayName("Should throw an exception if the required additional data is missing")

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/generator/PresentationGenerator.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/generator/PresentationGenerator.java
@@ -26,23 +26,6 @@ import java.util.Map;
  */
 @FunctionalInterface
 public interface PresentationGenerator<T> {
-    /**
-     * Generates a Verifiable Presentation based on a list of Verifiable Credential Containers and a key ID. Implementors must
-     * use the key ID to resolve the private key used for signing. Recipients of the VP must use the key ID to resolve the public
-     * key for verification. How the public key is made available is out-of-scope here, but a popular method is DID documents.
-     * <p>
-     * Implementors must check whether all VCs can be represented in one <em>one</em> VP, and if not, must throw a {@link IllegalArgumentException}.
-     * <p>
-     * The concrete return type of the VP depends on the implementation, for example JWT VPs are represented as String, LDP VPs are represented
-     * as {@link jakarta.json.JsonObject}.
-     *
-     * @param credentials The list of Verifiable Credential Containers to include in the presentation.
-     * @param keyId       The key ID of the private key to be used for generating the presentation.
-     * @return The generated Verifiable Presentation. The concrete return type depends on the implementation.
-     * @throws IllegalArgumentException      If not all VCs can be represented in one VP.
-     * @throws UnsupportedOperationException If additional data is required by the implementation, or if specified key is not suitable for signing.
-     */
-    T generatePresentation(List<VerifiableCredentialContainer> credentials, String keyId);
 
     /**
      * Generates a Verifiable Presentation based on a list of Verifiable Credential Containers and a key ID. Implementors must
@@ -54,12 +37,33 @@ public interface PresentationGenerator<T> {
      * The concrete return type of the VP depends on the implementation, for example JWT VPs are represented as String, LDP VPs are represented
      * as {@link jakarta.json.JsonObject}.
      *
-     * @param credentials The list of Verifiable Credential Containers to include in the presentation.
-     * @param keyId       The key ID of the private key to be used for generating the presentation.
+     * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
+     * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
+     * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
+     * @return The generated Verifiable Presentation. The concrete return type depends on the implementation.
+     * @throws IllegalArgumentException      If not all VCs can be represented in one VP.
+     * @throws UnsupportedOperationException If additional data is required by the implementation, or if specified key is not suitable for signing.
+     */
+    T generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId);
+
+    /**
+     * Generates a Verifiable Presentation based on a list of Verifiable Credential Containers and a key ID. Implementors must
+     * use the key ID to resolve the private key used for signing. Recipients of the VP must use the key ID to resolve the public
+     * key for verification. How the public key is made available is out-of-scope here, but a popular method is DID documents.
+     * <p>
+     * Implementors must check whether all VCs can be represented in one <em>one</em> VP, and if not, must throw a {@link IllegalArgumentException}.
+     * <p>
+     * The concrete return type of the VP depends on the implementation, for example JWT VPs are represented as String, LDP VPs are represented
+     * as {@link jakarta.json.JsonObject}.
+     *
+     * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
+     * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
+     * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
+     * @param additionalData  Additional data used for validation.
      * @return The generated Verifiable Presentation. The concrete return type depends on the implementation.
      * @throws IllegalArgumentException If not all VCs can be represented in one VP, mandatory additional information was not given, or the specified key is not suitable for signing.
      */
-    default T generatePresentation(List<VerifiableCredentialContainer> credentials, String keyId, Map<String, Object> additionalData) {
-        return generatePresentation(credentials, keyId);
+    default T generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, Map<String, Object> additionalData) {
+        return generatePresentation(credentials, privateKeyAlias, publicKeyId);
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Add missing `kid` header in output of `JwtPresentationGenerator`.

## Why it does that

`kid` is used by the counterparty to resolve the public key required to validate the VP.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
