### PR TITLE
fix: use `type` and `credentialSubject` properties in `VerifiableCredential`

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -186,7 +186,6 @@ maven/mavencentral/net.sf.jopt-simple/jopt-simple/5.0.4, MIT, approved, CQ13174
 maven/mavencentral/net.sf.saxon/Saxon-HE/12.3, MPL-2.0-no-copyleft-exception AND (LicenseRef-scancode-proprietary-license AND MPL-2.0-no-copyleft-exception) AND (MPL-2.0-no-copyleft-exception AND X11) AND (MIT AND MPL-2.0-no-copyleft-exception) AND (MPL-1.0 AND MPL-2.0-no-copyleft-exception) AND (Apache-2.0 AND MPL-2.0-no-copyleft-exception) AND MPL-1.0, restricted, #13191
 maven/mavencentral/org.antlr/antlr4-runtime/4.11.1, BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
-maven/mavencentral/org.apache.commons/commons-compress/1.25.0, Apache-2.0, approved, #11600
 maven/mavencentral/org.apache.commons/commons-digester3/3.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.10, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.commons/commons-lang3/3.11, Apache-2.0, approved, CQ22642
@@ -375,13 +374,13 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.35, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.6, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/database-commons/1.19.4, Apache-2.0, approved, #10345
-maven/mavencentral/org.testcontainers/jdbc/1.19.4, Apache-2.0, approved, #10348
+maven/mavencentral/org.testcontainers/database-commons/1.19.5, Apache-2.0, approved, #10345
+maven/mavencentral/org.testcontainers/jdbc/1.19.5, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.3, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.4, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/postgresql/1.19.4, MIT, approved, #10350
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.5, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/postgresql/1.19.5, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.3, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.testcontainers/testcontainers/1.19.4, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/testcontainers/1.19.5, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/CredentialResourceLookup.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/CredentialResourceLookup.java
@@ -59,11 +59,9 @@ public class CredentialResourceLookup extends ReflectionPropertyLookup {
                 .collect(Collectors.joining("."));
         var subjects = credentialResource.getVerifiableCredential().credential().getCredentialSubject();
 
-        var claims = subjects.stream().map(subj -> ReflectionUtil.getFieldValue("claims." + credentialSubjectPath, subj))
+        return subjects.stream().map(subj -> ReflectionUtil.getFieldValue("claims." + credentialSubjectPath, subj))
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
-
-        return claims;
     }
 }

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformer.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/EdcScopeToCriterionTransformer.java
@@ -38,7 +38,7 @@ import static org.eclipse.edc.spi.result.Result.success;
  * <em>Do NOT use this in production code!</em>
  */
 public class EdcScopeToCriterionTransformer implements ScopeToCriterionTransformer {
-    public static final String TYPE_OPERAND = "verifiableCredential.credential.types";
+    public static final String TYPE_OPERAND = "verifiableCredential.credential.type";
     public static final String ALIAS_LITERAL = "org.eclipse.edc.vc.type";
     public static final String LIKE_OPERATOR = "like";
     public static final String CONTAINS_OPERATOR = "contains";

--- a/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/CredentialStoreTestBase.java
+++ b/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/CredentialStoreTestBase.java
@@ -155,7 +155,7 @@ public abstract class CredentialStoreTestBase {
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(new Criterion("participantId", "=", TEST_PARTICIPANT_CONTEXT_ID))
-                .filter(new Criterion("verifiableCredential.credential.types", "contains", "UniversityDegreeCredential"))
+                .filter(new Criterion("verifiableCredential.credential.type", "contains", "UniversityDegreeCredential"))
                 .build();
 
         var result = getStore().query(query);
@@ -236,7 +236,7 @@ public abstract class CredentialStoreTestBase {
         creds.forEach(getStore()::create);
 
         var query = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("verifiableCredential.credential.types", "contains", "TestType"))
+                .filter(new Criterion("verifiableCredential.credential.type", "contains", "TestType"))
                 .build();
 
         assertThat(getStore().query(query)).isSucceeded()


### PR DESCRIPTION
## What this PR changes/adds

Use class argument name and serialized name for the `type` and `credentialSubject` properties of the `VerifiableCredential` object.

## Why it does that

This is required to have a consistent way to query for a VC independently on the type of VC store (in-mem store uses reflection while PostgreSQL store will work on the serialized json structure.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
