### PR TITLE
fix: register sql keypairesource store

### DIFF
--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStoreExtension.java
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStoreExtension.java
@@ -14,7 +14,59 @@
 
 package org.eclipse.edc.identityhub.store.sql.keypair;
 
+import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
+import org.eclipse.edc.identityhub.store.sql.keypair.schema.postgres.PostgresDialectStatements;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
+import static org.eclipse.edc.identityhub.store.sql.keypair.SqlKeyPairResourceStoreExtension.NAME;
+
+@Extension(NAME)
 public class SqlKeyPairResourceStoreExtension implements ServiceExtension {
+    public static final String NAME = "KeyPair Resource SQL Store Extension";
+
+    @Setting(value = "Datasource name for the KeyPairResource database", defaultValue = DataSourceRegistry.DEFAULT_DATASOURCE)
+    public static final String DATASOURCE_SETTING_NAME = "edc.datasource.keypair.name";
+
+    @Inject
+    private DataSourceRegistry dataSourceRegistry;
+
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Inject
+    private TypeManager typemanager;
+
+    @Inject
+    private QueryExecutor queryExecutor;
+
+    @Inject(required = false)
+    private KeyPairResourceStoreStatements statements;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public KeyPairResourceStore createSqlStore(ServiceExtensionContext context) {
+        return new SqlKeyPairResourceStore(dataSourceRegistry, getDataSourceName(context), transactionContext, typemanager.getMapper(),
+                queryExecutor, getStatementImpl());
+    }
+
+    private KeyPairResourceStoreStatements getStatementImpl() {
+        return statements != null ? statements : new PostgresDialectStatements();
+    }
+
+    private String getDataSourceName(ServiceExtensionContext context) {
+        return context.getConfig().getString(DATASOURCE_SETTING_NAME, DataSourceRegistry.DEFAULT_DATASOURCE);
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR registers the `SqlKeyPairResourceStore` in the context

## Why it does that

It had been forgotten previously

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
