### PR TITLE
fix: set keypair to ACTIVE

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -42,8 +42,11 @@ maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.16.1, Apache-2.0, approve
 maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/4.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.cliftonlabs/json-simple/3.0.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.4, Apache-2.0, approved, #10346
+maven/mavencentral/com.github.docker-java/docker-java-api/3.3.5, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.4, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.5, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #7946
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.4, Apache-2.0, approved, #7942
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.5, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-or-later, approved, #2721
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #2719
@@ -78,7 +81,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
-maven/mavencentral/com.puppycrawl.tools/checkstyle/10.13.0, , restricted, clearlydefined
+maven/mavencentral/com.puppycrawl.tools/checkstyle/10.14.0, , restricted, clearlydefined
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
 maven/mavencentral/com.squareup.okhttp3/okhttp/4.12.0, Apache-2.0, approved, #11156
@@ -362,7 +365,7 @@ maven/mavencentral/org.ow2.asm/asm-commons/9.6, BSD-3-Clause, approved, #10775
 maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
 maven/mavencentral/org.ow2.asm/asm/9.1, BSD-3-Clause, approved, CQ23029
 maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
-maven/mavencentral/org.postgresql/postgresql/42.7.1, BSD-2-Clause AND Apache-2.0, approved, #11681
+maven/mavencentral/org.postgresql/postgresql/42.7.2, BSD-2-Clause AND Apache-2.0, approved, #11681
 maven/mavencentral/org.reflections/reflections/0.10.2, Apache-2.0 AND WTFPL, approved, clearlydefined
 maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
 maven/mavencentral/org.slf4j/slf4j-api/1.7.22, MIT, approved, CQ11943
@@ -373,13 +376,13 @@ maven/mavencentral/org.slf4j/slf4j-api/1.7.35, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368
 maven/mavencentral/org.slf4j/slf4j-api/2.0.6, MIT, approved, #5915
 maven/mavencentral/org.slf4j/slf4j-api/2.0.9, MIT, approved, #5915
-maven/mavencentral/org.testcontainers/database-commons/1.19.5, Apache-2.0, approved, #10345
-maven/mavencentral/org.testcontainers/jdbc/1.19.5, Apache-2.0, approved, #10348
+maven/mavencentral/org.testcontainers/database-commons/1.19.6, Apache-2.0, approved, #10345
+maven/mavencentral/org.testcontainers/jdbc/1.19.6, Apache-2.0, approved, #10348
 maven/mavencentral/org.testcontainers/junit-jupiter/1.19.3, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/junit-jupiter/1.19.5, MIT, approved, #10344
-maven/mavencentral/org.testcontainers/postgresql/1.19.5, MIT, approved, #10350
+maven/mavencentral/org.testcontainers/junit-jupiter/1.19.6, MIT, approved, #10344
+maven/mavencentral/org.testcontainers/postgresql/1.19.6, MIT, approved, #10350
 maven/mavencentral/org.testcontainers/testcontainers/1.19.3, Apache-2.0 AND MIT, approved, #10347
-maven/mavencentral/org.testcontainers/testcontainers/1.19.5, Apache-2.0 AND MIT, approved, #10347
+maven/mavencentral/org.testcontainers/testcontainers/1.19.6, Apache-2.0 AND MIT, approved, #10347
 maven/mavencentral/org.xmlresolver/xmlresolver/5.2.2, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.xmlunit/xmlunit-placeholders/2.9.1, Apache-2.0, approved, clearlydefined

--- a/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApi.java
+++ b/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApi.java
@@ -82,6 +82,22 @@ public interface KeyPairResourceApi {
     )
     void addKeyPair(String participantId, KeyDescriptor keyDescriptor, boolean makeDefault, SecurityContext securityContext);
 
+
+    @Tag(name = "KeyPairResources Management API")
+    @Operation(description = "Sets a KeyPairResource to the ACTIVE state. Will fail if the current state is anything other than ACTIVE or CREATED.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The KeyPairResource.",
+                            content = @Content(schema = @Schema(implementation = ParticipantContext.class))),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
+                    @ApiResponse(responseCode = "404", description = "A KeyPairResource with the given ID does not exist.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
+            }
+    )
+    void setActive(String keyPairResourceId, SecurityContext securityContext);
+
     @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Rotates (=retires) a particular key pair, identified by their ID and optionally create a new successor key.",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = KeyDescriptor.class), mediaType = "application/json")),

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/KeyPairService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/KeyPairService.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi;
 
 import org.eclipse.edc.identityhub.spi.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.model.KeyPairState;
 import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -67,4 +68,12 @@ public interface KeyPairService {
     ServiceResult<Void> revokeKey(String id, @Nullable KeyDescriptor newKeySpec);
 
     ServiceResult<Collection<KeyPairResource>> query(QuerySpec querySpec);
+
+    /**
+     * Sets a key pair to the {@link KeyPairState#ACTIVE} state.
+     *
+     * @param keyPairResourceId The ID of the {@link KeyPairResource}
+     * @return return a failure if the key pair resource is not in either {@link KeyPairState#CREATED} or {@link KeyPairState#ACTIVE}
+     */
+    ServiceResult<Void> activate(String keyPairResourceId);
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/KeyPairResource.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/KeyPairResource.java
@@ -119,6 +119,10 @@ public class KeyPairResource extends ParticipantResource {
         defaultPair = false;
     }
 
+    public void activate() {
+        state = KeyPairState.ACTIVE.code();
+    }
+
     public static final class Builder extends ParticipantResource.Builder<KeyPairResource, KeyPairResource.Builder> {
 
         private Builder() {
@@ -142,6 +146,13 @@ public class KeyPairResource extends ParticipantResource {
         @Override
         public Builder self() {
             return this;
+        }
+
+        public KeyPairResource build() {
+            if (entity.useDuration == 0) {
+                entity.useDuration = Duration.ofDays(6 * 30).toMillis();
+            }
+            return super.build();
         }
 
         public Builder timestamp(long timestamp) {
@@ -187,13 +198,6 @@ public class KeyPairResource extends ParticipantResource {
         public Builder state(KeyPairState state) {
             entity.state = state.code();
             return this;
-        }
-
-        public KeyPairResource build() {
-            if (entity.useDuration == 0) {
-                entity.useDuration = Duration.ofDays(6 * 30).toMillis();
-            }
-            return super.build();
         }
     }
 }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/model/participant/KeyDescriptor.java
@@ -39,6 +39,7 @@ public class KeyDescriptor {
     private Map<String, Object> publicKeyJwk;
     private String publicKeyPem;
     private Map<String, Object> keyGeneratorParams;
+    private boolean isActive = true;
 
     private KeyDescriptor() {
     }
@@ -88,6 +89,15 @@ public class KeyDescriptor {
         return keyGeneratorParams;
     }
 
+    /**
+     * Determines whether the new key should be set to {@link org.eclipse.edc.identityhub.spi.model.KeyPairState#ACTIVE}.
+     * If this is set to {@code false}, the key pair will be created in the {@link org.eclipse.edc.identityhub.spi.model.KeyPairState#CREATED} state.
+     * Defaults to {@code true}.
+     */
+    public boolean isActive() {
+        return isActive;
+    }
+
 
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
@@ -129,6 +139,11 @@ public class KeyDescriptor {
 
         public Builder keyGeneratorParams(Map<String, Object> keyGeneratorParams) {
             keyDescriptor.keyGeneratorParams = keyGeneratorParams;
+            return this;
+        }
+
+        public Builder active(boolean isActive) {
+            keyDescriptor.isActive = isActive;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR fixes the handling of the KeyPairResource's ACTIVE state

## Why it does that

There was no way to move the key pair to the ACTIVE state before.

## Further notes



## Linked Issue(s)

Closes #284

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
