### PR TITLE
fix: make InMem- and SQL stores behave the same

### DIFF
--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/InMemoryEntityStore.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/InMemoryEntityStore.java
@@ -74,8 +74,7 @@ abstract class InMemoryEntityStore<T> {
         lock.readLock().lock();
         try {
             // if no filter is present, we return true
-            Predicate<Object> fallback = querySpec.getFilterExpression().isEmpty() ? x -> true : x -> false;
-            var result = queryResolver.query(store.values().stream(), querySpec, Predicate::or, fallback);
+            var result = queryResolver.query(store.values().stream(), querySpec, Predicate::and, x -> true);
             return success(result.toList());
         } finally {
             lock.readLock().unlock();

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -27,12 +27,12 @@ import org.eclipse.edc.identityhub.spi.events.keypair.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextCreated;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextUpdated;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -311,7 +311,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     }
 
     private Collection<DidResource> findByParticipantId(String participantId) {
-        return didResourceStore.query(QuerySpec.Builder.newInstance().filter(new Criterion("participantId", "=", participantId)).build());
+        return didResourceStore.query(ParticipantResource.queryByParticipantId(participantId).build());
     }
 
 

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -16,11 +16,11 @@ package org.eclipse.edc.identityhub.participantcontext;
 
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.events.participant.ParticipantContextObservable;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContextState;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
-import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.Vault;
@@ -73,7 +73,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     @Override
     public ServiceResult<ParticipantContext> getParticipantContext(String participantId) {
         return transactionContext.execute(() -> {
-            var res = participantContextStore.query(QuerySpec.Builder.newInstance().filter(new Criterion("participantId", "=", participantId)).build());
+            var res = participantContextStore.query(ParticipantResource.queryByParticipantId(participantId).build());
             if (res.succeeded()) {
                 return res.getContent().stream().findFirst()
                         .map(ServiceResult::success)
@@ -149,7 +149,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     }
 
     private ParticipantContext findByIdInternal(String participantId) {
-        var resultStream = participantContextStore.query(QuerySpec.Builder.newInstance().filter(new Criterion("participantId", "=", participantId)).build());
+        var resultStream = participantContextStore.query(ParticipantResource.queryByParticipantId(participantId).build());
         if (resultStream.failed()) return null;
         return resultStream.getContent().stream().findFirst().orElse(null);
     }

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ManagementApiEndToEndTest.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.identityhub.participantcontext.ApiTokenGenerator;
 import org.eclipse.edc.identityhub.spi.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.authentication.ServicePrincipal;
 import org.eclipse.edc.identityhub.spi.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantManifest;
@@ -96,9 +97,8 @@ public abstract class ManagementApiEndToEndTest {
     }
 
     protected Collection<KeyPairResource> getKeyPairsForParticipant(String participantId) {
-        return getService(KeyPairResourceStore.class).query(QuerySpec.Builder.newInstance()
-                .filter(new Criterion("participantId", "=", participantId))
-                .build()).getContent();
+        return getService(KeyPairResourceStore.class).query(ParticipantResource.queryByParticipantId(participantId).build())
+                .getContent();
     }
 
     protected Collection<DidDocument> getDidForParticipant(String participantId) {

--- a/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApiController.java
+++ b/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApiController.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.identityhub.api.v1.validation.KeyDescriptorValidator;
 import org.eclipse.edc.identityhub.spi.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.KeyPairService;
 import org.eclipse.edc.identityhub.spi.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.model.participant.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.spi.EdcException;
@@ -80,7 +81,7 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
     @Override
     public Collection<KeyPairResource> findForParticipant(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
         return onEncoded(participantId).map(decoded -> {
-            var query = QuerySpec.Builder.newInstance().filter(new Criterion("participantId", "=", decoded)).build();
+            var query = ParticipantResource.queryByParticipantId(decoded).build();
             return keyPairService.query(query).orElseThrow(exceptionMapper(KeyPairResource.class, decoded)).stream().filter(kpr -> authorizationService.isAuthorized(securityContext, kpr.getId(), KeyPairResource.class).succeeded()).toList();
         }).orElseThrow(InvalidRequestException::new);
     }

--- a/spi/identity-hub-did-spi/src/testFixtures/java/org/eclipse/edc/identityhub/did/store/test/DidResourceStoreTestBase.java
+++ b/spi/identity-hub-did-spi/src/testFixtures/java/org/eclipse/edc/identityhub/did/store/test/DidResourceStoreTestBase.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
 import org.eclipse.edc.identithub.did.spi.model.DidResource;
 import org.eclipse.edc.identithub.did.spi.model.DidState;
 import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.spi.message.Range;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -158,7 +159,7 @@ public abstract class DidResourceStoreTestBase {
         dids.add(expected);
         dids.forEach(getStore()::save);
 
-        var q = QuerySpec.Builder.newInstance().filter(new Criterion("participantId", "=", expected.getParticipantId())).build();
+        var q = ParticipantResource.queryByParticipantId(expected.getParticipantId()).build();
         Assertions.assertThat(getStore().query(q))
                 .hasSize(1)
                 .usingRecursiveFieldByFieldElementComparator()

--- a/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/CredentialStoreTestBase.java
+++ b/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/CredentialStoreTestBase.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.store.test;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.model.VcState;
 import org.eclipse.edc.identityhub.spi.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
@@ -133,8 +134,7 @@ public abstract class CredentialStoreTestBase {
                         .build())
                 .forEach(getStore()::create);
 
-        var query = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("participantId", "=", "participant2"))
+        var query = ParticipantResource.queryByParticipantId("participant2")
                 .build();
 
         assertThat(getStore().query(query)).isSucceeded()
@@ -153,8 +153,7 @@ public abstract class CredentialStoreTestBase {
 
         Arrays.asList(cred1, cred2, cred3).forEach(getStore()::create);
 
-        var query = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("participantId", "=", TEST_PARTICIPANT_CONTEXT_ID))
+        var query = ParticipantResource.queryByParticipantId(TEST_PARTICIPANT_CONTEXT_ID)
                 .filter(new Criterion("verifiableCredential.credential.type", "contains", "UniversityDegreeCredential"))
                 .build();
 

--- a/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/ParticipantContextStoreTestBase.java
+++ b/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/ParticipantContextStoreTestBase.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.store.test;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.edc.identityhub.spi.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.model.participant.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.spi.query.Criterion;
@@ -57,8 +58,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .mapToObj(i -> createParticipantContextBuilder().participantId("id" + i).build())
                 .forEach(getStore()::create);
 
-        var query = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("participantId", "=", "id2"))
+        var query = ParticipantResource.queryByParticipantId("id2")
                 .build();
 
         assertThat(getStore().query(query)).isSucceeded()
@@ -106,8 +106,7 @@ public abstract class ParticipantContextStoreTestBase {
 
         resources.forEach(getStore()::create);
 
-        var query = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("participantId", "=", "id7"))
+        var query = ParticipantResource.queryByParticipantId("id7")
                 .build();
         var res = getStore().query(query);
         assertThat(res).isSucceeded();


### PR DESCRIPTION
## What this PR changes/adds

This PR adapts the behaviour of the `InMem-` stores so that it is identical to the `Sql-` stores. 

In particular, the in-mem stores joined multiple `Criterion` filters with a logical _or_, whereas the SQL stores 
use an _and_. 

## Why it does that

Achieve identical behaviour.

## Further notes

- I updated some files to use the `ParticipantResource.queryByParticipantId()` factory method to query by participant ID.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
