### PR TITLE
docs: prevent collision in operation names in IdentityHub management API

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -178,9 +178,10 @@ maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.1, (CDDL-1.1 OR GPL-2.0 WITH Cl
 maven/mavencentral/joda-time/joda-time/2.10.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.1, Apache-2.0, approved, #7164
-maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.11, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.12, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.1, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.11, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.12, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #6709
 maven/mavencentral/net.javacrumbs.json-unit/json-unit-core/2.36.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/net.minidev/accessors-smart/2.4.7, Apache-2.0, approved, #7515
@@ -356,8 +357,8 @@ maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.15, CDDL-1.1 OR GPL-2.0-only 
 maven/mavencentral/org.mock-server/mockserver-client-java/5.15.0, Apache-2.0 AND LGPL-3.0-only, approved, #9324
 maven/mavencentral/org.mock-server/mockserver-core/5.15.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.mock-server/mockserver-netty/5.15.0, Apache-2.0, approved, #9276
+maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
 maven/mavencentral/org.mockito/mockito-core/5.2.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #7401
-maven/mavencentral/org.mockito/mockito-core/5.9.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #12774
 maven/mavencentral/org.mozilla/rhino/1.7.7.2, MPL-2.0 AND BSD-3-Clause AND ISC, approved, CQ16320
 maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713

--- a/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
+++ b/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApi.java
@@ -36,10 +36,11 @@ import java.util.Collection;
 
 @OpenAPIDefinition(
         info = @Info(description = "This is the Management API for DID documents", title = "DID Management API", version = "1"))
+@Tag(name = "DID")
 public interface DidManagementApi {
 
-    @Tag(name = "DID Management API")
     @Operation(description = "Publish an (existing) DID document. The DID is expected to exist in the database.",
+            operationId = "publishDid",
             parameters = {@Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)},
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
             responses = {
@@ -52,8 +53,8 @@ public interface DidManagementApi {
     )
     void publishDid(DidRequestPayload didRequestPayload, SecurityContext securityContext);
 
-    @Tag(name = "DID Management API")
     @Operation(description = "Un-Publish an (existing) DID document. The DID is expected to exist in the database.",
+            operationId = "unpublishDid",
             parameters = {@Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)},
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
             responses = {
@@ -66,10 +67,10 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void unpublishDidFromBody(DidRequestPayload didRequestPayload, SecurityContext securityContext);
+    void unpublishDid(DidRequestPayload didRequestPayload, SecurityContext securityContext);
 
-    @Tag(name = "DID Management API")
-    @Operation(description = "Query for DID documents..",
+    @Operation(description = "Query for DID documents.",
+            operationId = "queryDids",
             parameters = {@Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)},
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
             responses = {
@@ -81,10 +82,10 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<DidDocument> queryDid(QuerySpec querySpec, SecurityContext securityContext);
+    Collection<DidDocument> queryDids(QuerySpec querySpec, SecurityContext securityContext);
 
-    @Tag(name = "DID Management API")
     @Operation(description = "Get state of a DID document",
+            operationId = "getDidState",
             parameters = {@Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)},
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = DidRequestPayload.class), mediaType = "application/json")),
             responses = {
@@ -95,10 +96,10 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    String getState(DidRequestPayload request, SecurityContext securityContext);
+    String getDidState(DidRequestPayload request, SecurityContext securityContext);
 
-    @Tag(name = "DID Management API")
     @Operation(description = "Adds a service endpoint to a particular DID document.",
+            operationId = "addDidEndpoint",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
             parameters = {
                     @Parameter(name = "autoPublish", description = "Whether the DID should get republished after the removal. Defaults to false."),
@@ -114,10 +115,10 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void addEndpoint(String did, Service service, boolean autoPublish, SecurityContext securityContext);
+    void addDidEndpoint(String did, Service service, boolean autoPublish, SecurityContext securityContext);
 
-    @Tag(name = "DID Management API")
     @Operation(description = "Replaces a service endpoint of a particular DID document.",
+            operationId = "replaceDidEndpoint",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = Service.class), mediaType = "application/json")),
             parameters = {
                     @Parameter(name = "autoPublish", description = "Whether the DID should get republished after the removal. Defaults to false."),
@@ -133,10 +134,10 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void replaceEndpoint(String did, Service service, boolean autoPublish, SecurityContext securityContext);
+    void replaceDidEndpoint(String did, Service service, boolean autoPublish, SecurityContext securityContext);
 
-    @Tag(name = "DID Management API")
     @Operation(description = "Removes a service endpoint from a particular DID document.",
+            operationId = "deleteDidEndpoint",
             parameters = {
                     @Parameter(name = "serviceId", description = "The ID of the service that should get removed"),
                     @Parameter(name = "autoPublish", description = "Whether the DID should " + "get republished after the removal. Defaults to false."),
@@ -152,6 +153,6 @@ public interface DidManagementApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void removeEndpoint(String did, String serviceId, boolean autoPublish, SecurityContext securityContext);
+    void deleteDidEndpoint(String did, String serviceId, boolean autoPublish, SecurityContext securityContext);
 
 }

--- a/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiController.java
+++ b/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/DidManagementApiController.java
@@ -63,7 +63,7 @@ public class DidManagementApiController implements DidManagementApi {
     @Override
     @POST
     @Path("/unpublish")
-    public void unpublishDidFromBody(DidRequestPayload didRequestPayload, @Context SecurityContext securityContext) {
+    public void unpublishDid(DidRequestPayload didRequestPayload, @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, didRequestPayload.did(), DidResource.class)
                 .compose(u -> documentService.unpublish(didRequestPayload.did()))
                 .orElseThrow(exceptionMapper(DidDocument.class, didRequestPayload.did()));
@@ -73,7 +73,7 @@ public class DidManagementApiController implements DidManagementApi {
     @POST
     @Path("/query")
     @Override
-    public Collection<DidDocument> queryDid(QuerySpec querySpec, @Context SecurityContext securityContext) {
+    public Collection<DidDocument> queryDids(QuerySpec querySpec, @Context SecurityContext securityContext) {
         return documentService.queryDocuments(querySpec)
                 .orElseThrow(exceptionMapper(DidDocument.class, null))
                 .stream().filter(dd -> authorizationService.isAuthorized(securityContext, dd.getId(), DidResource.class).succeeded())
@@ -83,7 +83,7 @@ public class DidManagementApiController implements DidManagementApi {
     @Override
     @POST
     @Path("/state")
-    public String getState(DidRequestPayload request, @Context SecurityContext securityContext) {
+    public String getDidState(DidRequestPayload request, @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, request.did(), DidResource.class)
                 .orElseThrow(exceptionMapper(DidResource.class, request.did()));
         var byId = documentService.findById(request.did());
@@ -93,8 +93,8 @@ public class DidManagementApiController implements DidManagementApi {
     @Override
     @POST
     @Path("/{did}/endpoints")
-    public void addEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish,
-                            @Context SecurityContext securityContext) {
+    public void addDidEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish,
+                               @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, did, DidResource.class)
                 .compose(u -> documentService.addService(did, service))
                 .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
@@ -104,8 +104,8 @@ public class DidManagementApiController implements DidManagementApi {
     @Override
     @PATCH
     @Path("/{did}/endpoints")
-    public void replaceEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish,
-                                @Context SecurityContext securityContext) {
+    public void replaceDidEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish,
+                                   @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, did, DidResource.class)
                 .compose(u -> documentService.replaceService(did, service))
                 .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
@@ -115,8 +115,8 @@ public class DidManagementApiController implements DidManagementApi {
     @Override
     @DELETE
     @Path("/{did}/endpoints")
-    public void removeEndpoint(@PathParam("did") String did, @QueryParam("serviceId") String serviceId, @QueryParam("autoPublish") boolean autoPublish,
-                               @Context SecurityContext securityContext) {
+    public void deleteDidEndpoint(@PathParam("did") String did, @QueryParam("serviceId") String serviceId, @QueryParam("autoPublish") boolean autoPublish,
+                                  @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, did, DidResource.class)
                 .compose(u -> documentService.removeService(did, serviceId))
                 .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())

--- a/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/GetAllDidsApi.java
+++ b/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/GetAllDidsApi.java
@@ -30,10 +30,12 @@ import java.util.Collection;
 
 @OpenAPIDefinition(
         info = @Info(description = "This is the Management API for DID documents", title = "DID Management API", version = "1"))
+@Tag(name = "DID")
 public interface GetAllDidsApi {
 
-    @Tag(name = "DID Management API")
+
     @Operation(description = "Get all DID documents across all Participant Contexts. Requires elevated access.",
+            operationId = "getAllDids",
             parameters = {
                     @Parameter(name = "offset", description = "the paging offset. defaults to 0"),
                     @Parameter(name = "limit", description = "the page size. defaults to 50")},
@@ -46,5 +48,5 @@ public interface GetAllDidsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<DidDocument> getAll(Integer offset, Integer limit);
+    Collection<DidDocument> getAllDids(Integer offset, Integer limit);
 }

--- a/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/GetAllDidsApiController.java
+++ b/extensions/api/did-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/GetAllDidsApiController.java
@@ -45,8 +45,8 @@ public class GetAllDidsApiController implements GetAllDidsApi {
     @Override
     @GET
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
-    public Collection<DidDocument> getAll(@DefaultValue("0") @QueryParam("offset") Integer offset,
-                                          @DefaultValue("50") @QueryParam("limit") Integer limit) {
+    public Collection<DidDocument> getAllDids(@DefaultValue("0") @QueryParam("offset") Integer offset,
+                                              @DefaultValue("50") @QueryParam("limit") Integer limit) {
         if (offset < 0 || limit < 0) {
             throw new InvalidRequestException("offset and limit must be > 0");
         }

--- a/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/GetAllKeyPairsApi.java
+++ b/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/GetAllKeyPairsApi.java
@@ -14,8 +14,10 @@
 
 package org.eclipse.edc.identityhub.api.keypair.v1;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,10 +28,14 @@ import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.Collection;
 
+
+@OpenAPIDefinition(info = @Info(description = "This is the Management API for KeyPairResources", title = "KeyPairResources Management API", version = "1"))
+@Tag(name = "Key Pairs")
 public interface GetAllKeyPairsApi {
 
-    @Tag(name = "KeyPairResources Management API")
+
     @Operation(description = "Get all KeyPair resources across all Participant Contexts. Requires elevated access.",
+            operationId = "getAllKeyPairs",
             parameters = {
                     @Parameter(name = "offset", description = "the paging offset. defaults to 0"),
                     @Parameter(name = "limit", description = "the page size. defaults to 50")},
@@ -42,5 +48,5 @@ public interface GetAllKeyPairsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<KeyPairResource> getAll(Integer offset, Integer limit);
+    Collection<KeyPairResource> getAllKeyPairs(Integer offset, Integer limit);
 }

--- a/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/GetAllKeyPairsApiController.java
+++ b/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/GetAllKeyPairsApiController.java
@@ -45,8 +45,8 @@ public class GetAllKeyPairsApiController implements GetAllKeyPairsApi {
     @GET
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     @Override
-    public Collection<KeyPairResource> getAll(@DefaultValue("0") @QueryParam("offset") Integer offset,
-                                              @DefaultValue("50") @QueryParam("limit") Integer limit) {
+    public Collection<KeyPairResource> getAllKeyPairs(@DefaultValue("0") @QueryParam("offset") Integer offset,
+                                                      @DefaultValue("50") @QueryParam("limit") Integer limit) {
         return keyPairService.query(QuerySpec.Builder.newInstance().offset(offset).limit(limit).build())
                 .orElseThrow(exceptionMapper(KeyPairResource.class));
     }

--- a/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApi.java
+++ b/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApi.java
@@ -34,10 +34,11 @@ import org.eclipse.edc.web.spi.ApiErrorDetail;
 import java.util.Collection;
 
 @OpenAPIDefinition(info = @Info(description = "This is the Management API for KeyPairResources", title = "KeyPairResources Management API", version = "1"))
+@Tag(name = "Key Pairs")
 public interface KeyPairResourceApi {
 
-    @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Finds a KeyPairResource by ID.",
+            operationId = "getKeyPair",
             parameters = {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)
             },
@@ -52,10 +53,10 @@ public interface KeyPairResourceApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    KeyPairResource findById(String id, SecurityContext securityContext);
+    KeyPairResource getKeyPair(String id, SecurityContext securityContext);
 
-    @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Finds all KeyPairResources for a particular ParticipantContext.",
+            operationId = "queryKeyPairByParticipantId",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The KeyPairResource.",
                             content = @Content(schema = @Schema(implementation = ParticipantContext.class))),
@@ -67,10 +68,10 @@ public interface KeyPairResourceApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    Collection<KeyPairResource> findForParticipant(String participantId, SecurityContext securityContext);
+    Collection<KeyPairResource> queryKeyPairByParticipantId(String participantId, SecurityContext securityContext);
 
-    @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Adds a new key pair to a ParticipantContext. Note that the key pair is either generated, or the private key is expected to be found in the vault.",
+            operationId = "addKeyPair",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = KeyDescriptor.class), mediaType = "application/json")),
             parameters = @Parameter(name = "makeDefault", description = "Make the new key pair the default key pair"),
             responses = {
@@ -87,8 +88,8 @@ public interface KeyPairResourceApi {
     void addKeyPair(String participantId, KeyDescriptor keyDescriptor, boolean makeDefault, SecurityContext securityContext);
 
 
-    @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Sets a KeyPairResource to the ACTIVE state. Will fail if the current state is anything other than ACTIVE or CREATED.",
+            operationId = "activateKeyPair",
             parameters = {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)
             },
@@ -103,10 +104,10 @@ public interface KeyPairResourceApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void setActive(String keyPairResourceId, SecurityContext securityContext);
+    void activateKeyPair(String keyPairResourceId, SecurityContext securityContext);
 
-    @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Rotates (=retires) a particular key pair, identified by their ID and optionally create a new successor key.",
+            operationId = "rotateKeyPair",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = KeyDescriptor.class), mediaType = "application/json")),
             parameters = {
                     @Parameter(name = "duration", description = "Indicates for how long the public key of the rotated/retired key pair should still be available "),
@@ -125,8 +126,8 @@ public interface KeyPairResourceApi {
     )
     void rotateKeyPair(String id, KeyDescriptor newKey, long duration, SecurityContext securityContext);
 
-    @Tag(name = "KeyPairResources Management API")
     @Operation(description = "Revokes (=removes) a particular key pair, identified by their ID and create a new successor key.",
+            operationId = "revokeKeyPair",
             parameters = {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)
             },
@@ -142,7 +143,7 @@ public interface KeyPairResourceApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void revokeKey(String id, KeyDescriptor newKey, SecurityContext securityContext);
+    void revokeKeyPair(String id, KeyDescriptor newKey, SecurityContext securityContext);
 
 
 }

--- a/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApiController.java
+++ b/extensions/api/keypair-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/KeyPairResourceApiController.java
@@ -63,7 +63,7 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
     @GET
     @Path("/{keyPairId}")
     @Override
-    public KeyPairResource findById(@PathParam("keyPairId") String id, @Context SecurityContext securityContext) {
+    public KeyPairResource getKeyPair(@PathParam("keyPairId") String id, @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, id, KeyPairResource.class).orElseThrow(exceptionMapper(KeyPairResource.class, id));
 
         var query = QuerySpec.Builder.newInstance().filter(new Criterion("id", "=", id)).build();
@@ -79,7 +79,7 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
 
     @GET
     @Override
-    public Collection<KeyPairResource> findForParticipant(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
+    public Collection<KeyPairResource> queryKeyPairByParticipantId(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
         return onEncoded(participantId).map(decoded -> {
             var query = ParticipantResource.queryByParticipantId(decoded).build();
             return keyPairService.query(query).orElseThrow(exceptionMapper(KeyPairResource.class, decoded)).stream().filter(kpr -> authorizationService.isAuthorized(securityContext, kpr.getId(), KeyPairResource.class).succeeded()).toList();
@@ -101,7 +101,7 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
     @POST
     @Path("/{keyPairId}/activate")
     @Override
-    public void setActive(@PathParam("keyPairId") String keyPairResourceId, @Context SecurityContext context) {
+    public void activateKeyPair(@PathParam("keyPairId") String keyPairResourceId, @Context SecurityContext context) {
         authorizationService.isAuthorized(context, keyPairResourceId, KeyPairResource.class).compose(u -> keyPairService.activate(keyPairResourceId)).orElseThrow(exceptionMapper(KeyPairResource.class, keyPairResourceId));
 
     }
@@ -119,7 +119,7 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
     @POST
     @Path("/{keyPairId}/revoke")
     @Override
-    public void revokeKey(@PathParam("keyPairId") String id, KeyDescriptor newKey, @Context SecurityContext securityContext) {
+    public void revokeKeyPair(@PathParam("keyPairId") String id, KeyDescriptor newKey, @Context SecurityContext securityContext) {
         if (newKey != null) {
             keyDescriptorValidator.validate(newKey).orElseThrow(ValidationFailureException::new);
         }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApi.java
@@ -33,10 +33,12 @@ import java.util.Collection;
 import java.util.List;
 
 @OpenAPIDefinition(info = @Info(description = "This is the Management API for ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
+@Tag(name = "Participant Context")
 public interface ParticipantContextApi {
 
-    @Tag(name = "ParticipantContext Management API")
+
     @Operation(description = "Creates a new ParticipantContext object.",
+            operationId = "createParticipant",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The ParticipantContext was created successfully, its API token is returned in the response body."),
@@ -51,8 +53,8 @@ public interface ParticipantContextApi {
     String createParticipant(ParticipantManifest manifest);
 
 
-    @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Gets ParticipantContexts by ID.",
+            operationId = "getParticipant",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The list of ParticipantContexts.",
                             content = @Content(schema = @Schema(implementation = ParticipantContext.class))),
@@ -66,8 +68,8 @@ public interface ParticipantContextApi {
     )
     ParticipantContext getParticipant(String participantId, SecurityContext securityContext);
 
-    @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Regenerates the API token for a ParticipantContext and returns the new token.",
+            operationId = "regenerateParticipantToken",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The API token was regenerated successfully", content = {@Content(schema = @Schema(implementation = String.class))}),
@@ -79,10 +81,10 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    String regenerateToken(String participantId, SecurityContext securityContext);
+    String regenerateParticipantToken(String participantId, SecurityContext securityContext);
 
-    @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Activates a ParticipantContext. This operation is idempotent, i.e. activating an already active ParticipantContext is a NOOP.",
+            operationId = "activateParticipant",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
             parameters = {@Parameter(name = "isActive", description = "Whether the participantContext should be activated or deactivated. Defaults to 'false'")},
             responses = {
@@ -97,8 +99,8 @@ public interface ParticipantContextApi {
     )
     void activateParticipant(String participantId, boolean isActive);
 
-    @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Delete a ParticipantContext.",
+            operationId = "deleteParticipant",
             responses = {
                     @ApiResponse(responseCode = "200", description = "The ParticipantContext was deleted successfully", content = {@Content(schema = @Schema(implementation = String.class))}),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
@@ -111,8 +113,8 @@ public interface ParticipantContextApi {
     )
     void deleteParticipant(String participantId, SecurityContext securityContext);
 
-    @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Updates a ParticipantContext's roles. Note that this is an absolute update, that means all roles that the Participant should have must be submitted in the body. Requires elevated privileges.",
+            operationId = "updateParticipantRoles",
             requestBody = @RequestBody(content = @Content(array = @ArraySchema(schema = @Schema(implementation = List.class)))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "The ParticipantContext was updated successfully"),
@@ -124,10 +126,10 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    void updateRoles(String participantId, List<String> roles);
+    void updateParticipantRoles(String participantId, List<String> roles);
 
-    @Tag(name = "ParticipantContext Management API")
     @Operation(description = "Get all DID documents across all Participant Contexts. Requires elevated access.",
+            operationId = "getAllParticipants",
             parameters = {
                     @Parameter(name = "offset", description = "the paging offset. defaults to 0"),
                     @Parameter(name = "limit", description = "the page size. defaults to 50")},
@@ -140,5 +142,5 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<ParticipantContext> getAll(Integer offset, Integer limit);
+    Collection<ParticipantContext> getAllParticipants(Integer offset, Integer limit);
 }

--- a/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
+++ b/extensions/api/participant-context-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/ParticipantContextApiController.java
@@ -82,7 +82,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Override
     @POST
     @Path("/{participantId}/token")
-    public String regenerateToken(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
+    public String regenerateParticipantToken(@PathParam("participantId") String participantId, @Context SecurityContext securityContext) {
         return onEncoded(participantId)
                 .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, ParticipantContext.class)
                         .compose(u -> participantContextService.regenerateApiToken(decoded))
@@ -116,7 +116,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @PUT
     @Path("/{participantId}/roles")
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
-    public void updateRoles(@PathParam("participantId") String participantId, List<String> roles) {
+    public void updateParticipantRoles(@PathParam("participantId") String participantId, List<String> roles) {
         onEncoded(participantId)
                 .onSuccess(decoded -> participantContextService.updateParticipant(decoded, participantContext -> participantContext.setRoles(roles))
                         .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
@@ -126,8 +126,8 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @GET
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     @Override
-    public Collection<ParticipantContext> getAll(@DefaultValue("0") @QueryParam("offset") Integer offset,
-                                                 @DefaultValue("50") @QueryParam("limit") Integer limit) {
+    public Collection<ParticipantContext> getAllParticipants(@DefaultValue("0") @QueryParam("offset") Integer offset,
+                                                             @DefaultValue("50") @QueryParam("limit") Integer limit) {
         return participantContextService.query(QuerySpec.Builder.newInstance().offset(offset).limit(limit).build())
                 .orElseThrow(exceptionMapper(ParticipantContext.class));
     }

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/GetAllCredentialsApi.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/GetAllCredentialsApi.java
@@ -29,10 +29,12 @@ import org.eclipse.edc.web.spi.ApiErrorDetail;
 import java.util.Collection;
 
 @OpenAPIDefinition(info = @Info(description = "This is the Management API for VerifiableCredentials", title = "VerifiableCredentials Management API", version = "1"))
+@Tag(name = "Verifiable Credentials")
 public interface GetAllCredentialsApi {
 
-    @Tag(name = "VerifiableCredentials Management API")
+
     @Operation(description = "Get all VerifiableCredentials across all Participant Contexts. Requires elevated access.",
+            operationId = "getAllCredentials",
             parameters = {
                     @Parameter(name = "offset", description = "the paging offset. defaults to 0"),
                     @Parameter(name = "limit", description = "the page size. defaults to 50")},
@@ -45,5 +47,5 @@ public interface GetAllCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<VerifiableCredentialResource> getAll(Integer offset, Integer limit);
+    Collection<VerifiableCredentialResource> getAllCredentials(Integer offset, Integer limit);
 }

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/GetAllCredentialsApiController.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/GetAllCredentialsApiController.java
@@ -45,8 +45,8 @@ public class GetAllCredentialsApiController implements GetAllCredentialsApi {
     @GET
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
     @Override
-    public Collection<VerifiableCredentialResource> getAll(@DefaultValue("0") @QueryParam("offset") Integer offset,
-                                                           @DefaultValue("50") @QueryParam("limit") Integer limit) {
+    public Collection<VerifiableCredentialResource> getAllCredentials(@DefaultValue("0") @QueryParam("offset") Integer offset,
+                                                                      @DefaultValue("50") @QueryParam("limit") Integer limit) {
         var res = credentialStore.query(QuerySpec.Builder.newInstance().limit(limit).offset(offset).build());
         return ServiceResult.from(res).orElseThrow(exceptionMapper(VerifiableCredentialResource.class));
     }

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/VerifiableCredentialsApi.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/VerifiableCredentialsApi.java
@@ -33,10 +33,12 @@ import org.eclipse.edc.web.spi.ApiErrorDetail;
 import java.util.Collection;
 
 @OpenAPIDefinition(info = @Info(description = "This is the Management API for VerifiableCredentials", title = "VerifiableCredentials Management API", version = "1"))
+@Tag(name = "Verifiable Credentials")
 public interface VerifiableCredentialsApi {
 
-    @Tag(name = "VerifiableCredentials Management API")
+
     @Operation(description = "Finds a VerifiableCredential by ID.",
+            operationId = "getCredential",
             parameters = {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH),
             },
@@ -51,11 +53,11 @@ public interface VerifiableCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    VerifiableCredentialResource findById(String id, SecurityContext securityContext);
+    VerifiableCredentialResource getCredential(String id, SecurityContext securityContext);
 
 
-    @Tag(name = "VerifiableCredentials Management API")
     @Operation(description = "Query VerifiableCredentials by type.",
+            operationId = "queryCredentialsByType",
             parameters = {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)
             },
@@ -68,10 +70,10 @@ public interface VerifiableCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
             }
     )
-    Collection<VerifiableCredentialResource> findByType(String type, SecurityContext securityContext);
+    Collection<VerifiableCredentialResource> queryCredentialsByType(String type, SecurityContext securityContext);
 
-    @Tag(name = "VerifiableCredentials Management API")
     @Operation(description = "Delete a VerifiableCredential.",
+            operationId = "deleteCredential",
             parameters = {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH),
             },

--- a/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/VerifiableCredentialsApiController.java
+++ b/extensions/api/verifiable-credential-mgmt-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/VerifiableCredentialsApiController.java
@@ -53,7 +53,7 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
     @GET
     @Path("/{credentialId}")
     @Override
-    public VerifiableCredentialResource findById(@PathParam("credentialId") String id, @Context SecurityContext securityContext) {
+    public VerifiableCredentialResource getCredential(@PathParam("credentialId") String id, @Context SecurityContext securityContext) {
         authorizationService.isAuthorized(securityContext, id, VerifiableCredentialResource.class)
                 .orElseThrow(exceptionMapper(VerifiableCredentialResource.class, id));
 
@@ -64,7 +64,7 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
 
     @GET
     @Override
-    public Collection<VerifiableCredentialResource> findByType(@QueryParam("type") String type, @Context SecurityContext securityContext) {
+    public Collection<VerifiableCredentialResource> queryCredentialsByType(@QueryParam("type") String type, @Context SecurityContext securityContext) {
         var query = QuerySpec.Builder.newInstance()
                 .filter(new Criterion("verifiableCredential.credential.types", "contains", type))
                 .build();


### PR DESCRIPTION
## What this PR changes/adds

Prevent API operation name collision in merged OpenAPI file for Management API.

## Why it does that

Some API Gateway such as Azure API Management does not support multiple API operations having the same name in the same openapi file.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
