### PR TITLE
fix: use JacksonTypeManager instead

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -222,11 +222,11 @@ maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, 
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.77, MIT, approved, #11593
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14235
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.77, MIT AND CC0-1.0, approved, #11595
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14237
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.77, MIT, approved, #11596
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14238
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
@@ -262,6 +262,7 @@ maven/mavencentral/org.eclipse.edc/jetty-core/0.6.1-SNAPSHOT, Apache-2.0, approv
 maven/mavencentral/org.eclipse.edc/json-ld-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/json-ld-spi/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/json-ld/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/json-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit-base/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jws2020-lib/0.6.1-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/core/identity-hub-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.api;
 
 import org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage;
+import org.eclipse.edc.iam.identitytrust.transform.from.JsonObjectFromPresentationResponseMessageTransformer;
 import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToPresentationQueryTransformer;
 import org.eclipse.edc.identityhub.api.v1.PresentationApiController;
 import org.eclipse.edc.identityhub.api.validation.PresentationQueryValidator;
@@ -87,6 +88,7 @@ public class PresentationApiExtension implements ServiceExtension {
         // register transformer -- remove once registration is handled in EDC
         typeTransformer.register(new JsonObjectToPresentationQueryTransformer(jsonLdMapper));
         typeTransformer.register(new JsonValueToGenericTypeTransformer(jsonLdMapper));
+        typeTransformer.register(new JsonObjectFromPresentationResponseMessageTransformer());
     }
 
 

--- a/extensions/store/sql/identity-hub-credentials-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/credentials/SqlCredentialsStoreTest.java
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/credentials/SqlCredentialsStoreTest.java
@@ -17,8 +17,8 @@ package org.eclipse.edc.identityhub.store.sql.credentials;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.identityhub.store.sql.credentials.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.identityhub.store.test.CredentialStoreTestBase;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -38,7 +38,7 @@ class SqlCredentialsStoreTest extends CredentialStoreTestBase {
 
     @BeforeEach
     void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
-        var typeManager = new TypeManager();
+        var typeManager = new JacksonTypeManager();
         store = new SqlCredentialStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
                 extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
 

--- a/extensions/store/sql/identity-hub-did-store-sql/src/test/java/org/eclipse/edc/identityhub/did/store/sql/SqlDidResourceStoreTest.java
+++ b/extensions/store/sql/identity-hub-did-store-sql/src/test/java/org/eclipse/edc/identityhub/did/store/sql/SqlDidResourceStoreTest.java
@@ -17,8 +17,8 @@ package org.eclipse.edc.identityhub.did.store.sql;
 import org.eclipse.edc.identithub.did.spi.store.DidResourceStore;
 import org.eclipse.edc.identityhub.did.store.sql.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.identityhub.did.store.test.DidResourceStoreTestBase;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -38,7 +38,7 @@ class SqlDidResourceStoreTest extends DidResourceStoreTestBase {
 
     @BeforeEach
     void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
-        var typeManager = new TypeManager();
+        var typeManager = new JacksonTypeManager();
         store = new SqlDidResourceStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
                 extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
 

--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStoreTest.java
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStoreTest.java
@@ -17,8 +17,8 @@ package org.eclipse.edc.identityhub.store.sql.keypair;
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.identityhub.store.sql.keypair.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.identityhub.store.test.KeyPairResourceStoreTestBase;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -37,7 +37,7 @@ class SqlKeyPairResourceStoreTest extends KeyPairResourceStoreTestBase {
 
     @BeforeEach
     void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
-        var typeManager = new TypeManager();
+        var typeManager = new JacksonTypeManager();
         store = new SqlKeyPairResourceStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
                 extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
 

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/credentials/SqlParticipantContextStoreTest.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/test/java/org/eclipse/edc/identityhub/store/sql/credentials/SqlParticipantContextStoreTest.java
@@ -19,8 +19,8 @@ import org.eclipse.edc.identityhub.store.sql.participantcontext.ParticipantConte
 import org.eclipse.edc.identityhub.store.sql.participantcontext.SqlParticipantContextStore;
 import org.eclipse.edc.identityhub.store.sql.participantcontext.schema.postgres.PostgresDialectStatements;
 import org.eclipse.edc.identityhub.store.test.ParticipantContextStoreTestBase;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.junit.annotations.ComponentTest;
-import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.sql.QueryExecutor;
 import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -40,7 +40,7 @@ class SqlParticipantContextStoreTest extends ParticipantContextStoreTestBase {
 
     @BeforeEach
     void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) throws IOException {
-        var typeManager = new TypeManager();
+        var typeManager = new JacksonTypeManager();
         store = new SqlParticipantContextStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
                 extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements);
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ edc-lib-jws2020 = { module = "org.eclipse.edc:jws2020-lib", version.ref = "edc" 
 edc-lib-store = { "module" = "org.eclipse.edc:store-lib", version.ref = "edc" }
 edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
 edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
+edc-lib-json = { module = "org.eclipse.edc:json-lib", version.ref = "edc" }
 edc-common-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
 edc-core-jerseyproviders = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
 

--- a/spi/identity-hub-spi/build.gradle.kts
+++ b/spi/identity-hub-spi/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
         exclude(group = "com.fasterxml.jackson.jaxrs", module = "jackson-jaxrs-json-provider")
     }
 
+    testImplementation(libs.edc.lib.json)
     testFixturesImplementation(libs.nimbus.jwt)
     testFixturesImplementation(libs.edc.spi.identity.did)
 }

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/diddocument/DidDocumentPublishedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/diddocument/DidDocumentPublishedTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.spi.events.diddocument;
 
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DidDocumentPublishedTest {
 
-    private final TypeManager manager = new TypeManager();
+    private final TypeManager manager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/diddocument/DidDocumentUnpublishedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/diddocument/DidDocumentUnpublishedTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.spi.events.diddocument;
 
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DidDocumentUnpublishedTest {
 
-    private final TypeManager manager = new TypeManager();
+    private final TypeManager manager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/keypair/KeyPairAddedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/keypair/KeyPairAddedTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.events.keypair;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class KeyPairAddedTest {
 
-    private final TypeManager typeManager = new TypeManager();
+    private final TypeManager typeManager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() throws JsonProcessingException {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/keypair/KeyPairRevokedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/keypair/KeyPairRevokedTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.events.keypair;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class KeyPairRevokedTest {
 
-    private final TypeManager typeManager = new TypeManager();
+    private final TypeManager typeManager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() throws JsonProcessingException {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/keypair/KeyPairRotatedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/keypair/KeyPairRotatedTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.events.keypair;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class KeyPairRotatedTest {
 
-    private final TypeManager typeManager = new TypeManager();
+    private final TypeManager typeManager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() throws JsonProcessingException {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextCreatedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextCreatedTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.events.participant;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ParticipantContextCreatedTest {
 
-    private final TypeManager manager = new TypeManager();
+    private final TypeManager manager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() throws JsonProcessingException {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextDeletedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextDeletedTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.events.participant;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ParticipantContextDeletedTest {
 
-    private final TypeManager manager = new TypeManager();
+    private final TypeManager manager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() throws JsonProcessingException {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextUpdatedTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/edc/identityhub/spi/events/participant/ParticipantContextUpdatedTest.java
@@ -15,13 +15,14 @@
 package org.eclipse.edc.identityhub.spi.events.participant;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ParticipantContextUpdatedTest {
-    private final TypeManager manager = new TypeManager();
+    private final TypeManager manager = new JacksonTypeManager();
 
     @Test
     void verify_serDes() throws JsonProcessingException {


### PR DESCRIPTION
## What this PR changes/adds

Uses the `JacksonTypeManager` now instead of the `TypeManager`, which is now an interface

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
