### PR TITLE
feat: allow newline characters in PEM 

### DIFF
--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -219,7 +219,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
             // either take the public key from the JWK structure or the PEM field
             publicKeySerialized = Optional.ofNullable(keyDescriptor.getPublicKeyJwk())
                     .map(m -> CryptoConverter.create(m).toJSONString())
-                    .orElseGet(keyDescriptor::getPublicKeyPem);
+                    .orElseGet(() -> keyDescriptor.getPublicKeyPem().replace("\\n", "\n"));
         }
         return Result.success(publicKeySerialized);
     }


### PR DESCRIPTION

## What this PR changes/adds

KeyPairServiceImpl replaces `\\n` characters with `\n` characters to allow for escaped newlines.

## Why it does that

When creating new keypair resources, e.g. during participant creation, PEM-encoded keys cannot be multiline, but must contain `\\n` characters instead, otherwise 
tools like `cUrl` will fail.

The PEM spec mandates that lines be separated with a `\n` so this quick fix provides a certain level of robustness.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
