### PR TITLE
chore: update codebase to work with latest iron-vc impl

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
       - name: Run Checkstyle
-        run: ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures
+        run: ./gradlew checkstyleMain checkstyleTest checkstyleTestFixtures --refresh-dependencies
 
   Javadoc:
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
       - name: Run Javadoc
-        run: ./gradlew javadoc
+        run: ./gradlew javadoc --refresh-dependencies
 
   Verify-Launcher:
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
       - name: 'Build launcher'
-        run: ./gradlew :launcher:shadowJar
+        run: ./gradlew :launcher:shadowJar --refresh-dependencies
 
       - name: 'Build Docker image'
         run: docker build -t identity-hub ./launcher
@@ -76,7 +76,7 @@ jobs:
       - name: 'Unit and system tests'
         uses: eclipse-edc/.github/.github/actions/run-tests@main
         with:
-          command: ./gradlew test
+          command: ./gradlew test --refresh-dependencies
         timeout-minutes: 10
         env:
           INTEGRATION_TEST: true
@@ -100,7 +100,7 @@ jobs:
       - name: Component Tests
         uses: eclipse-edc/.github/.github/actions/run-tests@main
         with:
-          command: ./gradlew compileJava compileTestJava test -DincludeTags="ComponentTest,ApiTest,EndToEndTest"
+          command: ./gradlew compileJava compileTestJava test -DincludeTags="ComponentTest,ApiTest,EndToEndTest" --refresh-dependencies
 
   Upload-Coverage-Report-To-Codecov:
     needs:

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,8 @@
-maven/mavencentral/com.apicatalog/carbon-did/0.0.2, Apache-2.0, approved, #9239
-maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.8.1, Apache-2.0, approved, #9234
+maven/mavencentral/com.apicatalog/carbon-did/0.3.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.apicatalog/copper-multibase/0.5.0, Apache-2.0, approved, #14501
+maven/mavencentral/com.apicatalog/copper-multicodec/0.1.1, Apache-2.0, approved, #14500
+maven/mavencentral/com.apicatalog/iron-verifiable-credentials/0.14.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.apicatalog/titanium-json-ld/1.3.1, Apache-2.0, approved, #8912
 maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #13683
 maven/mavencentral/com.ethlo.time/itu/1.7.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.10.3, Apache-2.0, approved, CQ21280
@@ -57,7 +58,7 @@ maven/mavencentral/com.google.code.findbugs/jsr305/2.0.1, BSD-3-Clause AND CC-BY
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0, approved, #20
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
 maven/mavencentral/com.google.crypto.tink/tink/1.12.0, Apache-2.0, approved, #12041
-maven/mavencentral/com.google.crypto.tink/tink/1.13.0, , restricted, clearlydefined
+maven/mavencentral/com.google.crypto.tink/tink/1.13.0, Apache-2.0, approved, #14502
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.11.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.22.0, Apache-2.0, approved, #10661
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.26.1, Apache-2.0, approved, #13657
@@ -223,11 +224,11 @@ maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, 
 maven/mavencentral/org.assertj/assertj-core/3.25.3, Apache-2.0, approved, #12585
 maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.72, MIT, approved, #3789
-maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14235
+maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78, MIT, approved, #14434
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.72, MIT AND CC0-1.0, approved, #3538
-maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14237
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.72, MIT, approved, #3790
-maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14238
+maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78, MIT, approved, #14435
 maven/mavencentral/org.ccil.cowan.tagsoup/tagsoup/1.2.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.12.0, MIT, approved, clearlydefined
 maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,4 +59,11 @@ allprojects {
         configDirectory.set(rootProject.file("resources"))
     }
 
+
+}
+
+configurations.all {
+    // Check for updates every build
+    resolutionStrategy.cacheChangingModulesFor(0, "seconds")
+    resolutionStrategy.cacheDynamicVersionsFor(0, "seconds")
 }

--- a/core/identity-hub-api/build.gradle.kts
+++ b/core/identity-hub-api/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     api(project(":spi:identity-hub-spi"))
     implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.spi.identitytrust)
+    implementation(libs.edc.spi.iatp)
     implementation(libs.edc.core.jerseyproviders)
     implementation(libs.edc.lib.transform)
     implementation(libs.edc.iatp.transform)

--- a/core/identity-hub-credentials/build.gradle.kts
+++ b/core/identity-hub-credentials/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(project(":spi:identity-hub-store-spi"))
     implementation(libs.edc.spi.token)
     implementation(libs.edc.spi.vc)
+    implementation(libs.edc.spi.iatp) //SignatureSuiteRegistry
     implementation(libs.edc.core.token) // for Jwt generation service, token validation service and rule registry impl
     implementation(libs.edc.core.connector) // for the CriterionToPredicateConverterImpl
     implementation(libs.edc.common.crypto) // for the crypto converter

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -36,7 +36,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.security.signature.jws2020.JwsSignature2020Suite;
+import org.eclipse.edc.security.signature.jws2020.Jws2020SignatureSuite;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
@@ -123,7 +123,7 @@ public class CoreServicesExtension implements ServiceExtension {
     public void initialize(ServiceExtensionContext context) {
         // Setup API
         cacheContextDocuments(getClass().getClassLoader());
-        suiteRegistry.register(IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, new JwsSignature2020Suite(JacksonJsonLd.createObjectMapper()));
+        suiteRegistry.register(IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, new Jws2020SignatureSuite(JacksonJsonLd.createObjectMapper()));
 
     }
 

--- a/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/InMemorySignatureSuiteRegistry.java
+++ b/core/identity-hub-credentials/src/main/java/org/eclipse/edc/identityhub/defaults/InMemorySignatureSuiteRegistry.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.edc.identityhub.defaults;
 
-import com.apicatalog.ld.signature.SignatureSuite;
+
+import com.apicatalog.vc.suite.SignatureSuite;
 import org.eclipse.edc.iam.identitytrust.spi.verification.SignatureSuiteRegistry;
 
 import java.util.Collection;
@@ -27,7 +28,6 @@ public class InMemorySignatureSuiteRegistry implements SignatureSuiteRegistry {
     @Override
     public void register(String w3cIdentifier, SignatureSuite suite) {
         registry.put(w3cIdentifier, suite);
-        registry.put(suite.getId().uri(), suite);
     }
 
     @Override

--- a/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/creators/LdpPresentationGeneratorTest.java
+++ b/core/identity-hub-credentials/src/test/java/org/eclipse/edc/identityhub/core/creators/LdpPresentationGeneratorTest.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
-import org.eclipse.edc.security.signature.jws2020.JwsSignature2020Suite;
+import org.eclipse.edc.security.signature.jws2020.Jws2020SignatureSuite;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.verifiablecredentials.jwt.JwtCreationUtils;
 import org.eclipse.edc.verifiablecredentials.jwt.TestConstants;
@@ -70,7 +70,10 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         when(privateKeyResolver.resolvePrivateKey(any())).thenReturn(Result.failure("no key found"));
         when(privateKeyResolver.resolvePrivateKey(eq(PRIVATE_KEY_ALIAS))).thenReturn(Result.success(vpSigningKey));
         var signatureSuiteRegistryMock = mock(SignatureSuiteRegistry.class);
-        when(signatureSuiteRegistryMock.getForId(IdentityHubConstants.JWS_2020_SIGNATURE_SUITE)).thenReturn(new JwsSignature2020Suite(new ObjectMapper()));
+        var suite = new Jws2020SignatureSuite(new ObjectMapper());
+        when(signatureSuiteRegistryMock.getForId(IdentityHubConstants.JWS_2020_SIGNATURE_SUITE)).thenReturn(suite);
+        when(signatureSuiteRegistryMock.getAllSuites()).thenReturn(List.of(suite));
+
         var ldpIssuer = LdpIssuer.Builder.newInstance()
                 .jsonLd(initializeJsonLd())
                 .monitor(mock())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ edc-spi-jsonld = { module = "org.eclipse.edc:json-ld-spi", version.ref = "edc" }
 edc-spi-validator = { module = "org.eclipse.edc:validator-spi", version.ref = "edc" }
 edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-token = { module = "org.eclipse.edc:token-spi", version.ref = "edc" }
-edc-spi-identitytrust = { module = "org.eclipse.edc:identity-trust-spi", version.ref = "edc" }
+edc-spi-iatp = { module = "org.eclipse.edc:identity-trust-spi", version.ref = "edc" }
 edc-spi-vc = { module = "org.eclipse.edc:verifiable-credentials-spi", version.ref = "edc" }
 edc-core-connector = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
 edc-core-sql = { module = "org.eclipse.edc:sql-core", version.ref = "edc" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/spi/identity-hub-spi/build.gradle.kts
+++ b/spi/identity-hub-spi/build.gradle.kts
@@ -22,7 +22,7 @@ val swagger: String by project
 
 dependencies {
 
-    api(libs.edc.spi.identitytrust)
+    api(libs.edc.spi.iatp)
     api(libs.edc.spi.vc)
     api(libs.edc.spi.web)
     implementation(libs.jackson.databind)


### PR DESCRIPTION
## What this PR changes/adds

This PR updates the code base to comply with the latest changes of upstream EDC that were made after the bump
of the `iron-verifiable-credentials` library. no functional changes, only adopted a new SPI.

## Why it does that

bump in iron-verifiable-credentials

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
