### PR TITLE
fix: fetch DID for participantContextId

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.edc.identityhub.query.CredentialQueryResolverImpl;
 import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.model.IdentityHubConstants;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.store.CredentialStore;
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.CredentialStatusCheckService;
@@ -120,6 +121,8 @@ public class CoreServicesExtension implements ServiceExtension {
 
     @Inject
     private LocalPublicKeyService fallbackService;
+    @Inject
+    private ParticipantContextService participantContextService;
 
     @Override
     public String name() {
@@ -136,7 +139,7 @@ public class CoreServicesExtension implements ServiceExtension {
     @Provider
     public AccessTokenVerifier createAccessTokenVerifier(ServiceExtensionContext context) {
         var keyResolver = new KeyPairResourcePublicKeyResolver(store, keyParserRegistry, context.getMonitor(), fallbackService);
-        return new AccessTokenVerifierImpl(tokenValidationService, keyResolver, tokenValidationRulesRegistry, context.getMonitor(), publicKeyResolver);
+        return new AccessTokenVerifierImpl(tokenValidationService, keyResolver, tokenValidationRulesRegistry, context.getMonitor(), publicKeyResolver, participantContextService);
     }
 
     @Provider

--- a/core/lib/accesstoken-lib/src/test/java/org/eclipse/edc/identityhub/accesstoken/verification/AccessTokenVerifierImplComponentTest.java
+++ b/core/lib/accesstoken-lib/src/test/java/org/eclipse/edc/identityhub/accesstoken/verification/AccessTokenVerifierImplComponentTest.java
@@ -23,9 +23,12 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.identityhub.accesstoken.rules.ClaimIsPresentRule;
 import org.eclipse.edc.identityhub.publickey.KeyPairResourcePublicKeyResolver;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.token.TokenValidationRulesRegistryImpl;
 import org.eclipse.edc.token.TokenValidationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +48,7 @@ import static org.eclipse.edc.identityhub.accesstoken.verification.AccessTokenCo
 import static org.eclipse.edc.identityhub.accesstoken.verification.AccessTokenConstants.TOKEN_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -54,7 +58,10 @@ import static org.mockito.Mockito.when;
 class AccessTokenVerifierImplComponentTest {
 
     public static final String STS_PUBLIC_KEY_ID = "sts-key-123";
+    public static final String PARTICIPANT_CONTEXT_ID = "did:web:test_participant";
+    public static final String PARTICIPANT_DID = "did:web:test_participant";
     private final Monitor monitor = mock();
+    private final ParticipantContextService participantContextService = mock();
     private AccessTokenVerifierImpl verifier;
     private KeyPair stsKeyPair; // this is used to sign the acces token
     private KeyPair providerKeyPair; // this is used to sign the incoming SI token
@@ -80,7 +87,8 @@ class AccessTokenVerifierImplComponentTest {
         var resolverMock = mock(KeyPairResourcePublicKeyResolver.class);
         when(resolverMock.resolveKey(anyString(), anyString())).thenReturn(Result.success(stsKeyPair.getPublic()));
 
-        verifier = new AccessTokenVerifierImpl(tokenValidationService, resolverMock, ruleRegistry, monitor, (id) -> Result.success(providerKeyPair.getPublic()));
+        when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().did(PARTICIPANT_DID).participantId(PARTICIPANT_CONTEXT_ID).apiTokenAlias("foobar").build()));
+        verifier = new AccessTokenVerifierImpl(tokenValidationService, resolverMock, ruleRegistry, monitor, (id) -> Result.success(providerKeyPair.getPublic()), participantContextService);
     }
 
     @Test
@@ -88,7 +96,7 @@ class AccessTokenVerifierImplComponentTest {
         var spoofedKey = generator.generateKeyPair().getPrivate();
 
         var selfIssuedIdToken = createSignedJwt(spoofedKey, new JWTClaimsSet.Builder().claim("foo", "bar").jwtID(UUID.randomUUID().toString()).build());
-        assertThat(verifier.verify(selfIssuedIdToken, "did:web:test_participant")).isFailed()
+        assertThat(verifier.verify(selfIssuedIdToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("Token verification failed");
 
     }
@@ -96,7 +104,7 @@ class AccessTokenVerifierImplComponentTest {
     @Test
     void selfIssuedToken_noAccessTokenClaim() {
         var selfIssuedIdToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder()/* missing: claims("access_token", "....") */.build());
-        assertThat(verifier.verify(selfIssuedIdToken, "did:web:test_participant")).isFailed()
+        assertThat(verifier.verify(selfIssuedIdToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("Required claim 'token' not present on token.");
     }
 
@@ -107,8 +115,43 @@ class AccessTokenVerifierImplComponentTest {
                 .build());
         var selfIssuedIdToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken)
                 .build());
-        assertThat(verifier.verify(selfIssuedIdToken, "did:web:test_participant")).isFailed()
+        assertThat(verifier.verify(selfIssuedIdToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("Mandatory claim 'aud' on 'token' was null.");
+    }
+
+
+    @Test
+    void accessToken_audClaimDoesNotBelongToParticipant() {
+        var accessToken = createSignedJwt(stsKeyPair.getPrivate(), new JWTClaimsSet.Builder()
+                .claim("scope", "foobar")
+                .audience(PARTICIPANT_DID)
+                .build());
+        var selfIssuedIdToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken)
+                .build());
+        when(participantContextService.getParticipantContext(eq(PARTICIPANT_CONTEXT_ID))).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .did("did:web:someone_else")
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .apiTokenAlias("foobar")
+                .build()));
+
+        assertThat(verifier.verify(selfIssuedIdToken, PARTICIPANT_CONTEXT_ID)).isFailed()
+                .detail()
+                .isEqualTo("The DID associated with the Participant Context ID of this request ('did:web:someone_else') must match 'aud' claim in 'access_token' ([%s]).".formatted(PARTICIPANT_DID));
+    }
+
+    @Test
+    void accessToken_participantServiceError() {
+        var accessToken = createSignedJwt(stsKeyPair.getPrivate(), new JWTClaimsSet.Builder()
+                .claim("scope", "foobar")
+                .audience(PARTICIPANT_DID)
+                .build());
+        var selfIssuedIdToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken)
+                .build());
+        when(participantContextService.getParticipantContext(eq(PARTICIPANT_CONTEXT_ID))).thenReturn(ServiceResult.notFound("foobar not found barbaz"));
+
+        assertThat(verifier.verify(selfIssuedIdToken, PARTICIPANT_CONTEXT_ID)).isFailed()
+                .detail()
+                .isEqualTo("foobar not found barbaz");
     }
 
     @Test
@@ -117,7 +160,7 @@ class AccessTokenVerifierImplComponentTest {
         var accessToken = createSignedJwt(spoofedKey, new JWTClaimsSet.Builder().claim("scope", "foobar").claim("foo", "bar").build());
         var siToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken).build());
 
-        assertThat(verifier.verify(siToken, "did:web:test_participant")).isFailed()
+        assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("Token verification failed");
     }
 
@@ -126,12 +169,12 @@ class AccessTokenVerifierImplComponentTest {
         var accessToken = createSignedJwt(stsKeyPair.getPrivate(), new JWTClaimsSet.Builder()
                 /* missing: .claim("scope", "foobar") */
                 .claim("foo", "bar")
-                .audience("did:web:test_participant")
+                .audience(PARTICIPANT_CONTEXT_ID)
                 .build());
         var siToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken)
                 .build());
 
-        assertThat(verifier.verify(siToken, "did:web:test_participant")).isFailed()
+        assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("Required claim 'scope' not present on token.");
     }
 
@@ -145,7 +188,7 @@ class AccessTokenVerifierImplComponentTest {
         var siToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken)
                 .build());
 
-        assertThat(verifier.verify(siToken, "did:web:test_participant")).isFailed()
+        assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("Mandatory claim 'aud' on 'token' was null.");
     }
 
@@ -153,14 +196,15 @@ class AccessTokenVerifierImplComponentTest {
     void assertWarning_whenSubjectClaimsMismatch() {
         var accessToken = createSignedJwt(stsKeyPair.getPrivate(), new JWTClaimsSet.Builder()
                 .claim("scope", "foobar")
-                .audience("did:web:test_participant")
+                .audience(PARTICIPANT_CONTEXT_ID)
                 .subject("test-subject")
                 .build());
         var siToken = createSignedJwt(providerKeyPair.getPrivate(), new JWTClaimsSet.Builder().claim("token", accessToken).subject("mismatching-subject").build());
 
-        assertThat(verifier.verify(siToken, "did:web:test_participant")).isSucceeded();
+        assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID)).isSucceeded();
         verify(monitor).warning(startsWith("ID token [sub] claim is not equal to [token.sub]"));
     }
+
 
     private String createSignedJwt(PrivateKey signingKey, JWTClaimsSet claimsSet) {
         try {

--- a/core/lib/accesstoken-lib/src/test/java/org/eclipse/edc/identityhub/accesstoken/verification/AccessTokenVerifierImplTest.java
+++ b/core/lib/accesstoken-lib/src/test/java/org/eclipse/edc/identityhub/accesstoken/verification/AccessTokenVerifierImplTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.accesstoken.verification;
 
 import org.assertj.core.api.Assertions;
 import org.eclipse.edc.identityhub.publickey.KeyPairResourcePublicKeyResolver;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil;
 import org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.VerifiableCredentialTestUtil;
 import org.eclipse.edc.junit.assertions.AbstractResultAssert;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.when;
 
 class AccessTokenVerifierImplTest {
     public static final String OWN_DID = "did:web:consumer";
+    public static final String PARTICIPANT_CONTEXT_ID = "did:web:test_participant";
     private static final String OTHER_PARTICIPANT_DID = "did:web:provider";
     private final TokenValidationService tokenValidationSerivce = mock();
     private final TokenValidationRulesRegistry tokenValidationRulesRegistry = mock();
@@ -47,13 +49,14 @@ class AccessTokenVerifierImplTest {
             .claim("scope", "org.eclipse.edc.vc.type:AlumniCredential:read")
             .build();
     private final KeyPairResourcePublicKeyResolver localPublicKeyResolver = mock();
-    private final AccessTokenVerifierImpl verifier = new AccessTokenVerifierImpl(tokenValidationSerivce, localPublicKeyResolver, tokenValidationRulesRegistry, mock(), pkResolver);
+    private final ParticipantContextService participantContextService = mock();
+    private final AccessTokenVerifierImpl verifier = new AccessTokenVerifierImpl(tokenValidationSerivce, localPublicKeyResolver, tokenValidationRulesRegistry, mock(), pkResolver, participantContextService);
 
     @Test
     void verify_validSiToken_validAccessToken() {
         when(tokenValidationSerivce.validate(anyString(), any(), anyList()))
                 .thenReturn(Result.success(idToken));
-        AbstractResultAssert.assertThat(verifier.verify(JwtCreationUtil.generateSiToken(OWN_DID, OTHER_PARTICIPANT_DID), "did:web:test_participant"))
+        AbstractResultAssert.assertThat(verifier.verify(JwtCreationUtil.generateSiToken(OWN_DID, OTHER_PARTICIPANT_DID), PARTICIPANT_CONTEXT_ID))
                 .isSucceeded()
                 .satisfies(strings -> Assertions.assertThat(strings).containsOnly(JwtCreationUtil.TEST_SCOPE));
         verify(tokenValidationSerivce, times(2)).validate(anyString(), any(PublicKeyResolver.class), anyList());
@@ -64,7 +67,7 @@ class AccessTokenVerifierImplTest {
     void verify_siTokenValidationFails() {
         when(tokenValidationSerivce.validate(anyString(), any(), anyList()))
                 .thenReturn(Result.failure("test-failure"));
-        AbstractResultAssert.assertThat(verifier.verify(JwtCreationUtil.generateSiToken(OWN_DID, OTHER_PARTICIPANT_DID), "did:web:test_participant")).isFailed()
+        AbstractResultAssert.assertThat(verifier.verify(JwtCreationUtil.generateSiToken(OWN_DID, OTHER_PARTICIPANT_DID), PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().contains("test-failure");
     }
 
@@ -73,7 +76,7 @@ class AccessTokenVerifierImplTest {
         when(tokenValidationSerivce.validate(anyString(), any(PublicKeyResolver.class), anyList()))
                 .thenReturn(Result.failure("no access token"));
 
-        AbstractResultAssert.assertThat(verifier.verify(JwtCreationUtil.generateSiToken(OWN_DID, OTHER_PARTICIPANT_DID), "did:web:test_participant")).isFailed()
+        AbstractResultAssert.assertThat(verifier.verify(JwtCreationUtil.generateSiToken(OWN_DID, OTHER_PARTICIPANT_DID), PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().contains("no access token");
         verify(tokenValidationSerivce).validate(anyString(), any(PublicKeyResolver.class), anyList());
     }
@@ -85,7 +88,7 @@ class AccessTokenVerifierImplTest {
         var siToken = JwtCreationUtil.generateJwt(OWN_DID, OTHER_PARTICIPANT_DID, OTHER_PARTICIPANT_DID, Map.of("client_id", OTHER_PARTICIPANT_DID, "access_token", accessToken), JwtCreationUtil.PROVIDER_KEY);
 
         when(tokenValidationSerivce.validate(anyString(), any(), anyList())).thenReturn(Result.failure("test-failure"));
-        AbstractResultAssert.assertThat(verifier.verify(siToken, "did:web:test_participant")).isFailed()
+        AbstractResultAssert.assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID)).isFailed()
                 .detail().isEqualTo("test-failure");
     }
 
@@ -102,7 +105,7 @@ class AccessTokenVerifierImplTest {
         when(tokenValidationSerivce.validate(anyString(), any(), anyList())).thenReturn(Result.success(idToken));
         when(tokenValidationSerivce.validate(anyString(), any(), anyList())).thenReturn(Result.failure("test-failure"));
 
-        AbstractResultAssert.assertThat(verifier.verify(siToken, "did:web:test_participant"))
+        AbstractResultAssert.assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID))
                 .isFailed()
                 .detail().contains("test-failure");
     }

--- a/core/lib/keypair-lib/src/main/java/org/eclipse/edc/identityhub/publickey/KeyPairResourcePublicKeyResolver.java
+++ b/core/lib/keypair-lib/src/main/java/org/eclipse/edc/identityhub/publickey/KeyPairResourcePublicKeyResolver.java
@@ -73,7 +73,8 @@ public class KeyPairResourcePublicKeyResolver {
         return resources.stream().findAny()
                 .map(kpr -> parseKey(kpr.getSerializedPublicKey()))
                 .orElseGet(() -> {
-                    monitor.warning("No KeyPairResource with keyId '%s' was found in the store. Will attempt to resolve from the Vault. This could be an indication of a data inconsistency, it is recommended to revoke and regenerate keys!");
+                    monitor.warning("No KeyPairResource with keyId '%s' was found for participant '%s' in the store. Will attempt to resolve from the Vault. ".formatted(publicKeyId, participantId) +
+                            "This could be an indication of a data inconsistency, it is recommended to revoke and regenerate keys!");
                     return fallbackResolver.resolveKey(publicKeyId); // attempt to resolve from vault
                 });
     }

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
@@ -39,12 +39,12 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubRuntimeConfiguration;
 import org.eclipse.edc.identityhub.tests.fixtures.TestData;
-import org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,6 +60,12 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.CONSUMER_DID;
+import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.CONSUMER_KEY;
+import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.PROVIDER_DID;
+import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.PROVIDER_KEY;
+import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.TEST_SCOPE;
+import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.generateJwt;
 import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil.generateSiToken;
 import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.hamcrest.Matchers.equalTo;
@@ -101,7 +107,7 @@ public class PresentationApiEndToEndTest {
               ]
             }
             """;
-    private static final String TEST_PARTICIPANT_CONTEXT_ID = "did:web:consumer";
+    private static final String TEST_PARTICIPANT_CONTEXT_ID = "consumer";
     private static final String TEST_PARTICIPANT_CONTEXT_ID_ENCODED = Base64.getUrlEncoder().encodeToString(TEST_PARTICIPANT_CONTEXT_ID.getBytes());
     private static final DidPublicKeyResolver DID_PUBLIC_KEY_RESOLVER = mock();
     private static final RevocationListService REVOCATION_LIST_SERVICE = mock();
@@ -200,8 +206,8 @@ public class PresentationApiEndToEndTest {
         createParticipant();
         var token = generateSiToken();
 
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(JwtCreationUtil.CONSUMER_KEY.toPublicKey()));
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(JwtCreationUtil.PROVIDER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
         // create the credential in the store
         var store = runtime.getContext().getService(CredentialStore.class);
@@ -244,8 +250,8 @@ public class PresentationApiEndToEndTest {
         createParticipant();
         var token = generateSiToken();
 
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(JwtCreationUtil.CONSUMER_KEY.toPublicKey()));
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(JwtCreationUtil.PROVIDER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
         var response = IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType(JSON)
@@ -279,8 +285,8 @@ public class PresentationApiEndToEndTest {
 
         store.create(res);
         var token = generateSiToken();
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(JwtCreationUtil.CONSUMER_KEY.toPublicKey()));
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(JwtCreationUtil.PROVIDER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
         var response = IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType(JSON)
@@ -341,8 +347,8 @@ public class PresentationApiEndToEndTest {
                 .build();
         store.create(res);
 
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(JwtCreationUtil.CONSUMER_KEY.toPublicKey()));
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(JwtCreationUtil.PROVIDER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
         var token = generateSiToken();
         var response = IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
@@ -369,8 +375,8 @@ public class PresentationApiEndToEndTest {
 
     @Test
     void query_accessTokenKeyIdDoesNotBelongToParticipant_shouldReturn401() throws JsonProcessingException, JOSEException {
-        createParticipant(TEST_PARTICIPANT_CONTEXT_ID, JwtCreationUtil.CONSUMER_KEY);
-        createParticipant("did:web:attacker", generateEcKey("did:web:attacker#key-1"));
+        createParticipant();
+        createParticipant("attacker", generateEcKey("did:web:attacker#key-1"));
 
         var store = runtime.getContext().getService(CredentialStore.class);
         var cred = OBJECT_MAPPER.readValue(TestData.VC_EXAMPLE, VerifiableCredential.class);
@@ -384,19 +390,52 @@ public class PresentationApiEndToEndTest {
 
         store.create(res);
         var token = generateSiToken();
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(JwtCreationUtil.CONSUMER_KEY.toPublicKey()));
-        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(JwtCreationUtil.PROVIDER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
         IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
                 .contentType(JSON)
                 .header(AUTHORIZATION, token)
                 .body(VALID_QUERY_WITH_SCOPE)
                 // attempt to request the presentation for a different participant than the one who issued the access token
-                .post("/v1/participants/%s/presentations/query".formatted(Base64.getUrlEncoder().encodeToString("did:web:attacker".getBytes())))
+                .post("/v1/participants/%s/presentations/query".formatted(Base64.getUrlEncoder().encodeToString("attacker".getBytes())))
                 .then()
                 .statusCode(401)
                 .log().ifValidationFails();
 
+    }
+
+    @Test
+    void query_accessTokenAudienceDoesNotBelongToParticipant_shouldReturn401() throws JsonProcessingException, JOSEException {
+        createParticipant();
+        var store = runtime.getContext().getService(CredentialStore.class);
+        var cred = OBJECT_MAPPER.readValue(TestData.VC_EXAMPLE, VerifiableCredential.class);
+        var res = VerifiableCredentialResource.Builder.newInstance()
+                .state(VcStatus.ISSUED)
+                .credential(new VerifiableCredentialContainer(TestData.VC_EXAMPLE, CredentialFormat.JWT, cred))
+                .issuerId("https://example.edu/issuers/565049")
+                .holderId("did:example:ebfeb1f712ebc6f1c276e12ec21")
+                .participantId(TEST_PARTICIPANT_CONTEXT_ID)
+                .build();
+
+        store.create(res);
+
+        var accessToken = generateJwt("did:web:someone_else", "did:web:someone_else", PROVIDER_DID, Map.of("scope", TEST_SCOPE), CONSUMER_KEY);
+        var token = generateJwt(CONSUMER_DID, PROVIDER_DID, PROVIDER_DID, Map.of("client_id", PROVIDER_DID, "token", accessToken), PROVIDER_KEY);
+
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
+        when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
+
+        IDENTITY_HUB_PARTICIPANT.getResolutionEndpoint().baseRequest()
+                .contentType(JSON)
+                .header(AUTHORIZATION, token)
+                .body(VALID_QUERY_WITH_SCOPE)
+                // attempt to request the presentation for a different participant than the one who issued the access token
+                .post("/v1/participants/%s/presentations/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
+                .then()
+                .statusCode(401)
+                .log().ifValidationFails()
+                .body(Matchers.containsString("The DID associated with the Participant Context ID of this request ('did:web:consumer') must match 'aud' claim in 'access_token' ([did:web:someone_else])."));
     }
 
     /**
@@ -419,7 +458,7 @@ public class PresentationApiEndToEndTest {
     }
 
     private void createParticipant() {
-        createParticipant(TEST_PARTICIPANT_CONTEXT_ID, JwtCreationUtil.CONSUMER_KEY);
+        createParticipant(TEST_PARTICIPANT_CONTEXT_ID, CONSUMER_KEY);
     }
 
     private void createParticipant(String participantContextId, ECKey participantKey) {
@@ -430,7 +469,7 @@ public class PresentationApiEndToEndTest {
         vault.storeSecret(privateKeyAlias, participantKey.toJSONString());
         var manifest = ParticipantManifest.Builder.newInstance()
                 .participantId(participantContextId)
-                .did("did:web:%s".formatted(participantContextId))
+                .did("did:web:%s".formatted(participantContextId.replace("did:web:", "")))
                 .active(true)
                 .key(KeyDescriptor.Builder.newInstance()
                         .publicKeyJwk(participantKey.toPublicJWK().toJSONObject())

--- a/spi/verifiable-credential-spi/src/testFixtures/java/org/eclipse/edc/identityhub/verifiablecredentials/testfixtures/JwtCreationUtil.java
+++ b/spi/verifiable-credential-spi/src/testFixtures/java/org/eclipse/edc/identityhub/verifiablecredentials/testfixtures/JwtCreationUtil.java
@@ -32,6 +32,8 @@ public class JwtCreationUtil {
     public static final String TEST_SCOPE = "org.eclipse.edc.vc.type:AlumniCredential:read";
     public static final ECKey CONSUMER_KEY = generateEcKey("did:web:consumer#key1");
     public static final ECKey PROVIDER_KEY = generateEcKey("did:web:provider#key1");
+    public static final String CONSUMER_DID = "did:web:consumer";
+    public static final String PROVIDER_DID = "did:web:provider";
 
     /**
      * Generates a self-issued token.
@@ -39,7 +41,7 @@ public class JwtCreationUtil {
      * @return The generated self-issued token.
      */
     public static String generateSiToken() {
-        return generateSiToken("did:web:consumer", "did:web:provider");
+        return generateSiToken(CONSUMER_DID, PROVIDER_DID);
     }
 
     /**


### PR DESCRIPTION

## What this PR changes/adds

when verifying the access_token we should fetch the DID for the requesting participant from the database instead of 
assuming the participant context ID is equal to the DID.

the participant context ID could be "some-participant" and the DID could be `did:web:some_participant`.

## Why it does that

flexibility in choosing the participant context id

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #360_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
