### PR TITLE
feat: disentangle `KeyPairResource#id` and `KeyPairResource#keyId`

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -228,7 +228,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
 
     private void keypairRevoked(KeyPairRevoked event) {
         var didResources = findByParticipantId(event.getParticipantId());
-        var keyId = event.getKeyId();
+        var keyId = event.getKeyPairResourceId();
 
         var errors = didResources.stream()
                 .peek(didResource -> didResource.getDocument().getVerificationMethod().removeIf(vm -> vm.getId().equals(keyId)))
@@ -252,7 +252,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
         var publicKey = keyParserRegistry.parse(serialized);
 
         if (publicKey.failed()) {
-            monitor.warning("Error adding KeyPair '%s' to DID Document of participant '%s': %s".formatted(event.getKeyId(), event.getParticipantId(), publicKey.getFailureDetail()));
+            monitor.warning("Error adding KeyPair '%s' to DID Document of participant '%s': %s".formatted(event.getKeyPairResourceId(), event.getParticipantId(), publicKey.getFailureDetail()));
             return;
         }
 
@@ -260,7 +260,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
 
         var errors = didResources.stream()
                 .peek(dd -> dd.getDocument().getVerificationMethod().add(VerificationMethod.Builder.newInstance()
-                        .id(dd.getDocument().getId() + "#" + event.getKeyId())
+                        .id(dd.getDocument().getId() + "#" + event.getKeyPairResourceId())
                         .publicKeyJwk(jwk.toJSONObject())
                         .controller(dd.getDocument().getId())
                         .type(event.getType())

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
@@ -38,7 +38,8 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
     public void added(KeyPairResource keyPair, String type) {
         var event = KeyPairAdded.Builder.newInstance()
                 .participantId(keyPair.getParticipantId())
-                .keyId(keyPair.getId())
+                .keyPairResourceId(keyPair.getId())
+                .keyId(keyPair.getKeyId())
                 .publicKey(keyPair.getSerializedPublicKey(), type)
                 .build();
         publish(event);
@@ -48,7 +49,8 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
     public void rotated(KeyPairResource keyPair) {
         var event = KeyPairRotated.Builder.newInstance()
                 .participantId(keyPair.getParticipantId())
-                .keyId(keyPair.getId())
+                .keyPairResourceId(keyPair.getId())
+                .keyId(keyPair.getKeyId())
                 .build();
         publish(event);
     }
@@ -57,7 +59,8 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
     public void revoked(KeyPairResource keyPair) {
         var event = KeyPairRevoked.Builder.newInstance()
                 .participantId(keyPair.getParticipantId())
-                .keyId(keyPair.getId())
+                .keyPairResourceId(keyPair.getId())
+                .keyId(keyPair.getKeyId())
                 .build();
         publish(event);
     }

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -79,7 +79,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
         }
 
         var newResource = KeyPairResource.Builder.newInstance()
-                .id(keyDescriptor.getKeyId())
+                .id(keyDescriptor.getResourceId())
                 .keyId(keyDescriptor.getKeyId())
                 .state(keyDescriptor.isActive() ? KeyPairState.ACTIVE : KeyPairState.CREATED)
                 .isDefaultPair(makeDefault)

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityApiEndToEndTest.java
@@ -122,6 +122,7 @@ public abstract class IdentityApiEndToEndTest {
                 .did("did:web:" + participantId)
                 .key(KeyDescriptor.Builder.newInstance()
                         .privateKeyAlias(participantId + "-alias")
+                        .resourceId(participantId + "-resource")
                         .keyId(participantId + "-key")
                         .keyGeneratorParams(Map.of("algorithm", "EC", "curve", "secp256r1"))
                         .build())

--- a/extensions/api/identity-api/keypair-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/unstable/KeyPairResourceApiController.java
+++ b/extensions/api/identity-api/keypair-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/unstable/KeyPairResourceApiController.java
@@ -110,11 +110,11 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
     @POST
     @Path("/{keyPairId}/rotate")
     @Override
-    public void rotateKeyPair(@PathParam("keyPairId") String id, @Nullable KeyDescriptor newKey, @QueryParam("duration") long duration, @Context SecurityContext securityContext) {
+    public void rotateKeyPair(@PathParam("keyPairId") String keyPairId, @Nullable KeyDescriptor newKey, @QueryParam("duration") long duration, @Context SecurityContext securityContext) {
         if (newKey != null) {
             keyDescriptorValidator.validate(newKey).orElseThrow(ValidationFailureException::new);
         }
-        authorizationService.isAuthorized(securityContext, id, KeyPairResource.class).compose(u -> keyPairService.rotateKeyPair(id, newKey, duration)).orElseThrow(exceptionMapper(KeyPairResource.class, id));
+        authorizationService.isAuthorized(securityContext, keyPairId, KeyPairResource.class).compose(u -> keyPairService.rotateKeyPair(keyPairId, newKey, duration)).orElseThrow(exceptionMapper(KeyPairResource.class, keyPairId));
     }
 
     @POST

--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStore.java
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStore.java
@@ -51,7 +51,7 @@ public class SqlKeyPairResourceStore extends AbstractSqlStore implements KeyPair
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
                 if (findByIdInternal(connection, keyPairResource.getId()) != null) {
-                    return alreadyExists("A KeyPairResource with ID '%s' already exists.".formatted(keyPairResource.getKeyId()));
+                    return alreadyExists("A KeyPairResource with ID '%s' already exists.".formatted(keyPairResource.getId()));
                 }
                 var stmt = statements.getInsertTemplate();
                 queryExecutor.execute(connection, stmt, keyPairResource.getId(),

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEvent.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEvent.java
@@ -25,10 +25,18 @@ import java.util.Objects;
  */
 public abstract class KeyPairEvent extends Event {
     protected String participantId;
+    protected String keyPairResourceId;
     protected String keyId;
 
     /**
-     * The ID of the Key stored in the {@link KeyPairResource}
+     * The ID of the {@link KeyPairResource}. This is the internal database ID.
+     */
+    public String getKeyPairResourceId() {
+        return keyPairResourceId;
+    }
+
+    /**
+     * The Key ID. For example, this is what would go into the {@code kid} header of a JWT.
      */
     public String getKeyId() {
         return keyId;
@@ -58,6 +66,11 @@ public abstract class KeyPairEvent extends Event {
 
         public B keyId(String keyId) {
             event.keyId = keyId;
+            return self();
+        }
+
+        public B keyPairResourceId(String keyPairResourceId) {
+            event.keyPairResourceId = keyPairResourceId;
             return self();
         }
 

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairResource.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairResource.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResou
 import org.eclipse.edc.spi.security.Vault;
 
 import java.time.Duration;
+import java.util.Objects;
 
 /**
  * A {@link KeyPairResource} contains key material for a particular {@link ParticipantContext}. The public key is stored in the database in serialized form (JWK or PEM) and the private
@@ -149,6 +150,7 @@ public class KeyPairResource extends ParticipantResource {
         }
 
         public KeyPairResource build() {
+            Objects.requireNonNull(entity.id);
             if (entity.useDuration == 0) {
                 entity.useDuration = Duration.ofDays(6 * 30).toMillis();
             }

--- a/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairAddedTest.java
+++ b/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairAddedTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.spi.keypair.events;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,10 @@ class KeyPairAddedTest {
     private final TypeManager typeManager = new JacksonTypeManager();
 
     @Test
-    void verify_serDes() throws JsonProcessingException {
-        var evt = KeyPairAdded.Builder.newInstance().keyId("resource-id")
+    void verify_serDes() {
+        var evt = KeyPairAdded.Builder.newInstance()
+                .keyPairResourceId("resource-id")
+                .keyId("key-id")
                 .participantId("participant-id")
                 .build();
 

--- a/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRevokedTest.java
+++ b/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRevokedTest.java
@@ -26,7 +26,9 @@ class KeyPairRevokedTest {
 
     @Test
     void verify_serDes() {
-        var evt = KeyPairRevoked.Builder.newInstance().keyId("resource-id")
+        var evt = KeyPairRevoked.Builder.newInstance()
+                .keyPairResourceId("resource-id")
+                .keyId("key-id")
                 .participantId("participant-id")
                 .build();
 

--- a/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRotatedTest.java
+++ b/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRotatedTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.spi.keypair.events;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
@@ -26,8 +25,10 @@ class KeyPairRotatedTest {
     private final TypeManager typeManager = new JacksonTypeManager();
 
     @Test
-    void verify_serDes() throws JsonProcessingException {
-        var evt = KeyPairRotated.Builder.newInstance().keyId("resource-id")
+    void verify_serDes() {
+        var evt = KeyPairRotated.Builder.newInstance()
+                .keyPairResourceId("resource-id")
+                .keyId("key-id")
                 .participantId("participant-id")
                 .build();
 

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/KeyDescriptor.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/KeyDescriptor.java
@@ -21,6 +21,7 @@ import org.eclipse.edc.iam.did.spi.document.DidConstants;
 import org.eclipse.edc.spi.security.Vault;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Container object to describe, what security keys should be used when creating a {@link ParticipantContext}.
@@ -33,6 +34,7 @@ import java.util.Map;
  */
 @JsonDeserialize(builder = KeyDescriptor.Builder.class)
 public class KeyDescriptor {
+    private String resourceId = UUID.randomUUID().toString();
     private String keyId;
     private String type;
     private String privateKeyAlias;
@@ -98,6 +100,9 @@ public class KeyDescriptor {
         return isActive;
     }
 
+    public String getResourceId() {
+        return resourceId;
+    }
 
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder {
@@ -144,6 +149,11 @@ public class KeyDescriptor {
 
         public Builder active(boolean isActive) {
             keyDescriptor.isActive = isActive;
+            return this;
+        }
+
+        public Builder resourceId(String resourceId) {
+            keyDescriptor.resourceId = resourceId;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

disentangles the `KeyPairResource#id` and `KeyPairResource#keyId`

## Why it does that

avoid ID collisions in the future. the ID and the key ID were sometimes used interchangeably, which is not correct.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #368

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
