### PR TITLE
fix: use per-class runtimes in E2E tests

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -231,6 +231,7 @@ maven/mavencentral/org.codehaus.plexus/plexus-utils/3.3.0, , approved, CQ21066
 maven/mavencentral/org.eclipse.angus/angus-activation/1.0.0, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/api-observability/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/asset-spi/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/auth-spi/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/autodoc-processor/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-lib/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.7.1-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -300,8 +300,8 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
         //unpublish and delete all DIDs associated with that participant
         var errors = findByParticipantId(participantId)
                 .stream()
-                .map(didResource -> unpublish(didResource.getDid())
-                        .compose(u -> deleteById(didResource.getDid())))
+                .map(didResource -> unpublish(didResource.getDid()).compose(u -> deleteById(didResource.getDid())))
+                .filter(AbstractResult::failed)
                 .map(AbstractResult::getFailureDetail)
                 .collect(Collectors.joining(", "));
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
@@ -18,11 +18,14 @@ import io.restassured.http.Header;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.identithub.spi.did.events.DidDocumentPublished;
 import org.eclipse.edc.identithub.spi.did.events.DidDocumentUnpublished;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -38,6 +41,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 @EndToEndTest
 public class DidManagementApiEndToEndTest extends IdentityApiEndToEndTest {
+
+
+    @AfterEach
+    void tearDown() {
+        // purge all users
+        var store = RUNTIME.getService(ParticipantContextService.class);
+        store.query(QuerySpec.max()).getContent()
+                .forEach(pc -> store.deleteParticipantContext(pc.getParticipantId()));
+    }
 
     @Test
     void publishDid_notOwner_expect403() {

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityApiEndToEndTest.java
@@ -30,7 +30,7 @@ import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubRuntimeConfiguration;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
-import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -52,7 +52,7 @@ public abstract class IdentityApiEndToEndTest {
             .id("identity-hub")
             .build();
     @RegisterExtension
-    protected static final RuntimeExtension RUNTIME = new RuntimePerMethodExtension(new EmbeddedRuntime("identity-hub", RUNTIME_CONFIGURATION.controlPlaneConfiguration(), ":launcher"));
+    protected static final RuntimeExtension RUNTIME = new RuntimePerClassExtension(new EmbeddedRuntime("identity-hub", RUNTIME_CONFIGURATION.controlPlaneConfiguration(), ":launcher"));
 
     protected static String createSuperUser() {
         return createParticipant(SUPER_USER, List.of(ServicePrincipal.ROLE_ADMIN));

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityApiEndToEndTest.java
@@ -28,7 +28,9 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResou
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubRuntimeConfiguration;
-import org.eclipse.edc.junit.extensions.EdcRuntimeExtension;
+import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
+import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.junit.extensions.RuntimePerMethodExtension;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -50,34 +52,51 @@ public abstract class IdentityApiEndToEndTest {
             .id("identity-hub")
             .build();
     @RegisterExtension
-    protected static final EdcRuntimeExtension RUNTIME = new EdcRuntimeExtension(":launcher", "identity-hub", RUNTIME_CONFIGURATION.controlPlaneConfiguration());
+    protected static final RuntimeExtension RUNTIME = new RuntimePerMethodExtension(new EmbeddedRuntime("identity-hub", RUNTIME_CONFIGURATION.controlPlaneConfiguration(), ":launcher"));
 
-    protected static ParticipantManifest.Builder createNewParticipant() {
+    protected static String createSuperUser() {
+        return createParticipant(SUPER_USER, List.of(ServicePrincipal.ROLE_ADMIN));
+    }
+
+    private static String createParticipant(String participantId, List<String> roles) {
         var manifest = ParticipantManifest.Builder.newInstance()
-                .participantId("another-participant")
-                .active(false)
-                .did("did:web:another:participant")
-                .serviceEndpoint(new Service("test-service", "test-service-type", "https://test.com"))
-                .key(createKeyDescriptor().build());
-        return manifest;
+                .participantId(participantId)
+                .active(true)
+                .roles(roles)
+                .serviceEndpoint(new Service("test-service-id", "test-type", "http://foo.bar.com"))
+                .did("did:web:" + participantId)
+                .key(KeyDescriptor.Builder.newInstance()
+                        .privateKeyAlias(participantId + "-alias")
+                        .resourceId(participantId + "-resource")
+                        .keyId(participantId + "-key")
+                        .keyGeneratorParams(Map.of("algorithm", "EC", "curve", "secp256r1"))
+                        .build())
+                .build();
+        var srv = RUNTIME.getService(ParticipantContextService.class);
+        return srv.createParticipantContext(manifest).orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
     @NotNull
-    public static KeyDescriptor.Builder createKeyDescriptor() {
+    public KeyDescriptor.Builder createKeyDescriptor() {
         return KeyDescriptor.Builder.newInstance()
                 .privateKeyAlias("another-alias")
                 .keyGeneratorParams(Map.of("algorithm", "EdDSA", "curve", "Ed25519"))
                 .keyId("another-keyid");
     }
 
-    protected String createSuperUser() {
-        return createParticipant(SUPER_USER, List.of(ServicePrincipal.ROLE_ADMIN));
+    protected ParticipantManifest.Builder createNewParticipant() {
+        return ParticipantManifest.Builder.newInstance()
+                .participantId("another-participant")
+                .active(false)
+                .did("did:web:another:participant")
+                .serviceEndpoint(new Service("test-service", "test-service-type", "https://test.com"))
+                .key(createKeyDescriptor().build());
     }
 
     protected String storeParticipant(ParticipantContext pc) {
-        var store = RUNTIME.getContext().getService(ParticipantContextStore.class);
+        var store = RUNTIME.getService(ParticipantContextStore.class);
 
-        var vault = RUNTIME.getContext().getService(Vault.class);
+        var vault = RUNTIME.getService(Vault.class);
         var token = createTokenFor(pc.getParticipantId());
         vault.storeSecret(pc.getApiTokenAlias(), token);
         store.create(pc).orElseThrow(f -> new RuntimeException(f.getFailureDetail()));
@@ -93,7 +112,7 @@ public abstract class IdentityApiEndToEndTest {
     }
 
     protected <T> T getService(Class<T> type) {
-        return RUNTIME.getContext().getService(type);
+        return RUNTIME.getService(type);
     }
 
     protected Collection<KeyPairResource> getKeyPairsForParticipant(String participantId) {
@@ -111,23 +130,5 @@ public abstract class IdentityApiEndToEndTest {
         return getService(ParticipantContextService.class)
                 .getParticipantContext(participantId)
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));
-    }
-
-    private String createParticipant(String participantId, List<String> roles) {
-        var manifest = ParticipantManifest.Builder.newInstance()
-                .participantId(participantId)
-                .active(true)
-                .roles(roles)
-                .serviceEndpoint(new Service("test-service-id", "test-type", "http://foo.bar.com"))
-                .did("did:web:" + participantId)
-                .key(KeyDescriptor.Builder.newInstance()
-                        .privateKeyAlias(participantId + "-alias")
-                        .resourceId(participantId + "-resource")
-                        .keyId(participantId + "-key")
-                        .keyGeneratorParams(Map.of("algorithm", "EC", "curve", "secp256r1"))
-                        .build())
-                .build();
-        var srv = RUNTIME.getContext().getService(ParticipantContextService.class);
-        return srv.createParticipantContext(manifest).orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 }

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
@@ -494,7 +494,7 @@ public class KeyPairResourceApiEndToEndTest extends IdentityApiEndToEndTest {
 
         var descriptor = createKeyDescriptor(participantId).build();
 
-        var service = RUNTIME.getContext().getService(KeyPairService.class);
+        var service = RUNTIME.getService(KeyPairService.class);
         service.addKeyPair(participantId, descriptor, true)
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));
         return descriptor.getResourceId();

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -222,7 +222,7 @@ public class ParticipantContextApiEndToEndTest extends IdentityApiEndToEndTest {
                 .log().ifError()
                 .statusCode(204);
 
-        var updatedParticipant = RUNTIME.getContext().getService(ParticipantContextService.class).getParticipantContext(participantId).orElseThrow(f -> new EdcException(f.getFailureDetail()));
+        var updatedParticipant = RUNTIME.getService(ParticipantContextService.class).getParticipantContext(participantId).orElseThrow(f -> new EdcException(f.getFailureDetail()));
         assertThat(updatedParticipant.getState()).isEqualTo(ParticipantContextState.ACTIVATED.ordinal());
         // verify the correct event was emitted
         verify(subscriber).on(argThat(env -> {

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -26,6 +26,8 @@ import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -49,6 +51,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 @EndToEndTest
 public class ParticipantContextApiEndToEndTest extends IdentityApiEndToEndTest {
+
+    @AfterEach
+    void tearDown() {
+        // purge all users
+        var pcService = RUNTIME.getService(ParticipantContextService.class);
+        pcService.query(QuerySpec.max()).getContent()
+                .forEach(pc -> pcService.deleteParticipantContext(pc.getParticipantId()).getContent());
+    }
 
     @Test
     void getUserById() {


### PR DESCRIPTION
## What this PR changes/adds

Migrates E2E tests to the per-class model.

## Why it does that

Adopting upstream changes, make E2E MUCH faster

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
