### PR TITLE
feat: allow multiple VP isuers

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -76,6 +76,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.39.3, Apache-2.0, approved, #14830
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, , restricted, clearlydefined
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.17.0, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #15077
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -150,11 +150,11 @@ public class CoreServicesExtension implements ServiceExtension {
     @Provider
     public PresentationCreatorRegistry presentationCreatorRegistry(ServiceExtensionContext context) {
         if (presentationCreatorRegistry == null) {
-            presentationCreatorRegistry = new PresentationCreatorRegistryImpl(keyPairService);
-            presentationCreatorRegistry.addCreator(new JwtPresentationGenerator(privateKeyResolver, clock, getOwnDid(context), new JwtGenerationService()), CredentialFormat.JWT);
+            presentationCreatorRegistry = new PresentationCreatorRegistryImpl(keyPairService, participantContextService);
+            presentationCreatorRegistry.addCreator(new JwtPresentationGenerator(privateKeyResolver, clock, new JwtGenerationService()), CredentialFormat.JWT);
 
             var ldpIssuer = LdpIssuer.Builder.newInstance().jsonLd(jsonLd).monitor(context.getMonitor()).build();
-            presentationCreatorRegistry.addCreator(new LdpPresentationGenerator(privateKeyResolver, getOwnDid(context), signatureSuiteRegistry, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer, typeManager.getMapper(JSON_LD)),
+            presentationCreatorRegistry.addCreator(new LdpPresentationGenerator(privateKeyResolver, signatureSuiteRegistry, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer, typeManager.getMapper(JSON_LD)),
                     CredentialFormat.JSON_LD);
         }
         return presentationCreatorRegistry;
@@ -170,10 +170,6 @@ public class CoreServicesExtension implements ServiceExtension {
     @Provider
     public CredentialStatusCheckService createStatusCheckService() {
         return new CredentialStatusCheckServiceImpl(revocationService, clock);
-    }
-
-    private String getOwnDid(ServiceExtensionContext context) {
-        return context.getConfig().getString(OWN_DID_PROPERTY);
     }
 
     private void cacheContextDocuments(ClassLoader classLoader) {

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -45,7 +45,6 @@ import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.security.signature.jws2020.Jws2020SignatureSuite;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
@@ -75,8 +74,6 @@ import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 public class CoreServicesExtension implements ServiceExtension {
 
     public static final String NAME = "IdentityHub Core Services Extension";
-    @Setting(value = "Configure this IdentityHub's DID", required = true)
-    public static final String OWN_DID_PROPERTY = "edc.ih.iam.id";
 
     public static final String PRESENTATION_EXCHANGE_V_1_JSON = "presentation-exchange.v1.json";
     public static final String PRESENTATION_QUERY_V_08_JSON = "iatp.v08.json";

--- a/core/lib/verifiable-presentation-lib/src/main/java/org/eclipse/edc/identithub/verifiablepresentation/generators/JwtPresentationGenerator.java
+++ b/core/lib/verifiable-presentation-lib/src/main/java/org/eclipse/edc/identithub/verifiablepresentation/generators/JwtPresentationGenerator.java
@@ -49,7 +49,6 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
     public static final String VERIFIABLE_PRESENTATION_CLAIM = "vp";
     private final PrivateKeyResolver privateKeyResolver;
     private final Clock clock;
-    private final String issuerId;
 
     private final TokenGenerationService tokenGenerationService;
 
@@ -58,18 +57,16 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
      *
      * @param privateKeyResolver The resolver for private keys used for signing the presentation.
      * @param clock              The clock used for generating timestamps.
-     * @param issuerId           The ID of the issuer for the presentation. Could be a DID.
      */
-    public JwtPresentationGenerator(PrivateKeyResolver privateKeyResolver, Clock clock, String issuerId, TokenGenerationService tokenGenerationService) {
+    public JwtPresentationGenerator(PrivateKeyResolver privateKeyResolver, Clock clock, TokenGenerationService tokenGenerationService) {
         this.privateKeyResolver = privateKeyResolver;
         this.clock = clock;
-        this.issuerId = issuerId;
         this.tokenGenerationService = tokenGenerationService;
     }
 
     /**
      * Will always throw an {@link UnsupportedOperationException}.
-     * Please use {@link JwtPresentationGenerator#generatePresentation(List, String, String, Map)} instead.
+     * Please use {@link PresentationGenerator#generatePresentation(List, String, String, String, Map)} instead.
      */
     @Override
     public String generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId) {
@@ -82,6 +79,7 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
      * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
      * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
      * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
+     * @param issuerId        The ID of this issuer. Usually a DID.
      * @param additionalData  Additional data to include in the presentation. Must contain an entry 'aud'. Every entry in the map is added as a claim to the token.
      * @return The serialized JWT presentation.
      * @throws IllegalArgumentException      If the additional data does not contain the required 'aud' value or if no private key could be resolved for the key ID.
@@ -89,7 +87,7 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
      * @throws EdcException                  If signing the JWT fails.
      */
     @Override
-    public String generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, Map<String, Object> additionalData) {
+    public String generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, String issuerId, Map<String, Object> additionalData) {
 
         // check if expected data is there
         if (!additionalData.containsKey(JwtRegisteredClaimNames.AUDIENCE)) {
@@ -104,7 +102,7 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
                 .map(VerifiableCredentialContainer::rawVc)
                 .collect(Collectors.toList());
         Supplier<PrivateKey> privateKeySupplier = () -> privateKeyResolver.resolvePrivateKey(privateKeyAlias).orElseThrow(f -> new IllegalArgumentException(f.getFailureDetail()));
-        var tokenResult = tokenGenerationService.generate(privateKeySupplier, vpDecorator(rawVcs), tp -> {
+        var tokenResult = tokenGenerationService.generate(privateKeySupplier, vpDecorator(rawVcs, issuerId), tp -> {
             additionalData.forEach(tp::claims);
             return tp;
         }, new KeyIdDecorator(additionalData.get(CONTROLLER_ADDITIONAL_DATA) + "#" + publicKeyId));
@@ -112,7 +110,7 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
         return tokenResult.map(TokenRepresentation::getToken).orElseThrow(f -> new EdcException(f.getFailureDetail()));
     }
 
-    private TokenDecorator vpDecorator(List<String> rawVcs) {
+    private TokenDecorator vpDecorator(List<String> rawVcs, String issuerId) {
         var now = Date.from(clock.instant());
         return tp -> tp.claims(JwtRegisteredClaimNames.ISSUER, issuerId)
                 .claims(JwtRegisteredClaimNames.ISSUED_AT, now)

--- a/core/lib/verifiable-presentation-lib/src/main/java/org/eclipse/edc/identithub/verifiablepresentation/generators/LdpPresentationGenerator.java
+++ b/core/lib/verifiable-presentation-lib/src/main/java/org/eclipse/edc/identithub/verifiablepresentation/generators/LdpPresentationGenerator.java
@@ -61,16 +61,14 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
     public static final String HOLDER_PROPERTY = "holder";
     public static final URI ASSERTION_METHOD = URI.create("https://w3id.org/security#assertionMethod");
     private final PrivateKeyResolver privateKeyResolver;
-    private final String issuerId;
     private final SignatureSuiteRegistry signatureSuiteRegistry;
     private final String defaultSignatureSuite;
     private final LdpIssuer ldpIssuer;
     private final ObjectMapper mapper;
 
-    public LdpPresentationGenerator(PrivateKeyResolver privateKeyResolver, String ownDid,
+    public LdpPresentationGenerator(PrivateKeyResolver privateKeyResolver,
                                     SignatureSuiteRegistry signatureSuiteRegistry, String defaultSignatureSuite, LdpIssuer ldpIssuer, ObjectMapper mapper) {
         this.privateKeyResolver = privateKeyResolver;
-        this.issuerId = ownDid;
         this.signatureSuiteRegistry = signatureSuiteRegistry;
         this.defaultSignatureSuite = defaultSignatureSuite;
         this.ldpIssuer = ldpIssuer;
@@ -79,7 +77,7 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
 
     /**
      * Will always throw an {@link UnsupportedOperationException}.
-     * Please use {@link LdpPresentationGenerator#generatePresentation(List, String, String, Map)} instead.
+     * Please use {@link PresentationGenerator#generatePresentation(List, String, String, String, Map)} instead.
      */
     @Override
     public JsonObject generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String privateKeyId) {
@@ -94,6 +92,7 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
      * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
      * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
      * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
+     * @param issuerId        The ID of this issuer. Usually a DID.
      * @param additionalData  The additional data to be included in the presentation.
      *                        It must contain a "types" field and optionally, a "suite" field to indicate the desired signature suite.
      *                        If the "suite" parameter is specified, it must be a W3C identifier for signature suites.
@@ -104,7 +103,7 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
      *                                  or if one or more VerifiableCredentials cannot be represented in the JSON-LD format.
      */
     @Override
-    public JsonObject generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, Map<String, Object> additionalData) {
+    public JsonObject generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, String issuerId, Map<String, Object> additionalData) {
         if (!additionalData.containsKey(TYPE_ADDITIONAL_DATA)) {
             throw new IllegalArgumentException("Must provide additional data: '%s'".formatted(TYPE_ADDITIONAL_DATA));
         }

--- a/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/PresentationCreatorRegistryImplTest.java
+++ b/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/PresentationCreatorRegistryImplTest.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantConte
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.PresentationGenerator;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -51,12 +52,19 @@ class PresentationCreatorRegistryImplTest {
     private final ParticipantContextService participantContextService = mock();
     private final PresentationCreatorRegistryImpl registry = new PresentationCreatorRegistryImpl(keyPairService, participantContextService);
 
+    @BeforeEach
+    void setup() {
+        when(participantContextService.getParticipantContext(anyString()))
+                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                        .participantId("test-participant")
+                        .apiTokenAlias("test-token")
+                        .did(ISSUER_ID).build()));
+    }
+
     @Test
     void createPresentation_whenSingleKey() {
         var keyPair = createKeyPair(TEST_PARTICIPANT, "key-1").build();
         when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(keyPair)));
-        when(participantContextService.getParticipantContext(anyString()))
-                .thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance().did(ISSUER_ID).build()));
 
         var generator = mock(PresentationGenerator.class);
         registry.addCreator(generator, CredentialFormat.JWT);

--- a/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/generators/LdpPresentationGeneratorTest.java
+++ b/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/generators/LdpPresentationGeneratorTest.java
@@ -78,7 +78,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
                 .jsonLd(initializeJsonLd())
                 .monitor(mock())
                 .build();
-        creator = new LdpPresentationGenerator(privateKeyResolver, "did:web:test-issuer", signatureSuiteRegistryMock, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer,
+        creator = new LdpPresentationGenerator(privateKeyResolver, signatureSuiteRegistryMock, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer,
                 JacksonJsonLd.createObjectMapper());
     }
 
@@ -88,7 +88,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         var ldpVc = TestData.LDP_VC_WITH_PROOF;
         var vcc = new VerifiableCredentialContainer(ldpVc, CredentialFormat.JSON_LD, createDummyCredential());
 
-        var result = creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, ADDITIONAL_DATA);
+        var result = creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, issuerId, ADDITIONAL_DATA);
         assertThat(result).isNotNull();
         assertThat(result.get("https://w3id.org/security#proof")).isNotNull();
     }
@@ -103,7 +103,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         var jwtVc = JwtCreationUtils.createJwt(vcSigningKey, TestConstants.CENTRAL_ISSUER_DID, "degreeSub", TestConstants.VP_HOLDER_ID, Map.of("vc", TestConstants.VC_CONTENT_DEGREE_EXAMPLE));
         var vcc2 = new VerifiableCredentialContainer(jwtVc, CredentialFormat.JWT, createDummyCredential());
 
-        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc, vcc2), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, ADDITIONAL_DATA))
+        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc, vcc2), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, issuerId, ADDITIONAL_DATA))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("One or more VerifiableCredentials cannot be represented in the desired format %s".formatted(CredentialFormat.JSON_LD));
     }
@@ -111,7 +111,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
     @Override
     @Test
     public void create_whenVcsEmpty_shouldReturnEmptyVp() {
-        var result = creator.generatePresentation(List.of(), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, ADDITIONAL_DATA);
+        var result = creator.generatePresentation(List.of(), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, issuerId, ADDITIONAL_DATA);
         assertThat(result).isNotNull();
     }
 
@@ -121,7 +121,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         var ldpVc = TestData.LDP_VC_WITH_PROOF;
         var vcc = new VerifiableCredentialContainer(ldpVc, CredentialFormat.JSON_LD, createDummyCredential());
 
-        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), "not-exists", PUBLIC_KEY_ID, ADDITIONAL_DATA))
+        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), "not-exists", PUBLIC_KEY_ID, issuerId, ADDITIONAL_DATA))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -133,11 +133,11 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID)).isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Must provide additional data: 'types' and 'controller'");
 
-        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, Map.of("some-key", "some-value")))
+        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, issuerId, Map.of("some-key", "some-value")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Must provide additional data: 'types'");
 
-        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, Map.of("types", "some-value")))
+        assertThatThrownBy(() -> creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, issuerId, Map.of("types", "some-value")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Must provide additional data: 'controller'");
     }
@@ -147,7 +147,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
     @Override
     void create_whenEmptyList() {
 
-        var result = creator.generatePresentation(List.of(), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, ADDITIONAL_DATA);
+        var result = creator.generatePresentation(List.of(), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, issuerId, ADDITIONAL_DATA);
         assertThat(result).isNotNull();
         assertThat(result.get("https://w3id.org/security#proof")).isNotNull();
     }

--- a/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/generators/PresentationGeneratorTest.java
+++ b/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/generators/PresentationGeneratorTest.java
@@ -31,6 +31,7 @@ abstract class PresentationGeneratorTest {
 
     public static final String PRIVATE_KEY_ALIAS = "private-key";
     public static final String PUBLIC_KEY_ID = "key-1";
+    protected final String issuerId = "did:web:testissuer";
 
     @Test
     @DisplayName("Verify succesful creation of a JWT_VP")

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/generator/PresentationGenerator.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/generator/PresentationGenerator.java
@@ -60,11 +60,12 @@ public interface PresentationGenerator<T> {
      * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
      * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
      * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
+     * @param issuerId
      * @param additionalData  Additional data used for validation.
      * @return The generated Verifiable Presentation. The concrete return type depends on the implementation.
      * @throws IllegalArgumentException If not all VCs can be represented in one VP, mandatory additional information was not given, or the specified key is not suitable for signing.
      */
-    default T generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, Map<String, Object> additionalData) {
+    default T generatePresentation(List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, String issuerId, Map<String, Object> additionalData) {
         return generatePresentation(credentials, privateKeyAlias, publicKeyId);
     }
 }

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/generator/PresentationGenerator.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/generator/PresentationGenerator.java
@@ -60,7 +60,7 @@ public interface PresentationGenerator<T> {
      * @param credentials     The list of Verifiable Credential Containers to include in the presentation.
      * @param privateKeyAlias The alias of the private key to be used for generating the presentation.
      * @param publicKeyId     The ID used by the counterparty to resolve the public key for verifying the VP.
-     * @param issuerId
+     * @param issuerId        The ID of the issuer. Typically, this is a DID, NOT the participant ID!
      * @param additionalData  Additional data used for validation.
      * @return The generated Verifiable Presentation. The concrete return type depends on the implementation.
      * @throws IllegalArgumentException If not all VCs can be represented in one VP, mandatory additional information was not given, or the specified key is not suitable for signing.


### PR DESCRIPTION
- **allow multiple issuers (wip)**
- **fix test**
- **remove old property**

## What this PR changes/adds

instead of taking IH's issuer ID from a static config value (`edc.ih.iam.issuer.id`), it now takes the DID from the participant context, for whom the presentation query was issued.

For example, if "Company B" queries "Company A"'s IdentityHub for credentials, then the VP issuer would be the DID of "Company A".

## Why it does that

With the ability to host multiple participant contexts (="tenants") the issuer ID cannot be static anymore.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #361 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
