### PR TITLE
docs: provide developer docs readme file

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -44,7 +44,7 @@ maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.4, Apache-2.
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
 maven/mavencentral/com.github.java-json-tools/btf/1.3, Apache-2.0 OR LGPL-3.0-or-later, approved, #2721
 maven/mavencentral/com.github.java-json-tools/jackson-coreutils-equivalence/1.0, LGPL-3.0 OR Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 OR LGPL-3.0-or-later, approved, #2719
+maven/mavencentral/com.github.java-json-tools/jackson-coreutils/2.0, Apache-2.0 AND LGPL-2.1-or-later AND LGPL-3.0-only AND (Apache-2.0 AND GPL-1.0-or-later AND LGPL-3.0-only) AND Apache-2.0 AND LGPL-3.0-only, restricted, #15186
 maven/mavencentral/com.github.java-json-tools/json-patch/1.13, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23929
 maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, #2722
 maven/mavencentral/com.github.java-json-tools/json-schema-validator/2.2.14, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ20779
@@ -91,7 +91,7 @@ maven/mavencentral/commons-beanutils/commons-beanutils/1.8.3, Apache-2.0, approv
 maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
 maven/mavencentral/commons-codec/commons-codec/1.11, Apache-2.0 AND BSD-3-Clause, approved, CQ15971
 maven/mavencentral/commons-codec/commons-codec/1.15, Apache-2.0 AND BSD-3-Clause AND LicenseRef-Public-Domain, approved, CQ22641
-maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
+maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
 maven/mavencentral/commons-io/commons-io/2.11.0, Apache-2.0, approved, CQ23745
 maven/mavencentral/commons-logging/commons-logging/1.1.1, Apache-2.0, approved, CQ1907
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,5 @@
+# Developer documentation
+
+* [Api](architecture/identityhub-apis.md)
+* [Api Security](architecture/identity-api.security.md)
+* [Identity and Trust protocol](architecture/identity-trust-protocol/README.md)

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -4,4 +4,4 @@
 - [2022-07-01 Get Claims](2022-07-01-get-claims/)
 - [2022-07-29 Self-description](2022-07-29-self-description/)
 - [2022-08-12 Code Quality Tooling](2022-08-12-code-quality-tooling/)
-- [2023-01-20 Credentials Verifier Output Format](2023-01-20-credentials-verifier-output-format)
+- [2023-01-20 Credentials Verifier Output Format](2023-01-20-credentials-verifier-output-format/)


### PR DESCRIPTION
## What this PR changes/adds

Provides a root `README` for developer docs

## Why it does that

Fix 404 in the documentation site.

## Further notes

As reported in https://github.com/eclipse-edc/docs/issues/153

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
