### PR TITLE
fix: use the new JwsSignerProvider interface

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -266,6 +266,7 @@ maven/mavencentral/org.eclipse.edc/json-lib/0.8.2-SNAPSHOT, Apache-2.0, approved
 maven/mavencentral/org.eclipse.edc/junit-base/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/junit/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jws2020-lib/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/jwt-signer-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-spi/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jwt-verifiable-credentials/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/keys-lib/0.8.2-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(libs.edc.lib.jsonld)
     implementation(libs.edc.lib.query)
     implementation(libs.edc.lib.jws2020)
+    implementation(libs.edc.lib.common.crypto)
     implementation(libs.edc.spi.token)
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -33,8 +33,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.security.token.jwt.CryptoConverter;
-import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.security.token.jwt.DefaultJwsSignerProvider;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
@@ -114,8 +113,6 @@ public class DefaultServicesExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public JwsSignerProvider defaultSignerProvider() {
-        // default implementation: resolve the private key (from vault of config) and create a JWSSigner based on its algorithm
-        return privateKeyId -> privateKeyResolver.resolvePrivateKey(privateKeyId)
-                .compose(pk -> Result.ofThrowable(() -> CryptoConverter.createSignerFor(pk)));
+        return new DefaultJwsSignerProvider(privateKeyResolver);
     }
 }

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -39,6 +39,7 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.resolution.Credenti
 import org.eclipse.edc.identityhub.spi.verification.AccessTokenVerifier;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.keys.spi.LocalPublicKeyService;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
@@ -120,6 +121,8 @@ public class CoreServicesExtension implements ServiceExtension {
     private LocalPublicKeyService fallbackService;
     @Inject
     private ParticipantContextService participantContextService;
+    @Inject
+    private JwsSignerProvider jwsSignerProvider;
 
     @Override
     public String name() {
@@ -148,7 +151,7 @@ public class CoreServicesExtension implements ServiceExtension {
     public PresentationCreatorRegistry presentationCreatorRegistry(ServiceExtensionContext context) {
         if (presentationCreatorRegistry == null) {
             presentationCreatorRegistry = new PresentationCreatorRegistryImpl(keyPairService, participantContextService);
-            presentationCreatorRegistry.addCreator(new JwtPresentationGenerator(privateKeyResolver, clock, new JwtGenerationService()), CredentialFormat.JWT);
+            presentationCreatorRegistry.addCreator(new JwtPresentationGenerator(clock, new JwtGenerationService(jwsSignerProvider)), CredentialFormat.JWT);
 
             var ldpIssuer = LdpIssuer.Builder.newInstance().jsonLd(jsonLd).monitor(context.getMonitor()).build();
             presentationCreatorRegistry.addCreator(new LdpPresentationGenerator(privateKeyResolver, signatureSuiteRegistry, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer, typeManager.getMapper(JSON_LD)),

--- a/core/identity-hub-did/build.gradle.kts
+++ b/core/identity-hub-did/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(project(":spi:keypair-spi"))
     implementation(project(":spi:participant-context-spi"))
     implementation(libs.edc.core.connector) // for the reflection-based query resolver
-    implementation(libs.edc.common.crypto)
+    implementation(libs.edc.lib.common.crypto)
     implementation(libs.edc.lib.store)
     implementation(libs.edc.lib.query)
 

--- a/core/identity-hub-keypairs/build.gradle.kts
+++ b/core/identity-hub-keypairs/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
     api(project(":spi:identity-hub-store-spi"))
     api(libs.edc.spi.transaction)
     implementation(project(":core:lib:keypair-lib"))
-    implementation(libs.edc.common.crypto)
+    implementation(libs.edc.lib.common.crypto)
     implementation(libs.edc.core.connector)
     testImplementation(libs.edc.junit)
 }

--- a/core/identity-hub-participants/build.gradle.kts
+++ b/core/identity-hub-participants/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     api(project(":spi:identity-hub-store-spi"))
     api(libs.edc.spi.transaction)
     implementation(project(":core:lib:keypair-lib"))
-    implementation(libs.edc.common.crypto)
+    implementation(libs.edc.lib.common.crypto)
     implementation(libs.edc.core.connector)
 
     testImplementation(libs.edc.lib.keys)

--- a/core/lib/verifiable-presentation-lib/build.gradle.kts
+++ b/core/lib/verifiable-presentation-lib/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation(libs.edc.spi.vc)
     implementation(libs.edc.spi.jsonld)
     implementation(libs.edc.core.token) // for Jwt generation service, token validation service and rule registry impl
-    implementation(libs.edc.common.crypto) // for the CryptoConverter
+    implementation(libs.edc.lib.common.crypto) // for the CryptoConverter
     implementation(libs.edc.lib.jws2020)
     implementation(libs.edc.vc.ldp)
     implementation(libs.edc.verifiablecredentials)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ edc-lib-store = { "module" = "org.eclipse.edc:store-lib", version.ref = "edc" }
 edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
 edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
 edc-lib-json = { module = "org.eclipse.edc:json-lib", version.ref = "edc" }
-edc-common-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
+edc-lib-common-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
 edc-core-jerseyproviders = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
 
 

--- a/spi/verifiable-credential-spi/build.gradle.kts
+++ b/spi/verifiable-credential-spi/build.gradle.kts
@@ -28,5 +28,5 @@ dependencies {
     testImplementation(libs.edc.lib.json)
     testFixturesImplementation(libs.nimbus.jwt)
     testFixturesImplementation(libs.edc.spi.identity.did)
-    testFixturesImplementation(libs.edc.common.crypto)
+    testFixturesImplementation(libs.edc.lib.common.crypto)
 }


### PR DESCRIPTION
## What this PR changes/adds

adapts the code base to use the new `JwsSignerProvider` introduced recently in upstream EDC

## Why it does that

compile errors

## Further notes

also updates the version catalog entry `edc.common.crypto` -> `edc.libs.common.crypto` for consistency

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
