### PR TITLE
feat: check if DID exists before creating a participant

### DIFF
--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.participantcontext;
 
 import org.eclipse.edc.identithub.spi.did.DidDocumentService;
+import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
@@ -54,6 +55,8 @@ public class ParticipantContextExtension implements ServiceExtension {
     private Clock clock;
     @Inject
     private EventRouter eventRouter;
+    @Inject
+    private DidResourceStore didResourceStore;
 
     private ParticipantContextObservable participantContextObservable;
 
@@ -72,7 +75,7 @@ public class ParticipantContextExtension implements ServiceExtension {
 
     @Provider
     public ParticipantContextService createParticipantService() {
-        return new ParticipantContextServiceImpl(participantContextStore, vault, transactionContext, participantContextObservable());
+        return new ParticipantContextServiceImpl(participantContextStore, didResourceStore, vault, transactionContext, participantContextObservable());
     }
 
     @Provider

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -16,6 +16,9 @@ package org.eclipse.edc.identityhub.tests;
 
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.identithub.spi.did.model.DidResource;
+import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
@@ -52,6 +55,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -165,7 +169,6 @@ public class ParticipantContextApiEndToEndTest {
 
         }
 
-
         @Test
         void createNewUser_principalIsNotSuperuser_expect403(IdentityHubEndToEndTestContext context, EventRouter router) {
             var subscriber = mock(EventSubscriber.class);
@@ -213,6 +216,28 @@ public class ParticipantContextApiEndToEndTest {
                     .body(notNullValue());
             verifyNoInteractions(subscriber);
             assertThat(context.getKeyPairsForParticipant(manifest.getParticipantId())).isEmpty();
+        }
+
+        @Test
+        void createNewUser_whenDidAlreadyExists_expect409(IdentityHubEndToEndTestContext context, DidResourceStore didResourceStore, EventRouter router) {
+            var subscriber = mock(EventSubscriber.class);
+            router.registerSync(ParticipantContextCreated.class, subscriber);
+            var apikey = context.createSuperUser();
+
+            var manifest = context.createNewParticipant().build();
+
+            didResourceStore.save(DidResource.Builder.newInstance().did(manifest.getDid()).document(DidDocument.Builder.newInstance().build()).build());
+
+            context.getIdentityApiEndpoint().baseRequest()
+                    .header(new Header("x-api-key", apikey))
+                    .contentType(ContentType.JSON)
+                    .body(manifest)
+                    .post("/v1alpha/participants/")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(409);
+
+            verify(subscriber, never()).on(argThat(env -> ((ParticipantContextCreated) env.getPayload()).getParticipantId().equals(manifest.getParticipantId())));
         }
 
         @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/ParticipantContextApiEndToEndTest.java
@@ -112,7 +112,7 @@ public class ParticipantContextApiEndToEndTest {
         }
 
         @Test
-        void createNewUser_principalIsSuperser(IdentityHubEndToEndTestContext context, EventRouter router) {
+        void createNewUser_principalIsSuperuser(IdentityHubEndToEndTestContext context, EventRouter router) {
             var subscriber = mock(EventSubscriber.class);
             router.registerSync(ParticipantContextCreated.class, subscriber);
             var apikey = context.createSuperUser();

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -139,7 +139,7 @@ public class IdentityHubEndToEndTestContext {
         return ParticipantManifest.Builder.newInstance()
                 .participantId("another-participant")
                 .active(false)
-                .did("did:web:another:participant")
+                .did("did:web:another:participant:" + UUID.randomUUID())
                 .serviceEndpoint(new Service("test-service", "test-service-type", "https://test.com"))
                 .key(createKeyDescriptor().build());
     }


### PR DESCRIPTION
## What this PR changes/adds

defensively checks if another ParticipantContext already exists with the same DID when creating ParticipantContexts

## Why it does that

defensive checks are better than relying on the database operation failing with a PK violation
