### PR TITLE
chore: deprecate resolution api context

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -54,8 +54,8 @@ jobs:
           docker run -d --rm --name identity-hub \
             -e "WEB_HTTP_IDENTITY_PORT=8182" \
             -e "WEB_HTTP_IDENTITY_PATH=/api/identity" \
-            -e "WEB_HTTP_RESOLUTION_PORT=10001" \
-            -e "WEB_HTTP_RESOLUTION_PATH=/api/resolution" \
+            -e "WEB_HTTP_PRESENTATION_PORT=10001" \
+            -e "WEB_HTTP_PRESENTATION_PATH=/api/presentation" \
             identity-hub:latest
 
       - name: 'Wait for Identity Hub to be healthy'

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ extensibility mechanism.
 Here, developers find everything necessary to build and run a basic "vanilla" version of IdentityHub.
 
 ## Security Warning
-Older versions of IdentityHub (in particular <= 0.3.1 ) **must not be used anymore**, as they were intended for proof-of-concept 
-purposes only and may contain **significant security vulnerabilities** (for example missing authn/authz on the API) and possibly 
-others. 
+
+Older versions of IdentityHub (in particular <= 0.3.1 ) **must not be used anymore**, as they were intended for
+proof-of-concept
+purposes only and may contain **significant security vulnerabilities** (for example missing authn/authz on the API) and
+possibly
+others.
 **Please always use the latest version of IdentityHub.**
 
 ## Quick start
@@ -39,8 +42,8 @@ two ways of running IdentityHub:
 Once the jar file is built, IdentityHub can be launched using this shell command:
 
 ```bash
-java -Dweb.http.resolution.port=10001 \
-     -Dweb.http.resolution.path="/api/resolution" \
+java -Dweb.http.presentation.port=10001 \
+     -Dweb.http.presentation.path="/api/presentation" \
      -Dweb.http.port=8181 \
      -Dweb.http.path="/api" \
      -Dweb.http.identity.port=8182 \
@@ -49,7 +52,7 @@ java -Dweb.http.resolution.port=10001 \
      -jar launcher/build/libs/identity-hub.jar
 ```
 
-this will expose the Presentation API at `http://localhost:10001/api/resolution` and the Identity API
+this will expose the Presentation API at `http://localhost:10001/api/presentation` and the Identity API
 at `http://localhost:8191/api/identity`. More information about IdentityHub's APIs can be
 found [here](docs/developer/architecture/identityhub-apis.md)
 
@@ -63,8 +66,8 @@ docker build -t identity-hub ./launcher
 
 ```bash
 docker run --rm --name identity-hub \
-            -e "WEB_HTTP_RESOLUTION_PORT=10001" \
-            -e "WEB_HTTP_RESOLUTION_PATH=/api/resolution/" \
+            -e "WEB_HTTP_PRESENTATION_PORT=10001" \
+            -e "WEB_HTTP_PRESENTATION_PATH=/api/presentation/" \
             -e "WEB_HTTP_PATH=/api" \
             -e "WEB_HTTP_PORT=8181" \
             -e "WEB_HTTP_IDENTITY_PORT=8182" \

--- a/core/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApi.java
+++ b/core/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/v1/PresentationApi.java
@@ -30,7 +30,7 @@ import jakarta.json.JsonObject;
 import jakarta.ws.rs.core.Response;
 
 @OpenAPIDefinition(
-        info = @Info(description = "This represents the Presentation API as per DCP specification. It serves endpoints to query for specific VerifiablePresentations.", title = "Resolution API",
+        info = @Info(description = "This represents the Presentation API as per DCP specification. It serves endpoints to query for specific VerifiablePresentations.", title = "Presentation API",
                 version = "1"))
 @SecurityScheme(name = "Authentication",
         description = "Self-Issued ID token containing an access_token",
@@ -39,7 +39,7 @@ import jakarta.ws.rs.core.Response;
         bearerFormat = "JWT")
 public interface PresentationApi {
 
-    @Tag(name = "Resolution API")
+    @Tag(name = "Presentation API")
     @Operation(description = "Issues a new presentation query, that contains either a DIF presentation definition, or a list of scopes",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ApiSchema.PresentationQuerySchema.class))),
             responses = {

--- a/core/presentation-api/src/main/resources/presentation-api-version.json
+++ b/core/presentation-api/src/main/resources/presentation-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1",
-    "lastUpdated": "2024-08-22T09:20:00Z",
+    "lastUpdated": "2024-08-22T12:00:00Z",
     "maturity": "stable"
   }
 ]

--- a/docs/developer/architecture/identity-trust-protocol/identity-hub-modules.md
+++ b/docs/developer/architecture/identity-trust-protocol/identity-hub-modules.md
@@ -75,7 +75,7 @@ all SPIs that are relevant here.
 ## Hub API (`:core:presentation-api`)
 
 This module contains implementations for
-the [Resolution API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#4-resolution-api)
+the [Presentation API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#4-resolution-api)
 and
 the [Storage API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#5-storage-api).
 Is

--- a/docs/developer/architecture/identityhub-apis.md
+++ b/docs/developer/architecture/identityhub-apis.md
@@ -11,7 +11,7 @@ These APIs is intended to be exposed to the internet.
 This API allows clients to request credentials in the form of a VerifiablePresentation. It is part of the Verifiable
 Credential Presentation protocol of the DCP specification.
 
-Please refer to the [API documentation](https://eclipse-edc.github.io/IdentityHub/openapi/ih-resolution-api) for more
+Please refer to the [API documentation](https://eclipse-edc.github.io/IdentityHub/openapi/presentation-api) for more
 details.
 
 ### Storage API

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
@@ -146,7 +146,7 @@ public class PresentationApiEndToEndTest {
         @Test
         void query_tokenNotPresent_shouldReturn401(IdentityHubEndToEndTestContext context) {
 
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType("application/json")
                     .post("/v1/participants/%s/presentations/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                     .then()
@@ -166,7 +166,7 @@ public class PresentationApiEndToEndTest {
                       "@type": "PresentationQueryMessage"
                     }
                     """;
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, generateSiToken())
                     .body(query)
@@ -191,7 +191,7 @@ public class PresentationApiEndToEndTest {
                       }
                     }
                     """;
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, generateSiToken())
                     .body(query)
@@ -209,7 +209,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(spoofedKey.toPublicKey()));
 
             var token = generateSiToken();
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)
@@ -231,7 +231,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)
@@ -275,7 +275,7 @@ public class PresentationApiEndToEndTest {
             store.create(res2);
 
 
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_ADDITIONAL_SCOPE)
@@ -295,7 +295,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
-            var response = context.getResolutionEndpoint().baseRequest()
+            var response = context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)
@@ -329,7 +329,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
-            var response = context.getResolutionEndpoint().baseRequest()
+            var response = context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)
@@ -390,7 +390,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
             var token = generateSiToken();
-            var response = context.getResolutionEndpoint().baseRequest()
+            var response = context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)
@@ -431,7 +431,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)
@@ -463,7 +463,7 @@ public class PresentationApiEndToEndTest {
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:consumer#key1"))).thenReturn(Result.success(CONSUMER_KEY.toPublicKey()));
             when(DID_PUBLIC_KEY_RESOLVER.resolveKey(eq("did:web:provider#key1"))).thenReturn(Result.success(PROVIDER_KEY.toPublicKey()));
 
-            context.getResolutionEndpoint().baseRequest()
+            context.getPresentationEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, token)
                     .body(VALID_QUERY_WITH_SCOPE)

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -100,8 +100,8 @@ public class IdentityHubEndToEndTestContext {
         return configuration.getIdentityApiEndpoint();
     }
 
-    public IdentityHubRuntimeConfiguration.Endpoint getResolutionEndpoint() {
-        return configuration.getResolutionEndpoint();
+    public IdentityHubRuntimeConfiguration.Endpoint getPresentationEndpoint() {
+        return configuration.getPresentationEndpoint();
     }
 
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubRuntimeConfiguration.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubRuntimeConfiguration.java
@@ -29,13 +29,13 @@ import static org.eclipse.edc.util.io.Ports.getFreePort;
  */
 public class IdentityHubRuntimeConfiguration {
 
-    private Endpoint resolutionEndpoint;
+    private Endpoint presentationEndpoint;
     private Endpoint identityEndpoint;
     private String id;
     private String name;
 
-    public Endpoint getResolutionEndpoint() {
-        return resolutionEndpoint;
+    public Endpoint getPresentationEndpoint() {
+        return presentationEndpoint;
     }
 
     public Map<String, String> config() {
@@ -44,8 +44,8 @@ public class IdentityHubRuntimeConfiguration {
                 put(PARTICIPANT_ID, id);
                 put("web.http.port", String.valueOf(getFreePort()));
                 put("web.http.path", "/api/v1");
-                put("web.http.resolution.port", String.valueOf(resolutionEndpoint.getUrl().getPort()));
-                put("web.http.resolution.path", resolutionEndpoint.getUrl().getPath());
+                put("web.http.presentation.port", String.valueOf(presentationEndpoint.getUrl().getPort()));
+                put("web.http.presentation.path", presentationEndpoint.getUrl().getPath());
                 put("web.http.identity.port", String.valueOf(identityEndpoint.getUrl().getPort()));
                 put("web.http.identity.path", identityEndpoint.getUrl().getPath());
                 put("edc.runtime.id", name);
@@ -81,8 +81,8 @@ public class IdentityHubRuntimeConfiguration {
         }
 
         public IdentityHubRuntimeConfiguration build() {
-            participant.resolutionEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/v1/resolution"), Map.of());
-            participant.identityEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/management"), Map.of());
+            participant.presentationEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/presentation"), Map.of());
+            participant.identityEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/identity"), Map.of());
             return participant;
         }
     }

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/IdentityHubApiContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/IdentityHubApiContext.java
@@ -17,5 +17,7 @@ package org.eclipse.edc.identityhub.spi;
 public interface IdentityHubApiContext {
     String IDENTITY = "identity";
     String IH_DID = "did";
-    String PRESENTATION = "resolution"; // should be "presentation", but this would break config
+    String PRESENTATION = "presentation";
+    @Deprecated(since = "0.9.0")
+    String RESOLUTION = "resolution";
 }


### PR DESCRIPTION
## What this PR changes/adds

deprecates the `resolution` api context and replaces all occurrences with `presentation`. if `web.http.presentation.*` is configured, that overrides `resolution`. if only `resolution` is configured, then a warning is issued.

## Why it does that

consistent naming.

## Linked Issue(s)

Closes #431

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
