### PR TITLE
docs: adds decision record for VC create/update API

### DIFF
--- a/docs/developer/decision-records/2024-08-23-identity_hub_identity_write_credentials_api/README.md
+++ b/docs/developer/decision-records/2024-08-23-identity_hub_identity_write_credentials_api/README.md
@@ -1,0 +1,17 @@
+# Identity Hub - Identity Write Credentials API
+
+## Decision
+
+Write endpoints (create/update) will be added to the Identity Hub identity API to
+give users a way to add VCs that weren't issued using DCP Issuance, but using some other means, or enable
+users to populate the VC storage with existing VCs after moving to a new IH instance or similar.
+
+## Rationale
+
+VCs might not always be issued through DCP Issuance, but instead through some other means (e.g. download json file
+containing the VC from a website...). In such cases, users need a way to add these VCs to the Identity Hub. This is why
+we introduce write/update endpoints to the Identity Hub identity API.
+
+> **_NOTE:_**  It is worth emphasizing that these new endpoints must not be used as issuance APIs, and thus should
+> not exposed publicly over the internet. The same warning applies for all other endpoints under the `identity` API
+> context.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -5,3 +5,4 @@
 - [2022-07-29 Self-description](2022-07-29-self-description/)
 - [2022-08-12 Code Quality Tooling](2022-08-12-code-quality-tooling/)
 - [2023-01-20 Credentials Verifier Output Format](2023-01-20-credentials-verifier-output-format/)
+- [2024-08-23 Identity Hub Write Credentials API](2024-08-23-identity_hub_identity_write_credentials_api/)


### PR DESCRIPTION
## What this PR changes/adds

DR for adding endpoints to create/update VCs.

## Why it does that

Offers a way to add credentials into the Identity Hub.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Contributes #434 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
