### PR TITLE
chore: align createParticipantContext operation with DR

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -74,6 +74,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
                     .document(document)
                     .did(document.getId())
                     .participantId(participantId)
+                    .state(DidState.GENERATED.code())
                     .build();
             var result = didResourceStore.save(res);
             return result.succeeded() ?

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -68,6 +68,7 @@ class DidDocumentServiceImplTest {
         var doc = createDidDocument().build();
         when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.success());
         assertThat(service.store(doc, "test-participant")).isSucceeded();
+        verify(storeMock).save(argThat(didResource -> didResource.getState() == DidState.GENERATED.code()));
     }
 
     @Test

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -61,9 +61,9 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
                     .build();
 
             didDocumentService.store(doc, manifest.getParticipantId())
-                    .compose(u -> manifest.isActive() ? didDocumentService.publish(doc.getId()) : success())
                     // adding the keypair event will cause the DidDocumentService to update the DID.
                     .compose(u -> keyPairService.addKeyPair(createdEvent.getParticipantId(), createdEvent.getManifest().getKey(), true))
+                    .compose(u -> manifest.isActive() ? didDocumentService.publish(doc.getId()) : success())
                     .onFailure(f -> monitor.warning("%s".formatted(f.getFailureDetail())));
 
         } else {


### PR DESCRIPTION
## What this PR changes/adds

aligns the behaviour of the `createParticipantContext` operation with [Decision Record 2024-09-02](https://github.com/eclipse-edc/IdentityHub/tree/main/docs/developer/decision-records/2024-09-02-resource-operations).

## Why it does that

have consistent behaviour

## Further notes

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
