### PR TITLE
chore: align deleteParticipantContext with DR

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
-import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -65,7 +64,6 @@ public class DidServicesExtension implements ServiceExtension {
     public DidDocumentService createDidDocumentService(ServiceExtensionContext context) {
         var service = new DidDocumentServiceImpl(transactionContext, didResourceStore, getDidPublisherRegistry(), context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
         eventRouter.registerSync(ParticipantContextUpdated.class, service);
-        eventRouter.registerSync(ParticipantContextDeleted.class, service);
         eventRouter.registerSync(KeyPairAdded.class, service);
         eventRouter.registerSync(KeyPairRevoked.class, service);
         return service;

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -15,6 +15,9 @@
 package org.eclipse.edc.identityhub.did;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
@@ -23,9 +26,16 @@ import org.eclipse.edc.identithub.spi.did.DidDocumentPublisherRegistry;
 import org.eclipse.edc.identithub.spi.did.model.DidResource;
 import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
 import org.eclipse.edc.keys.keyparsers.JwkParser;
 import org.eclipse.edc.keys.keyparsers.PemParser;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.StoreResult;
@@ -34,9 +44,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 
+import static org.eclipse.edc.iam.did.spi.document.DidConstants.JSON_WEB_KEY_2020;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -47,10 +60,11 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class DidDocumentServiceImplTest {
-    private final DidResourceStore storeMock = mock();
+    private final DidResourceStore didResourceStoreMock = mock();
     private final DidDocumentPublisherRegistry publisherRegistry = mock();
     private final DidDocumentPublisher publisherMock = mock();
     private DidDocumentServiceImpl service;
+    private Monitor monitorMock;
 
     @BeforeEach
     void setUp() {
@@ -60,23 +74,24 @@ class DidDocumentServiceImplTest {
         var registry = new KeyParserRegistryImpl();
         registry.register(new JwkParser(new ObjectMapper(), mock()));
         registry.register(new PemParser(mock()));
-        service = new DidDocumentServiceImpl(trx, storeMock, publisherRegistry, mock(), registry);
+        monitorMock = mock();
+        service = new DidDocumentServiceImpl(trx, didResourceStoreMock, publisherRegistry, monitorMock, registry);
     }
 
     @Test
     void store() {
         var doc = createDidDocument().build();
-        when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.success());
         assertThat(service.store(doc, "test-participant")).isSucceeded();
-        verify(storeMock).save(argThat(didResource -> didResource.getState() == DidState.GENERATED.code()));
+        verify(didResourceStoreMock).save(argThat(didResource -> didResource.getState() == DidState.GENERATED.code()));
     }
 
     @Test
     void store_alreadyExists() {
         var doc = createDidDocument().build();
-        when(storeMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.alreadyExists("foo"));
+        when(didResourceStoreMock.save(argThat(dr -> dr.getDocument().equals(doc)))).thenReturn(StoreResult.alreadyExists("foo"));
         assertThat(service.store(doc, "test-participant")).isFailed().detail().isEqualTo("foo");
-        verify(storeMock).save(any());
+        verify(didResourceStoreMock).save(any());
         verifyNoInteractions(publisherMock);
     }
 
@@ -84,68 +99,68 @@ class DidDocumentServiceImplTest {
     void deleteById() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.UNPUBLISHED).document(doc).build());
-        when(storeMock.deleteById(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.UNPUBLISHED).document(doc).build());
+        when(didResourceStoreMock.deleteById(any())).thenReturn(StoreResult.success());
 
         assertThat(service.deleteById(did)).isSucceeded();
 
-        verify(storeMock).findById(did);
-        verify(storeMock).deleteById(did);
-        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+        verify(didResourceStoreMock).findById(did);
+        verify(didResourceStoreMock).deleteById(did);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock, publisherRegistry);
     }
 
     @Test
     void deleteById_alreadyPublished() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
 
         assertThat(service.deleteById(did)).isFailed()
                 .detail()
                 .isEqualTo("Cannot delete DID '%s' because it is already published. Un-publish first!".formatted(did));
 
-        verify(storeMock).findById(did);
-        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+        verify(didResourceStoreMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock, publisherRegistry);
     }
 
     @Test
     void deleteById_notExists() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.UNPUBLISHED).document(doc).build());
-        when(storeMock.deleteById(any())).thenReturn(StoreResult.notFound("test-message"));
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.UNPUBLISHED).document(doc).build());
+        when(didResourceStoreMock.deleteById(any())).thenReturn(StoreResult.notFound("test-message"));
 
         assertThat(service.deleteById(did)).isFailed().detail().isEqualTo("test-message");
 
-        verify(storeMock).findById(did);
-        verify(storeMock).deleteById(did);
-        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+        verify(didResourceStoreMock).findById(did);
+        verify(didResourceStoreMock).deleteById(did);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock, publisherRegistry);
     }
 
     @Test
     void publish() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
         when(publisherMock.publish(did)).thenReturn(Result.success());
 
         assertThat(service.publish(did)).isSucceeded();
 
-        verify(storeMock).findById(did);
+        verify(didResourceStoreMock).findById(did);
         verify(publisherMock).publish(did);
-        verifyNoMoreInteractions(publisherMock, storeMock);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock);
     }
 
     @Test
     void publish_notExist() {
         var did = "did:web:test-did";
-        when(storeMock.findById(eq(did))).thenReturn(null);
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(null);
 
         assertThat(service.publish(did)).isFailed()
                 .detail().isEqualTo(service.notFoundMessage(did));
 
-        verify(storeMock).findById(did);
-        verifyNoMoreInteractions(publisherMock, storeMock);
+        verify(didResourceStoreMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock);
     }
 
     @Test
@@ -153,56 +168,56 @@ class DidDocumentServiceImplTest {
         var doc = createDidDocument().build();
         var did = doc.getId();
         when(publisherRegistry.getPublisher(any())).thenReturn(null);
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
 
         assertThat(service.publish(did)).isFailed().detail()
                 .isEqualTo(service.noPublisherFoundMessage(did));
 
-        verify(storeMock).findById(did);
+        verify(didResourceStoreMock).findById(did);
         verify(publisherRegistry).getPublisher(did);
-        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock, publisherRegistry);
     }
 
     @Test
     void publish_publisherReportsError() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
         when(publisherMock.publish(did)).thenReturn(Result.failure("test-failure"));
 
         assertThat(service.publish(did)).isFailed()
                 .detail()
                 .isEqualTo("test-failure");
 
-        verify(storeMock).findById(did);
+        verify(didResourceStoreMock).findById(did);
         verify(publisherMock).publish(did);
-        verifyNoMoreInteractions(publisherMock, storeMock);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock);
     }
 
     @Test
     void unpublish() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
         when(publisherMock.unpublish(did)).thenReturn(Result.success());
 
         assertThat(service.unpublish(did)).isSucceeded();
 
-        verify(storeMock).findById(did);
+        verify(didResourceStoreMock).findById(did);
         verify(publisherMock).unpublish(did);
-        verifyNoMoreInteractions(publisherMock, storeMock);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock);
     }
 
     @Test
     void unpublish_notExist() {
         var did = "did:web:test-did";
-        when(storeMock.findById(eq(did))).thenReturn(null);
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(null);
 
         assertThat(service.unpublish(did)).isFailed()
                 .detail().isEqualTo(service.notFoundMessage(did));
 
-        verify(storeMock).findById(did);
-        verifyNoMoreInteractions(publisherMock, storeMock);
+        verify(didResourceStoreMock).findById(did);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock);
     }
 
     @Test
@@ -210,30 +225,30 @@ class DidDocumentServiceImplTest {
         var doc = createDidDocument().build();
         var did = doc.getId();
         when(publisherRegistry.getPublisher(any())).thenReturn(null);
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
 
         assertThat(service.unpublish(did)).isFailed().detail()
                 .isEqualTo(service.noPublisherFoundMessage(did));
 
-        verify(storeMock).findById(did);
+        verify(didResourceStoreMock).findById(did);
         verify(publisherRegistry).getPublisher(did);
-        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock, publisherRegistry);
     }
 
     @Test
     void unpublish_publisherReportsError() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
         when(publisherMock.unpublish(did)).thenReturn(Result.failure("test-failure"));
 
         assertThat(service.unpublish(did)).isFailed()
                 .detail()
                 .isEqualTo("test-failure");
 
-        verify(storeMock).findById(did);
+        verify(didResourceStoreMock).findById(did);
         verify(publisherMock).unpublish(did);
-        verifyNoMoreInteractions(publisherMock, storeMock);
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock);
     }
 
     @Test
@@ -241,26 +256,26 @@ class DidDocumentServiceImplTest {
         var q = QuerySpec.max();
         var doc = createDidDocument().build();
         var res = DidResource.Builder.newInstance().did(doc.getId()).state(DidState.PUBLISHED).document(doc).build();
-        when(storeMock.query(any())).thenReturn(List.of(res));
+        when(didResourceStoreMock.query(any())).thenReturn(List.of(res));
 
         assertThat(service.queryDocuments(q)).isSucceeded();
 
-        verify(storeMock).query(eq(q));
-        verifyNoMoreInteractions(publisherMock, storeMock, publisherRegistry);
+        verify(didResourceStoreMock).query(eq(q));
+        verifyNoMoreInteractions(publisherMock, didResourceStoreMock, publisherRegistry);
     }
 
     @Test
     void addEndpoint() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
-        when(storeMock.update(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
         var res = service.addService(did, new Service("new-id", "test-type", "https://test.com"));
         assertThat(res).isSucceeded();
 
-        verify(storeMock).findById(eq(did));
-        verify(storeMock).update(any());
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verify(didResourceStoreMock).update(any());
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
@@ -268,28 +283,28 @@ class DidDocumentServiceImplTest {
         var newService = new Service("new-id", "test-type", "https://test.com");
         var doc = createDidDocument().service(List.of(newService)).build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
         var res = service.addService(did, newService);
         assertThat(res).isFailed()
                 .detail()
                 .isEqualTo("DID 'did:web:testdid' already contains a service endpoint with ID 'new-id'.");
 
-        verify(storeMock).findById(eq(did));
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
     void addEndpoint_didNotFound() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(null);
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(null);
         var res = service.addService(did, new Service("test-id", "test-type", "https://test.com"));
         assertThat(res).isFailed()
                 .detail()
                 .isEqualTo("DID 'did:web:testdid' not found.");
 
-        verify(storeMock).findById(eq(did));
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
@@ -297,15 +312,15 @@ class DidDocumentServiceImplTest {
         var toReplace = new Service("new-id", "test-type", "https://test.com");
         var doc = createDidDocument().service(List.of(toReplace)).build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
-        when(storeMock.update(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
 
         var res = service.replaceService(did, toReplace);
         assertThat(res).isSucceeded();
 
-        verify(storeMock).findById(eq(did));
-        verify(storeMock).update(any());
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verify(didResourceStoreMock).update(any());
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
@@ -313,29 +328,29 @@ class DidDocumentServiceImplTest {
         var replace = new Service("new-id", "test-type", "https://test.com");
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
 
         var res = service.replaceService(did, replace);
         assertThat(res).isFailed()
                 .detail()
                 .isEqualTo("DID 'did:web:testdid' does not contain a service endpoint with ID 'new-id'.");
 
-        verify(storeMock).findById(eq(did));
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
     void replaceEndpoint_didNotFound() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(null);
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(null);
         var res = service.replaceService(did, new Service("test-id", "test-type", "https://test.com"));
         assertThat(res).isFailed()
                 .detail()
                 .isEqualTo("DID 'did:web:testdid' not found.");
 
-        verify(storeMock).findById(eq(did));
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
@@ -343,45 +358,217 @@ class DidDocumentServiceImplTest {
         var toRemove = new Service("new-id", "test-type", "https://test.com");
         var doc = createDidDocument().service(List.of(toRemove)).build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
-        when(storeMock.update(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
 
         var res = service.removeService(did, toRemove.getId());
         assertThat(res).isSucceeded();
 
-        verify(storeMock).findById(eq(did));
-        verify(storeMock).update(any());
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verify(didResourceStoreMock).update(any());
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
     void removeEndpoint_doesNotExist() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).document(doc).build());
 
         var res = service.removeService(did, "not-exist-id");
         assertThat(res).isFailed()
                 .detail().isEqualTo("DID 'did:web:testdid' does not contain a service endpoint with ID 'not-exist-id'.");
 
-        verify(storeMock).findById(eq(did));
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
     @Test
     void removeEndpoint_didNotFound() {
         var doc = createDidDocument().build();
         var did = doc.getId();
-        when(storeMock.findById(eq(did))).thenReturn(null);
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(null);
         var res = service.removeService(did, "does-not-matter-id");
         assertThat(res).isFailed()
                 .detail()
                 .isEqualTo("DID 'did:web:testdid' not found.");
 
-        verify(storeMock).findById(eq(did));
-        verifyNoMoreInteractions(storeMock, publisherMock);
+        verify(didResourceStoreMock).findById(eq(did));
+        verifyNoMoreInteractions(didResourceStoreMock, publisherMock);
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void onParticipantContextUpdated_whenDeactivates_shouldUnpublish() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var participantId = "test-id";
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build();
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
+        when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
+
+        service.on(EventEnvelope.Builder.newInstance()
+                .payload(ParticipantContextUpdated.Builder.newInstance()
+                        .newState(ParticipantContextState.DEACTIVATED)
+                        .participantId(participantId)
+                        .build())
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .build());
+
+        verify(publisherMock).unpublish(eq(did));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onParticipantContextUpdated_whenDeactivated_notPublished_shouldBeNoop() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var participantId = "test-id";
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
+        when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
+
+        service.on(EventEnvelope.Builder.newInstance()
+                .payload(ParticipantContextUpdated.Builder.newInstance()
+                        .newState(ParticipantContextState.DEACTIVATED)
+                        .participantId(participantId)
+                        .build())
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .build());
+
+        verifyNoInteractions(publisherMock);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onParticipantContextUpdated_whenDeactivated_published_shouldBeNoop() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var participantId = "test-id";
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build();
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
+        when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
+
+        service.on(EventEnvelope.Builder.newInstance()
+                .payload(ParticipantContextUpdated.Builder.newInstance()
+                        .newState(ParticipantContextState.DEACTIVATED)
+                        .participantId(participantId)
+                        .build())
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .build());
+
+        verify(publisherMock).unpublish(eq(did));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onParticipantContextUpdated_whenActivated_shouldPublish() {
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var participantId = "test-id";
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
+        when(publisherMock.publish(anyString())).thenReturn(Result.success());
+
+        service.on(EventEnvelope.Builder.newInstance()
+                .payload(ParticipantContextUpdated.Builder.newInstance()
+                        .newState(ParticipantContextState.ACTIVATED)
+                        .participantId(participantId)
+                        .build())
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .build());
+
+        verify(publisherMock).publish(eq(did));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onKeyPairAdded() throws JOSEException {
+        var keyId = "key-id";
+        var key = new ECKeyGenerator(Curve.P_256).keyID(keyId).generate();
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+
+        when(didResourceStoreMock.query(any(QuerySpec.class))).thenReturn(List.of(didResource));
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
+
+        var event = EventEnvelope.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .payload(KeyPairAdded.Builder.newInstance()
+                        .keyId(keyId)
+                        .keyPairResourceId("test-resource-id")
+                        .participantId("test-participant")
+                        .publicKey(key.toPublicJWK().toJSONString(), JSON_WEB_KEY_2020)
+                        .build())
+                .build();
+
+        service.on(event);
+
+        verify(didResourceStoreMock).query(any(QuerySpec.class));
+        verify(didResourceStoreMock).update(argThat(dr -> dr.getDocument().getVerificationMethod().stream().anyMatch(vm -> vm.getId().equals(keyId))));
+        verifyNoMoreInteractions(didResourceStoreMock);
+        verifyNoInteractions(publisherMock);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onKeyPairRevoked() throws JOSEException {
+        var keyId = "key-id";
+        var doc = createDidDocument().verificationMethod(List.of(VerificationMethod.Builder.newInstance()
+                        .id(keyId)
+                        .publicKeyJwk(new ECKeyGenerator(Curve.P_256).keyID(keyId).generate().toJSONObject())
+                        .build()))
+                .build();
+        var did = doc.getId();
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+
+        when(didResourceStoreMock.query(any(QuerySpec.class))).thenReturn(List.of(didResource));
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
+
+        var event = EventEnvelope.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .payload(KeyPairRevoked.Builder.newInstance()
+                        .keyId(keyId)
+                        .keyPairResourceId("test-resource-id")
+                        .participantId("test-participant")
+                        .build())
+                .build();
+
+        service.on(event);
+
+        verify(didResourceStoreMock).query(any(QuerySpec.class));
+        // assert that the DID Doc does not contain a VerificationMethod with the ID that was revoked
+        verify(didResourceStoreMock).update(argThat(dr -> dr.getDocument().getVerificationMethod().stream().noneMatch(vm -> vm.getId().equals(keyId))));
+        verifyNoMoreInteractions(didResourceStoreMock);
+        verifyNoInteractions(publisherMock);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onOtherEvent_shouldLogWarning() {
+        service.on(EventEnvelope.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .payload(new Event() {
+                    @Override
+                    public String name() {
+                        return "TestEvent";
+                    }
+                })
+                .build());
+        verify(monitorMock).warning(startsWith("Received event with unexpected payload type: "));
+    }
 
     private DidDocument.Builder createDidDocument() {
         return DidDocument.Builder.newInstance()

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 
@@ -42,6 +43,8 @@ public class KeyPairServiceExtension implements ServiceExtension {
     private EventRouter eventRouter;
     @Inject
     private Clock clock;
+    @Inject
+    private TransactionContext transactionContext;
 
     private KeyPairObservable observable;
 
@@ -52,7 +55,7 @@ public class KeyPairServiceExtension implements ServiceExtension {
 
     @Provider
     public KeyPairService createParticipantService(ServiceExtensionContext context) {
-        var service = new KeyPairServiceImpl(keyPairResourceStore, vault, context.getMonitor().withPrefix("KeyPairService"), keyPairObservable());
+        var service = new KeyPairServiceImpl(keyPairResourceStore, vault, context.getMonitor().withPrefix("KeyPairService"), keyPairObservable(), transactionContext);
         eventRouter.registerSync(ParticipantContextDeleted.class, service);
         return service;
     }

--- a/core/identity-hub-keypairs/src/test/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImplTest.java
+++ b/core/identity-hub-keypairs/src/test/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImplTest.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -53,7 +54,7 @@ class KeyPairServiceImplTest {
     private final KeyPairResourceStore keyPairResourceStore = mock(i -> StoreResult.success());
     private final Vault vault = mock();
     private final KeyPairObservable observableMock = mock();
-    private final KeyPairServiceImpl keyPairService = new KeyPairServiceImpl(keyPairResourceStore, vault, mock(), observableMock);
+    private final KeyPairServiceImpl keyPairService = new KeyPairServiceImpl(keyPairResourceStore, vault, mock(), observableMock, new NoopTransactionContext());
 
 
     @ParameterizedTest(name = "make default: {0}")

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -17,11 +17,16 @@ package org.eclipse.edc.identityhub.participantcontext;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleting;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.stream.Stream;
 
 import static org.eclipse.edc.spi.result.ServiceResult.success;
 
@@ -66,8 +71,25 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
                     .compose(u -> manifest.isActive() ? didDocumentService.publish(doc.getId()) : success())
                     .onFailure(f -> monitor.warning("%s".formatted(f.getFailureDetail())));
 
+        } else if (payload instanceof ParticipantContextDeleting deletionEvent) {
+            var participantContext = deletionEvent.getParticipantContext();
+
+            // unpublish and delete did document, remove keypairs
+            didDocumentService.unpublish(participantContext.getDid())
+                    .compose(u -> didDocumentService.deleteById(participantContext.getDid()))
+                    .compose(u -> keyPairService.query(KeyPairResource.queryByParticipantId(participantContext.getParticipantId()).build()))
+                    .compose(keyPairs -> keyPairs.stream()
+                            .map(r -> keyPairService.revokeKey(r.getId(), null))
+                            .reduce(this::merge)
+                            .orElse(success()))
+                    .onFailure(f -> monitor.warning("Removing key pairs from a deleted ParticipantContext failed: %s".formatted(f.getFailureDetail())));
         } else {
             monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
         }
+    }
+
+    private ServiceResult<Void> merge(ServiceResult<Void> sr1, ServiceResult<Void> sr2) {
+        return sr1.succeeded() && sr2.succeeded() ? success() :
+                ServiceResult.unexpected(Stream.concat(sr1.getFailureMessages().stream(), sr2.getFailureMessages().stream()).toArray(String[]::new));
     }
 }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventPublisher.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventPublisher.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.participantcontext;
 
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleting;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextEvent;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextListener;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
@@ -49,6 +50,15 @@ public class ParticipantContextEventPublisher implements ParticipantContextListe
         var event = ParticipantContextUpdated.Builder.newInstance()
                 .participantId(updatedContext.getParticipantId())
                 .newState(updatedContext.getStateAsEnum())
+                .build();
+        publish(event);
+    }
+
+    @Override
+    public void deleting(ParticipantContext deletedContext) {
+        var event = ParticipantContextDeleting.Builder.newInstance()
+                .participantId(deletedContext.getParticipantId())
+                .participant(deletedContext)
                 .build();
         publish(event);
     }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleting;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextObservable;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
@@ -71,6 +72,7 @@ public class ParticipantContextExtension implements ServiceExtension {
                 didDocumentService, keyPairService);
 
         eventRouter.registerSync(ParticipantContextCreated.class, coordinator);
+        eventRouter.registerSync(ParticipantContextDeleting.class, coordinator);
     }
 
     @Provider

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -97,7 +97,9 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
                 return ServiceResult.notFound("A ParticipantContext with ID '%s' does not exist.");
             }
 
+            observable.invokeForEach(l -> l.deleting(participantContext));
             var res = participantContextStore.deleteById(participantId);
+            vault.deleteSecret(participantContext.getApiTokenAlias());
             if (res.failed()) {
                 return fromFailure(res);
             }

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -49,6 +49,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -223,7 +224,8 @@ class ParticipantContextServiceImplTest {
         assertThat(participantContextService.deleteParticipantContext("test-id")).isSucceeded();
 
         verify(participantContextStore).deleteById(anyString());
-        verify(observableMock).invokeForEach(any());
+        verify(observableMock, times(2)).invokeForEach(any());
+        verify(vault).deleteSecret(anyString());
         verifyNoMoreInteractions(vault, observableMock);
     }
 
@@ -239,7 +241,9 @@ class ParticipantContextServiceImplTest {
                     Assertions.assertThat(f.getFailureDetail()).isEqualTo("foo bar");
                 });
 
+        verify(observableMock).invokeForEach(any()); //deleting
         verify(participantContextStore).deleteById(anyString());
+        verify(vault).deleteSecret(anyString());
         verifyNoMoreInteractions(vault, observableMock);
     }
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -50,6 +50,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.Mockito.spy;
+
 /**
  * Identity Hub end to end context used in tests extended with {@link IdentityHubEndToEndExtension}
  */
@@ -136,7 +138,6 @@ public class IdentityHubEndToEndTestContext {
         return configuration.getPresentationEndpoint();
     }
 
-
     public Collection<DidDocument> getDidForParticipant(String participantId) {
         return runtime.getService(DidDocumentService.class).queryDocuments(QuerySpec.Builder.newInstance()
                 .filter(new Criterion("participantId", "=", participantId))
@@ -198,6 +199,10 @@ public class IdentityHubEndToEndTestContext {
                 .query(QuerySpec.Builder.newInstance().filter(new Criterion("id", "=", credentialId)).build())
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()))
                 .stream().findFirst();
+    }
+
+    public <S> S spyService(Class<S> serviceClass) {
+        return spy(runtime.getService(serviceClass));
     }
 
 }

--- a/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisher.java
+++ b/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisher.java
@@ -74,11 +74,6 @@ public class LocalDidPublisher implements DidDocumentPublisher {
             return Result.failure("A DID Resource with the ID '%s' was not found.".formatted(did));
         }
 
-        if (!isPublished(existingDocument)) {
-            monitor.info("Un-publish DID Resource '%s': not published -> NOOP.".formatted(did));
-            // do not return early, the state could be anything
-        }
-
         existingDocument.transitionState(DidState.UNPUBLISHED);
         return didResourceStore.update(existingDocument)
                 .map(v -> success())

--- a/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherTest.java
+++ b/extensions/did/local-did-publisher/src/test/java/org/eclipse/edc/identityhub/publisher/did/local/LocalDidPublisherTest.java
@@ -157,7 +157,6 @@ class LocalDidPublisherTest {
         verify(storeMock).update(any());
         verify(observableMock).invokeForEach(any());
         verifyNoMoreInteractions(storeMock, observableMock);
-        verify(monitor).info("Un-publish DID Resource 'did:web:test': not published -> NOOP.");
     }
 
     @Test

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextDeleting.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextDeleting.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.participantcontext.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
+
+/**
+ * Event that signals that a {@link ParticipantContext} is in the process of being deleted. This event is emitted <em>before</em>
+ * any storage interaction (= deletion) occurs.
+ */
+@JsonDeserialize(builder = ParticipantContextDeleting.Builder.class)
+public class ParticipantContextDeleting extends ParticipantContextEvent {
+    private ParticipantContext participantContext;
+
+    @Override
+    public String name() {
+        return "participantcontext.deleting";
+    }
+
+    public ParticipantContext getParticipantContext() {
+        return participantContext;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends ParticipantContextEvent.Builder<ParticipantContextDeleting, Builder> {
+
+        private Builder() {
+            super(new ParticipantContextDeleting());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        @Override
+        public Builder self() {
+            return this;
+        }
+
+        public Builder participant(ParticipantContext deletedContext) {
+            this.event.participantContext = deletedContext;
+            return self();
+        }
+    }
+}

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextListener.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextListener.java
@@ -46,10 +46,19 @@ public interface ParticipantContextListener {
     }
 
     /**
-     * Notifies about the fact that a {@link ParticipantContext} has been deleted, and further action, such as deleting keypairs or updating DID documents
-     * can now happen.
+     * Notifies about the fact that the deletion of a {@link ParticipantContext} is imminent. This is useful if resources like keypairs,
+     * DID documents etc. should be cleaned up <em>before the deletion of the {@link ParticipantContext}</em>.
      *
-     * @param deletedContext The updated (already persisted) participant context
+     * @param deletedContext The ParticipantContext that is going to be deleted.
+     */
+    default void deleting(ParticipantContext deletedContext) {
+
+    }
+
+    /**
+     * Notifies about the fact that a {@link ParticipantContext} and all associated data (key-pairs, DID documents, etc) have been deleted.
+     *
+     * @param deletedContext The deleted participant context
      */
     default void deleted(ParticipantContext deletedContext) {
 


### PR DESCRIPTION
## What this PR changes/adds

Aligns the code base with [this decision-record](https://github.com/eclipse-edc/IdentityHub/tree/main/docs/developer/decision-records/2024-09-02-resource-operations#2-deleting-a-participant-context-deleteparticipantcontext), specifically the delete-participant action.

In doing so, the following changes were made

- new event type `ParticipantContextDeleting` was introduced to signal an impending deletion. This event is consumed by the `ParticipantContextEventCoordinator` that triggers the `DidDocumentService` to unpublish and delete the DID Docs, and the `KeyPairService` to revoke the key.

- the `DidDocumentService` does **not** consume the `ParticipantContextDeleted` event anymore, because it gets invoked directly by the coordinator
- `KeyPairServiceImpl`: added transaction context
- unpublishing DIDs: the check if a DidDocument is in `PUBLISHED` state was moved from the publisher to the `DidDocumentService`

## Why it does that

alignment with the decision decision-records

## Further notes

other changes in the PR may not yet correctly reflect other sections of the D-R, those will get refactored in subsequent PRs.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
