### PR TITLE
chore: align DID operations with DR

### DIFF
--- a/core/identity-hub-did/build.gradle.kts
+++ b/core/identity-hub-did/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(project(":spi:did-spi"))
 
     implementation(project(":spi:keypair-spi"))
+    implementation(project(":spi:identity-hub-store-spi"))
     implementation(project(":spi:participant-context-spi"))
     implementation(libs.edc.core.connector) // for the reflection-based query resolver
     implementation(libs.edc.lib.common.crypto)

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -61,7 +61,8 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     private final Monitor monitor;
     private final KeyParserRegistry keyParserRegistry;
 
-    public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry, ParticipantContextService participantContextService, Monitor monitor, KeyParserRegistry keyParserRegistry) {
+    public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry,
+                                  ParticipantContextService participantContextService, Monitor monitor, KeyParserRegistry keyParserRegistry) {
         this.transactionContext = transactionContext;
         this.didResourceStore = didResourceStore;
         this.registry = registry;

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -24,7 +24,10 @@ import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.security.token.jwt.CryptoConverter;
@@ -54,13 +57,15 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     private final TransactionContext transactionContext;
     private final DidResourceStore didResourceStore;
     private final DidDocumentPublisherRegistry registry;
+    private final ParticipantContextService participantContextService;
     private final Monitor monitor;
     private final KeyParserRegistry keyParserRegistry;
 
-    public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry, Monitor monitor, KeyParserRegistry keyParserRegistry) {
+    public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry, ParticipantContextService participantContextService, Monitor monitor, KeyParserRegistry keyParserRegistry) {
         this.transactionContext = transactionContext;
         this.didResourceStore = didResourceStore;
         this.registry = registry;
+        this.participantContextService = participantContextService;
         this.monitor = monitor;
         this.keyParserRegistry = keyParserRegistry;
     }
@@ -101,18 +106,30 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     @Override
     public ServiceResult<Void> publish(String did) {
         return transactionContext.execute(() -> {
-            var existingDoc = didResourceStore.findById(did);
-            if (existingDoc == null) {
+            var existingResource = didResourceStore.findById(did);
+            if (existingResource == null) {
                 return ServiceResult.notFound(notFoundMessage(did));
             }
-            var publisher = registry.getPublisher(did);
-            if (publisher == null) {
-                return ServiceResult.badRequest(noPublisherFoundMessage(did));
-            }
-            var publishResult = publisher.publish(did);
-            return publishResult.succeeded() ?
-                    success() :
-                    ServiceResult.badRequest(publishResult.getFailureDetail());
+            var participantId = existingResource.getParticipantId();
+            return participantContextService.getParticipantContext(participantId)
+                    .map(ParticipantContext::getStateAsEnum)
+                    .compose(state -> {
+                        var canPublish = state.equals(ParticipantContextState.ACTIVATED);
+                        if (canPublish) {
+                            var publisher = registry.getPublisher(did);
+                            if (publisher == null) {
+                                return ServiceResult.badRequest(noPublisherFoundMessage(did));
+                            }
+                            var publishResult = publisher.publish(did);
+                            return publishResult.succeeded() ?
+                                    success() :
+                                    ServiceResult.badRequest(publishResult.getFailureDetail());
+                        }
+                        return ServiceResult.badRequest(("Cannot publish DID '%s' for participant '%s' because the ParticipantContext is not state '%s' state, " +
+                                "but was '%s'.")
+                                .formatted(did, participantId, ParticipantContextState.ACTIVATED, state));
+                    });
+
 
         });
     }
@@ -120,23 +137,35 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     @Override
     public ServiceResult<Void> unpublish(String did) {
         return transactionContext.execute(() -> {
-            var existingDoc = didResourceStore.findById(did);
-            if (existingDoc == null) {
+            var existingResource = didResourceStore.findById(did);
+            if (existingResource == null) {
                 return ServiceResult.notFound(notFoundMessage(did));
             }
-            var publisher = registry.getPublisher(did);
-            if (publisher == null) {
-                return ServiceResult.badRequest(noPublisherFoundMessage(did));
-            }
-            // only unpublish if published, NOOP otherwise
-            if (existingDoc.getState() == DidState.PUBLISHED.code()) {
-                var publishResult = publisher.unpublish(did);
-                return publishResult.succeeded() ?
-                        success() :
-                        ServiceResult.badRequest(publishResult.getFailureDetail());
-            }
-            monitor.info("Unpublishing DID Document '%s': not in state '%s', unpublishing is a NOOP.".formatted(did, existingDoc.getStateAsEnum()));
-            return success();
+
+            var participantId = existingResource.getParticipantId();
+            return participantContextService.getParticipantContext(participantId)
+                    .map(ParticipantContext::getStateAsEnum)
+                    .compose(state -> {
+                        var canUnpublish = state.equals(ParticipantContextState.DEACTIVATED);
+                        if (canUnpublish) {
+                            var publisher = registry.getPublisher(did);
+                            if (publisher == null) {
+                                return ServiceResult.badRequest(noPublisherFoundMessage(did));
+                            }
+                            // only unpublish if published, NOOP otherwise
+                            if (existingResource.getState() == DidState.PUBLISHED.code()) {
+                                var publishResult = publisher.unpublish(did);
+                                return publishResult.succeeded() ?
+                                        success() :
+                                        ServiceResult.badRequest(publishResult.getFailureDetail());
+                            }
+                            monitor.info("Unpublishing DID Document '%s': not in state '%s', unpublishing is a NOOP.".formatted(did, existingResource.getStateAsEnum()));
+                            return success();
+                        }
+                        return ServiceResult.badRequest(("Cannot un-publish DID '%s' for participant '%s' because the ParticipantContext is not state '%s' state, " +
+                                "but was '%s'.")
+                                .formatted(did, participantId, ParticipantContextState.DEACTIVATED, state));
+                    });
         });
     }
 

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -46,6 +47,8 @@ public class DidServicesExtension implements ServiceExtension {
 
     @Inject
     private KeyParserRegistry keyParserRegistry;
+    @Inject
+    private ParticipantContextService participantContextService;
 
     @Override
     public String name() {
@@ -62,7 +65,8 @@ public class DidServicesExtension implements ServiceExtension {
 
     @Provider
     public DidDocumentService createDidDocumentService(ServiceExtensionContext context) {
-        var service = new DidDocumentServiceImpl(transactionContext, didResourceStore, getDidPublisherRegistry(), context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
+        var service = new DidDocumentServiceImpl(transactionContext, didResourceStore,
+                getDidPublisherRegistry(), participantContextService, context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
         eventRouter.registerSync(ParticipantContextUpdated.class, service);
         eventRouter.registerSync(KeyPairAdded.class, service);
         eventRouter.registerSync(KeyPairRevoked.class, service);

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
@@ -63,6 +64,7 @@ class DidDocumentServiceImplTest {
     private final DidResourceStore didResourceStoreMock = mock();
     private final DidDocumentPublisherRegistry publisherRegistry = mock();
     private final DidDocumentPublisher publisherMock = mock();
+    private final ParticipantContextService participantContextServiceMock = mock();
     private DidDocumentServiceImpl service;
     private Monitor monitorMock;
 
@@ -75,7 +77,7 @@ class DidDocumentServiceImplTest {
         registry.register(new JwkParser(new ObjectMapper(), mock()));
         registry.register(new PemParser(mock()));
         monitorMock = mock();
-        service = new DidDocumentServiceImpl(trx, didResourceStoreMock, publisherRegistry, monitorMock, registry);
+        service = new DidDocumentServiceImpl(trx, didResourceStoreMock, publisherRegistry, participantContextServiceMock, monitorMock, registry);
     }
 
     @Test

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -30,6 +30,7 @@ import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
 import org.eclipse.edc.keys.keyparsers.JwkParser;
@@ -39,6 +40,7 @@ import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +63,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class DidDocumentServiceImplTest {
+    public static final String TEST_DID = "did:web:testdid";
+    private static final String TEST_PARTICIPANT_ID = "test-participant";
     private final DidResourceStore didResourceStoreMock = mock();
     private final DidDocumentPublisherRegistry publisherRegistry = mock();
     private final DidDocumentPublisher publisherMock = mock();
@@ -78,6 +82,12 @@ class DidDocumentServiceImplTest {
         registry.register(new PemParser(mock()));
         monitorMock = mock();
         service = new DidDocumentServiceImpl(trx, didResourceStoreMock, publisherRegistry, participantContextServiceMock, monitorMock, registry);
+
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .participantId(TEST_PARTICIPANT_ID)
+                .apiTokenAlias("token")
+                .state(ParticipantContextState.ACTIVATED)
+                .build()));
     }
 
     @Test
@@ -202,6 +212,11 @@ class DidDocumentServiceImplTest {
         var did = doc.getId();
         when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
         when(publisherMock.unpublish(did)).thenReturn(Result.success());
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .participantId(TEST_PARTICIPANT_ID)
+                .apiTokenAlias("token")
+                .state(ParticipantContextState.DEACTIVATED)
+                .build()));
 
         assertThat(service.unpublish(did)).isSucceeded();
 
@@ -228,6 +243,11 @@ class DidDocumentServiceImplTest {
         var did = doc.getId();
         when(publisherRegistry.getPublisher(any())).thenReturn(null);
         when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .participantId(TEST_PARTICIPANT_ID)
+                .apiTokenAlias("token")
+                .state(ParticipantContextState.DEACTIVATED)
+                .build()));
 
         assertThat(service.unpublish(did)).isFailed().detail()
                 .isEqualTo(service.noPublisherFoundMessage(did));
@@ -243,7 +263,12 @@ class DidDocumentServiceImplTest {
         var did = doc.getId();
         when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
         when(publisherMock.unpublish(did)).thenReturn(Result.failure("test-failure"));
-
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .participantId(TEST_PARTICIPANT_ID)
+                .apiTokenAlias("token")
+                .state(ParticipantContextState.DEACTIVATED)
+                .build()));
+        
         assertThat(service.unpublish(did)).isFailed()
                 .detail()
                 .isEqualTo("test-failure");
@@ -410,6 +435,12 @@ class DidDocumentServiceImplTest {
         when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
         when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
 
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .participantId(TEST_PARTICIPANT_ID)
+                .apiTokenAlias("token")
+                .state(ParticipantContextState.DEACTIVATED)
+                .build()));
+
         service.on(EventEnvelope.Builder.newInstance()
                 .payload(ParticipantContextUpdated.Builder.newInstance()
                         .newState(ParticipantContextState.DEACTIVATED)
@@ -455,6 +486,12 @@ class DidDocumentServiceImplTest {
         when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
         when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
         when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
+
+        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+                .participantId(TEST_PARTICIPANT_ID)
+                .apiTokenAlias("token")
+                .state(ParticipantContextState.DEACTIVATED)
+                .build()));
 
         service.on(EventEnvelope.Builder.newInstance()
                 .payload(ParticipantContextUpdated.Builder.newInstance()
@@ -574,10 +611,10 @@ class DidDocumentServiceImplTest {
 
     private DidDocument.Builder createDidDocument() {
         return DidDocument.Builder.newInstance()
-                .id("did:web:testdid")
+                .id(TEST_DID)
                 .service(List.of(new Service("test-service", "test-service", "https://test.service.com/")))
                 .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
-                        .id("did:web:testdid#key-1")
+                        .id(TEST_DID + "#key-1")
                         .publicKeyMultibase("saflasjdflaskjdflasdkfj")
                         .build()));
     }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextCoordinatorExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextCoordinatorExtension.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.participantcontext;
+
+import org.eclipse.edc.identithub.spi.did.DidDocumentService;
+import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleting;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import java.time.Clock;
+
+import static org.eclipse.edc.identityhub.participantcontext.ParticipantContextExtension.NAME;
+
+@Extension(NAME)
+public class ParticipantContextCoordinatorExtension implements ServiceExtension {
+    public static final String NAME = "ParticipantContext Coordinator Extension";
+
+    @Inject
+    private DidDocumentService didDocumentService;
+    @Inject
+    private KeyPairService keyPairService;
+    @Inject
+    private Clock clock;
+    @Inject
+    private EventRouter eventRouter;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var coordinator = new ParticipantContextEventCoordinator(context.getMonitor().withPrefix("ParticipantContextEventCoordinator"),
+                didDocumentService, keyPairService);
+
+        eventRouter.registerSync(ParticipantContextCreated.class, coordinator);
+        eventRouter.registerSync(ParticipantContextDeleting.class, coordinator);
+    }
+}

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -14,22 +14,17 @@
 
 package org.eclipse.edc.identityhub.participantcontext;
 
-import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
-import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
-import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleting;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextObservable;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
-import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
@@ -47,10 +42,6 @@ public class ParticipantContextExtension implements ServiceExtension {
     @Inject
     private TransactionContext transactionContext;
     @Inject
-    private KeyParserRegistry keyParserRegistry;
-    @Inject
-    private DidDocumentService didDocumentService;
-    @Inject
     private KeyPairService keyPairService;
     @Inject
     private Clock clock;
@@ -64,15 +55,6 @@ public class ParticipantContextExtension implements ServiceExtension {
     @Override
     public String name() {
         return NAME;
-    }
-
-    @Override
-    public void initialize(ServiceExtensionContext context) {
-        var coordinator = new ParticipantContextEventCoordinator(context.getMonitor().withPrefix("ParticipantContextEventCoordinator"),
-                didDocumentService, keyPairService);
-
-        eventRouter.registerSync(ParticipantContextCreated.class, coordinator);
-        eventRouter.registerSync(ParticipantContextDeleting.class, coordinator);
     }
 
     @Provider

--- a/core/identity-hub-participants/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/identity-hub-participants/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -12,3 +12,4 @@
 #
 #
 org.eclipse.edc.identityhub.participantcontext.ParticipantContextExtension
+org.eclipse.edc.identityhub.participantcontext.ParticipantContextCoordinatorExtension

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImplTest.java
@@ -221,10 +221,11 @@ class ParticipantContextServiceImplTest {
     void deleteParticipantContext() {
         when(participantContextStore.query(any())).thenReturn(StoreResult.success(List.of(createContext())));
         when(participantContextStore.deleteById(anyString())).thenReturn(StoreResult.success());
+        when(participantContextStore.update(any())).thenReturn(StoreResult.success());
         assertThat(participantContextService.deleteParticipantContext("test-id")).isSucceeded();
 
         verify(participantContextStore).deleteById(anyString());
-        verify(observableMock, times(2)).invokeForEach(any());
+        verify(observableMock, times(3)).invokeForEach(any());
         verify(vault).deleteSecret(anyString());
         verifyNoMoreInteractions(vault, observableMock);
     }
@@ -234,6 +235,8 @@ class ParticipantContextServiceImplTest {
     void deleteParticipantContext_whenNotExists() {
         when(participantContextStore.query(any())).thenReturn(StoreResult.success(List.of(createContext())));
         when(participantContextStore.deleteById(any())).thenReturn(StoreResult.notFound("foo bar"));
+        when(participantContextStore.update(any())).thenReturn(StoreResult.success());
+
         assertThat(participantContextService.deleteParticipantContext("test-id"))
                 .isFailed()
                 .satisfies(f -> {
@@ -241,7 +244,7 @@ class ParticipantContextServiceImplTest {
                     Assertions.assertThat(f.getFailureDetail()).isEqualTo("foo bar");
                 });
 
-        verify(observableMock).invokeForEach(any()); //deleting
+        verify(observableMock, times(2)).invokeForEach(any()); //deleting
         verify(participantContextStore).deleteById(anyString());
         verify(vault).deleteSecret(anyString());
         verifyNoMoreInteractions(vault, observableMock);

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
@@ -15,12 +15,14 @@
 package org.eclipse.edc.identityhub.tests;
 
 import io.restassured.http.Header;
+import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubEndToEndExtension;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubEndToEndTestContext;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
@@ -51,10 +53,16 @@ public class KeyPairResourceApiEndToEndTest {
     abstract static class Tests {
 
         @AfterEach
-        void tearDown(ParticipantContextService store) {
-            // purge all users
-            store.query(QuerySpec.max()).getContent()
-                    .forEach(pc -> store.deleteParticipantContext(pc.getParticipantId()).getContent());
+        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore) {
+            // purge all users, dids, keypairs
+
+            pcService.query(QuerySpec.max()).getContent()
+                    .forEach(pc -> pcService.deleteParticipantContext(pc.getParticipantId()).getContent());
+
+            didResourceStore.query(QuerySpec.max()).forEach(dr -> didResourceStore.deleteById(dr.getDid()).getContent());
+
+            keyPairResourceStore.query(QuerySpec.max()).getContent()
+                    .forEach(kpr -> keyPairResourceStore.deleteById(kpr.getId()).getContent());
         }
 
         @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
@@ -18,7 +18,9 @@ import io.restassured.http.Header;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
+import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialManifest;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubEndToEndExtension;
 import org.eclipse.edc.identityhub.tests.fixtures.IdentityHubEndToEndTestContext;
@@ -44,10 +46,16 @@ public class VerifiableCredentialApiEndToEndTest {
     abstract static class Tests {
 
         @AfterEach
-        void tearDown(ParticipantContextService store) {
-            // purge all users
-            store.query(QuerySpec.max()).getContent()
-                    .forEach(pc -> store.deleteParticipantContext(pc.getParticipantId()).getContent());
+        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore) {
+            // purge all users, dids, keypairs
+
+            pcService.query(QuerySpec.max()).getContent()
+                    .forEach(pc -> pcService.deleteParticipantContext(pc.getParticipantId()).getContent());
+
+            didResourceStore.query(QuerySpec.max()).forEach(dr -> didResourceStore.deleteById(dr.getDid()).getContent());
+
+            keyPairResourceStore.query(QuerySpec.max()).getContent()
+                    .forEach(kpr -> keyPairResourceStore.deleteById(kpr.getId()).getContent());
         }
 
         @Test


### PR DESCRIPTION
## What this PR changes/adds

aligns DID operations (publish, unpublish) with [this decision-record](https://github.com/eclipse-edc/IdentityHub/tree/main/docs/developer/decision-records/2024-09-02-resource-operations#did-document-operations).

## Why it does that

Alignment with D-R

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
