### PR TITLE
chore: align activate-key with D-R

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -17,7 +17,7 @@ package org.eclipse.edc.identityhub.did;
 import org.eclipse.edc.identithub.spi.did.DidDocumentPublisherRegistry;
 import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
-import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
@@ -68,8 +68,8 @@ public class DidServicesExtension implements ServiceExtension {
         var service = new DidDocumentServiceImpl(transactionContext, didResourceStore,
                 getDidPublisherRegistry(), participantContextService, context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
         eventRouter.registerSync(ParticipantContextUpdated.class, service);
-        eventRouter.registerSync(KeyPairAdded.class, service);
         eventRouter.registerSync(KeyPairRevoked.class, service);
+        eventRouter.registerSync(KeyPairActivated.class, service);
         return service;
     }
 }

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -26,7 +26,7 @@ import org.eclipse.edc.identithub.spi.did.DidDocumentPublisherRegistry;
 import org.eclipse.edc.identithub.spi.did.model.DidResource;
 import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
-import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
@@ -268,7 +268,7 @@ class DidDocumentServiceImplTest {
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.DEACTIVATED)
                 .build()));
-        
+
         assertThat(service.unpublish(did)).isFailed()
                 .detail()
                 .isEqualTo("test-failure");
@@ -530,7 +530,7 @@ class DidDocumentServiceImplTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void onKeyPairAdded() throws JOSEException {
+    void onKeyPairActivated() throws JOSEException {
         var keyId = "key-id";
         var key = new ECKeyGenerator(Curve.P_256).keyID(keyId).generate();
         var doc = createDidDocument().build();
@@ -543,7 +543,7 @@ class DidDocumentServiceImplTest {
         var event = EventEnvelope.Builder.newInstance()
                 .at(System.currentTimeMillis())
                 .id(UUID.randomUUID().toString())
-                .payload(KeyPairAdded.Builder.newInstance()
+                .payload(KeyPairActivated.Builder.newInstance()
                         .keyId(keyId)
                         .keyPairResourceId("test-resource-id")
                         .participantId("test-participant")

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.keypairs;
 
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairEvent;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairEventListener;
@@ -61,6 +62,17 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
                 .participantId(keyPair.getParticipantId())
                 .keyPairResourceId(keyPair.getId())
                 .keyId(keyPair.getKeyId())
+                .build();
+        publish(event);
+    }
+
+    @Override
+    public void activated(KeyPairResource activatedKeyPair, String type) {
+        var event = KeyPairActivated.Builder.newInstance()
+                .participantId(activatedKeyPair.getParticipantId())
+                .keyPairResourceId(activatedKeyPair.getId())
+                .publicKey(activatedKeyPair.getSerializedPublicKey(), type)
+                .keyId(activatedKeyPair.getKeyId())
                 .build();
         publish(event);
     }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -65,6 +65,11 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
                     // updating and adding a verification method happens as a result of the KeyPairAddedEvent
                     .build();
 
+            if (manifest.isActive() && !manifest.getKey().isActive()) {
+                monitor.warning("The ParticipantContext is 'active', but its (only) KeyPair is 'inActive'. " +
+                        "This will result in a DID Document without Verification Methods, and thus, an unusable ParticipantContext.");
+            }
+
             didDocumentService.store(doc, manifest.getParticipantId())
                     // adding the keypair event will cause the DidDocumentService to update the DID.
                     .compose(u -> keyPairService.addKeyPair(createdEvent.getParticipantId(), createdEvent.getManifest().getKey(), true))

--- a/core/lib/keypair-lib/src/test/java/org/eclipse/edc/identityhub/publickey/KeyPairResourcePublicKeyResolverTest.java
+++ b/core/lib/keypair-lib/src/test/java/org/eclipse/edc/identityhub/publickey/KeyPairResourcePublicKeyResolverTest.java
@@ -153,7 +153,7 @@ class KeyPairResourcePublicKeyResolverTest {
                 .id(UUID.randomUUID().toString())
                 .keyId(UUID.randomUUID().toString())
                 .isDefaultPair(true)
-                .state(KeyPairState.ACTIVE)
+                .state(KeyPairState.ACTIVATED)
                 .serializedPublicKey(createPublicKeyJwk().toJSONString())
                 .privateKeyAlias("test-key-alias");
     }

--- a/core/lib/verifiable-presentation-lib/src/main/java/org/eclipse/edc/identithub/verifiablepresentation/PresentationCreatorRegistryImpl.java
+++ b/core/lib/verifiable-presentation-lib/src/main/java/org/eclipse/edc/identithub/verifiablepresentation/PresentationCreatorRegistryImpl.java
@@ -56,7 +56,7 @@ public class PresentationCreatorRegistryImpl implements PresentationCreatorRegis
         var creator = ofNullable(creators.get(format)).orElseThrow(() -> new EdcException("No PresentationCreator was found for CredentialFormat %s".formatted(format)));
 
         var query = ParticipantResource.queryByParticipantId(participantContextId)
-                .filter(new Criterion("state", "=", KeyPairState.ACTIVE.code()))
+                .filter(new Criterion("state", "=", KeyPairState.ACTIVATED.code()))
                 .build();
 
         var keyPairResult = keyPairService.query(query)

--- a/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/PresentationCreatorRegistryImplTest.java
+++ b/core/lib/verifiable-presentation-lib/src/test/java/org/eclipse/edc/identithub/verifiablepresentation/PresentationCreatorRegistryImplTest.java
@@ -128,7 +128,7 @@ class PresentationCreatorRegistryImplTest {
         return KeyPairResource.Builder.newInstance()
                 .id(UUID.randomUUID().toString())
                 .keyId(keyId)
-                .state(KeyPairState.ACTIVE)
+                .state(KeyPairState.ACTIVATED)
                 .isDefaultPair(true)
                 .privateKeyAlias("%s-%s-alias".formatted(participantId, keyId));
     }

--- a/docs/developer/decision-records/2024-09-02-resource-operations/README.md
+++ b/docs/developer/decision-records/2024-09-02-resource-operations/README.md
@@ -75,7 +75,8 @@ This operation can be performed for the `CREATED` and `ACTIVATED` participant co
 Activating a key pair and publishing associated changes to a DID document must be performed in the following sequence:
 
 - A transaction is opened.
-- The new key pair is added to storage.
+- key key pair resource's state is set to ACTIVATED
+- The new (now active) key pair is added to the did document resource in its storage.
 - If the DID document resource is in the `PUBLISHED` state, the DID document is published with all verification methods
   for public keys in the `ACTIVATED` state. Note that the DID document resource cannot be in the `PUBLISHED` state if
   the participant context is not `ACTIVATED`.
@@ -92,9 +93,12 @@ It must not be possible to activate a key without publishing it.
 
 This operation can be performed for the `CREATED` and `ACTIVATED` participant context states.
 
-If activation is false, the key pair is committed to storage.
+the following sequence takes place:
 
-If activation is true, see activating key pair above.
+- open transaction
+- add key pair resource to the storage
+- if activation is false, the key pair is committed to storage.
+- if activation is true, see activating key pair above.
 
 ## 3. Key rotation: *rotateKeyPair()*
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -154,20 +154,21 @@ public class IdentityHubEndToEndTestContext {
                 .getContent();
     }
 
-    public String createKeyPair(String participantId) {
+    public KeyDescriptor createKeyPair(String participantId) {
 
         var descriptor = createKeyDescriptor(participantId).build();
 
         var service = runtime.getService(KeyPairService.class);
         service.addKeyPair(participantId, descriptor, true)
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));
-        return descriptor.getResourceId();
+        return descriptor;
     }
 
     public KeyDescriptor.Builder createKeyDescriptor(String participantId) {
-        var keyId = UUID.randomUUID().toString();
+        var keyId = "key-id-%s".formatted(UUID.randomUUID());
         return KeyDescriptor.Builder.newInstance()
                 .keyId(keyId)
+                .active(false)
                 .resourceId(UUID.randomUUID().toString())
                 .keyGeneratorParams(Map.of("algorithm", "EC", "curve", Curve.P_384.getStdName()))
                 .privateKeyAlias("%s-%s-alias".formatted(participantId, keyId));

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2024-08-27T11:00:00Z",
+    "lastUpdated": "2024-09-11T08:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/keypair-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/unstable/KeyPairResourceApiController.java
+++ b/extensions/api/identity-api/keypair-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/v1/unstable/KeyPairResourceApiController.java
@@ -103,7 +103,8 @@ public class KeyPairResourceApiController implements KeyPairResourceApi {
     @Path("/{keyPairId}/activate")
     @Override
     public void activateKeyPair(@PathParam("keyPairId") String keyPairResourceId, @Context SecurityContext context) {
-        authorizationService.isAuthorized(context, keyPairResourceId, KeyPairResource.class).compose(u -> keyPairService.activate(keyPairResourceId)).orElseThrow(exceptionMapper(KeyPairResource.class, keyPairResourceId));
+        authorizationService.isAuthorized(context, keyPairResourceId, KeyPairResource.class)
+                .compose(u -> keyPairService.activate(keyPairResourceId)).orElseThrow(exceptionMapper(KeyPairResource.class, keyPairResourceId));
 
     }
 

--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/BaseSqlDialectStatements.java
@@ -36,6 +36,7 @@ public class BaseSqlDialectStatements implements KeyPairResourceStoreStatements 
                 .column(getSerializedPublicKeyColumn())
                 .column(getPrivateKeyAliasColumn())
                 .column(getStateColumn())
+                .column(getKeyContextColumn())
                 .insertInto(getTableName());
     }
 
@@ -53,6 +54,7 @@ public class BaseSqlDialectStatements implements KeyPairResourceStoreStatements 
                 .column(getSerializedPublicKeyColumn())
                 .column(getPrivateKeyAliasColumn())
                 .column(getStateColumn())
+                .column(getKeyContextColumn())
                 .update(getTableName(), getIdColumn());
     }
 

--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/KeyPairResourceStoreStatements.java
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/KeyPairResourceStoreStatements.java
@@ -71,6 +71,10 @@ public interface KeyPairResourceStoreStatements extends SqlStatements {
         return "state";
     }
 
+    default String getKeyContextColumn() {
+        return "key_context";
+    }
+
     String getInsertTemplate();
 
     String getUpdateTemplate();

--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStore.java
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/keypair/SqlKeyPairResourceStore.java
@@ -64,7 +64,8 @@ public class SqlKeyPairResourceStore extends AbstractSqlStore implements KeyPair
                         keyPairResource.getRotationDuration(),
                         keyPairResource.getSerializedPublicKey(),
                         keyPairResource.getPrivateKeyAlias(),
-                        keyPairResource.getState());
+                        keyPairResource.getState(),
+                        keyPairResource.getKeyContext());
 
                 return success();
             } catch (SQLException e) {
@@ -108,6 +109,7 @@ public class SqlKeyPairResourceStore extends AbstractSqlStore implements KeyPair
                         keyPairResource.getSerializedPublicKey(),
                         keyPairResource.getPrivateKeyAlias(),
                         keyPairResource.getState(),
+                        keyPairResource.getKeyContext(),
                         id);
 
                 return success();
@@ -156,6 +158,7 @@ public class SqlKeyPairResourceStore extends AbstractSqlStore implements KeyPair
                 .serializedPublicKey(resultSet.getString(statements.getSerializedPublicKeyColumn()))
                 .privateKeyAlias(resultSet.getString(statements.getPrivateKeyAliasColumn()))
                 .state(resultSet.getInt(statements.getStateColumn()))
+                .keyContext(resultSet.getString(statements.getKeyContextColumn()))
                 .build();
     }
 

--- a/extensions/store/sql/identity-hub-keypair-store-sql/src/main/resources/keypairs-schema.sql
+++ b/extensions/store/sql/identity-hub-keypair-store-sql/src/main/resources/keypairs-schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS keypair_resource
     rotation_duration     BIGINT,                                     -- duration during which this keypair is in a transitional state (rotated, not yet deactivated)
     serialized_public_key VARCHAR             NOT NULL,               -- serialized public key (PEM, JWK,...)
     private_key_alias     VARCHAR             NOT NULL,               -- alias under which the private key is stored in the HSM/Vault
-    state                 INT                 NOT NULL DEFAULT 100    -- KeyPairState
+    state                 INT                 NOT NULL DEFAULT 100,   -- KeyPairState
+    key_context           VARCHAR                                     --the key context, will end up in the VerificationMethod of the DID Document
 );
 

--- a/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/KeyPairResourceStoreTestBase.java
+++ b/spi/identity-hub-store-spi/src/testFixtures/java/org/eclipse/edc/identityhub/store/test/KeyPairResourceStoreTestBase.java
@@ -129,7 +129,7 @@ public abstract class KeyPairResourceStoreTestBase {
 
     @Test
     void query_byIdAndState() {
-        var kp1 = createKeyPairResource().id("id1").state(KeyPairState.ACTIVE).build();
+        var kp1 = createKeyPairResource().id("id1").state(KeyPairState.ACTIVATED).build();
         var kp2 = createKeyPairResource().id("id2").state(KeyPairState.CREATED).build();
         var kp3 = createKeyPairResource().id("id3").state(KeyPairState.REVOKED).build();
         var kp4 = createKeyPairResource().id("id4").state(KeyPairState.ROTATED).build();
@@ -198,6 +198,7 @@ public abstract class KeyPairResourceStoreTestBase {
                 .privateKeyAlias("private-key-alias")
                 .participantId("test-participant")
                 .serializedPublicKey("this-is-a-pem-string")
+                .keyContext("JsonWebKey2020")
                 .useDuration(Duration.ofDays(6).toMillis());
     }
 }

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/KeyPairService.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/KeyPairService.java
@@ -70,10 +70,10 @@ public interface KeyPairService {
     ServiceResult<Collection<KeyPairResource>> query(QuerySpec querySpec);
 
     /**
-     * Sets a key pair to the {@link KeyPairState#ACTIVE} state.
+     * Sets a key pair to the {@link KeyPairState#ACTIVATED} state.
      *
      * @param keyPairResourceId The ID of the {@link KeyPairResource}
-     * @return return a failure if the key pair resource is not in either {@link KeyPairState#CREATED} or {@link KeyPairState#ACTIVE}
+     * @return return a failure if the key pair resource is not in either {@link KeyPairState#CREATED} or {@link KeyPairState#ACTIVATED}
      */
     ServiceResult<Void> activate(String keyPairResourceId);
 }

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairActivated.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairActivated.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.keypair.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * Event that signals that a key pair was added for a particular participant
+ */
+@JsonDeserialize(builder = KeyPairActivated.Builder.class)
+public class KeyPairActivated extends KeyPairEvent {
+    private String publicKeySerialized;
+    private String type;
+
+    @Override
+    public String name() {
+        return "keypair.activated";
+    }
+
+    public String getKeyType() {
+        return type;
+    }
+
+    public String getPublicKeySerialized() {
+        return publicKeySerialized;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends KeyPairEvent.Builder<KeyPairActivated, Builder> {
+
+        private Builder() {
+            super(new KeyPairActivated());
+        }
+
+        @JsonCreator
+        public static Builder newInstance() {
+            return new KeyPairActivated.Builder();
+        }
+
+        public Builder publicKey(String publicKeySerialized, String type) {
+            event.publicKeySerialized = publicKeySerialized;
+            event.type = type;
+            return this;
+        }
+
+        @Override
+        public KeyPairActivated.Builder self() {
+            return this;
+        }
+    }
+}

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEventListener.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEventListener.java
@@ -54,4 +54,14 @@ public interface KeyPairEventListener {
     default void revoked(KeyPairResource keyPair) {
 
     }
+
+    /**
+     * A {@link KeyPairResource} was activated. Only keys that are in the {@link org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState#ACTIVATED} state can be used for signing.
+     *
+     * @param activatedKeyPair the {@link KeyPairResource} that was activated
+     * @param type             Verification type specifying the cryptographic context in which the public key is used, e.g. JsonWebKey2020...
+     */
+    default void activated(KeyPairResource activatedKeyPair, String type) {
+
+    }
 }

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairResource.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairResource.java
@@ -31,6 +31,7 @@ public class KeyPairResource extends ParticipantResource {
     private long timestamp;
     private String keyId;
     private String groupName;
+    private String keyContext;
     private boolean defaultPair;
     private long useDuration;
     private long rotationDuration;
@@ -103,6 +104,16 @@ public class KeyPairResource extends ParticipantResource {
         return useDuration;
     }
 
+    /**
+     * The context in which this key resource is to be used, for example this could be "JsonWebKey2020". This value will
+     * be set on the Verification Method's {@code type} field of the participant's DID document
+     *
+     * @return the context in which the key context is to be used.
+     */
+    public String getKeyContext() {
+        return keyContext;
+    }
+
 
     public int getState() {
         return state;
@@ -121,7 +132,7 @@ public class KeyPairResource extends ParticipantResource {
     }
 
     public void activate() {
-        state = KeyPairState.ACTIVE.code();
+        state = KeyPairState.ACTIVATED.code();
     }
 
     public static final class Builder extends ParticipantResource.Builder<KeyPairResource, KeyPairResource.Builder> {
@@ -194,6 +205,11 @@ public class KeyPairResource extends ParticipantResource {
 
         public Builder state(int state) {
             entity.state = state;
+            return this;
+        }
+
+        public Builder keyContext(String keyContext) {
+            entity.keyContext = keyContext;
             return this;
         }
 

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairState.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairState.java
@@ -27,7 +27,7 @@ public enum KeyPairState {
     /**
      * Key pair is actively used to sign or encrypt material.
      */
-    ACTIVE(200),
+    ACTIVATED(200),
     /**
      * The key is not used to sign or encrypt anymore, but it can still be used to verify material that was signed with it in the past. At this point
      * the private key is likely expunged from the vault.


### PR DESCRIPTION
## What this PR changes/adds

Aligns the "active-key" operation with the decision record

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- adds the `KeyPairActivated` event (and associated methods), which is consumed by the `DidDocumentService`
- adds a `keyContext` field to the `KeyPairResource` (and the associated DB schema) to track the "context" of the key, e.g. `"JsonWebKey2020"`
- renames `KeyPairStates#ACTIVE` to `KeyPairStates#ACTIVATED` for consistency
- the `PArticipantContextEventCoordinator` emits a warning log if a participant is added and activated, but its only key is in the `"inactive"` state
- `KeyPairService`: when a key is added in the `active` state, the `activateKey` method is invoked in the same transaction
- `DidDocumentService` reacts to the `KeyPairActivated` event instead of `KeyPairAdded`

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
