### PR TITLE
chore: align activate-keypair operation with DR

### DIFF
--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceExtension.java
@@ -18,6 +18,7 @@ import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairObservable;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.store.KeyPairResourceStore;
+import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
@@ -45,6 +46,9 @@ public class KeyPairServiceExtension implements ServiceExtension {
     private Clock clock;
     @Inject
     private TransactionContext transactionContext;
+    @Inject
+    private ParticipantContextStore participantContextService;
+
 
     private KeyPairObservable observable;
 
@@ -55,7 +59,7 @@ public class KeyPairServiceExtension implements ServiceExtension {
 
     @Provider
     public KeyPairService createParticipantService(ServiceExtensionContext context) {
-        var service = new KeyPairServiceImpl(keyPairResourceStore, vault, context.getMonitor().withPrefix("KeyPairService"), keyPairObservable(), transactionContext);
+        var service = new KeyPairServiceImpl(keyPairResourceStore, vault, context.getMonitor().withPrefix("KeyPairService"), keyPairObservable(), transactionContext, participantContextService);
         eventRouter.registerSync(ParticipantContextDeleted.class, service);
         return service;
     }


### PR DESCRIPTION
## What this PR changes/adds

aligns the `activateKeyPair` operation with the [decision-record](https://github.com/eclipse-edc/IdentityHub/tree/main/docs/developer/decision-records/2024-09-02-resource-operations)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- in essence, a check was added if the participant exists and is in the correct state. plus tests.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
