### PR TITLE
chore: align rotate keypair with dr

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -72,6 +72,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, Apache-2.0, approved, #15156
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.41, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.1, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #16060
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -539,6 +539,8 @@ class DidDocumentServiceImplTest {
 
         when(didResourceStoreMock.query(any(QuerySpec.class))).thenReturn(List.of(didResource));
         when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(publisherMock.publish(did)).thenReturn(Result.success());
 
         var event = EventEnvelope.Builder.newInstance()
                 .at(System.currentTimeMillis())
@@ -555,8 +557,9 @@ class DidDocumentServiceImplTest {
 
         verify(didResourceStoreMock).query(any(QuerySpec.class));
         verify(didResourceStoreMock).update(argThat(dr -> dr.getDocument().getVerificationMethod().stream().anyMatch(vm -> vm.getId().equals(keyId))));
+        verify(didResourceStoreMock).findById(did); // happens during the publishing
         verifyNoMoreInteractions(didResourceStoreMock);
-        verifyNoInteractions(publisherMock);
+        verify(publisherMock).publish(eq(did));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -125,7 +125,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
     }
 
     @Override
-    public ServiceResult<Void> rotateKeyPair(String oldId, @Nullable KeyDescriptor newKeySpec, long duration) {
+    public ServiceResult<Void> rotateKeyPair(String oldId, @Nullable KeyDescriptor newKeyDesc, long duration) {
         return transactionContext.execute(() -> {
             var oldKey = findById(oldId);
             if (oldKey == null) {
@@ -142,8 +142,8 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
             var updateResult = ServiceResult.from(keyPairResourceStore.update(oldKey))
                     .onSuccess(v -> observable.invokeForEach(l -> l.rotated(oldKey)));
 
-            if (newKeySpec != null) {
-                return updateResult.compose(v -> addKeyPair(participantId, newKeySpec, wasDefault));
+            if (newKeyDesc != null) {
+                return updateResult.compose(v -> addKeyPair(participantId, newKeyDesc, wasDefault));
             }
             monitor.warning("Rotating keys without a successor key may leave the participant without an active keypair.");
             return updateResult;

--- a/core/identity-hub-keypairs/src/test/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImplTest.java
+++ b/core/identity-hub-keypairs/src/test/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImplTest.java
@@ -286,6 +286,7 @@ class KeyPairServiceImplTest {
         verifyNoMoreInteractions(keyPairResourceStore, vault, observableMock);
     }
 
+
     @Test
     void revokeKey_withNewKey() {
         var oldId = "old-id";

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -157,7 +157,10 @@ public class IdentityHubEndToEndTestContext {
     public KeyDescriptor createKeyPair(String participantId) {
 
         var descriptor = createKeyDescriptor(participantId).build();
+        return createKeyPair(participantId, descriptor);
+    }
 
+    public KeyDescriptor createKeyPair(String participantId, KeyDescriptor descriptor) {
         var service = runtime.getService(KeyPairService.class);
         service.addKeyPair(participantId, descriptor, true)
                 .orElseThrow(f -> new EdcException(f.getFailureDetail()));


### PR DESCRIPTION
## What this PR changes/adds

aligns the `rotate-keypair` action with the decision record

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- added a `publish` action when activating a keypair. it wasn't there before. Note that this can lead to double publications when creating a participant context!

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
