### PR TITLE
feat: implement StsAccountProvisioner

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -72,7 +72,7 @@ maven/mavencentral/com.lmax/disruptor/3.4.4, Apache-2.0, approved, clearlydefine
 maven/mavencentral/com.networknt/json-schema-validator/1.0.76, Apache-2.0, approved, CQ22638
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.28, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.40, Apache-2.0, approved, #15156
-maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.41, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.41.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.puppycrawl.tools/checkstyle/10.18.1, LGPL-2.1-or-later AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0, approved, #16060
 maven/mavencentral/com.samskivert/jmustache/1.15, BSD-2-Clause AND BSD-3-Clause, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp3/okhttp-dnsoverhttps/4.12.0, Apache-2.0, approved, #11159
@@ -255,6 +255,7 @@ maven/mavencentral/org.eclipse.edc/identity-did-core/0.10.0-SNAPSHOT, Apache-2.0
 maven/mavencentral/org.eclipse.edc/identity-did-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-did-web/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-sts-api/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-sts-core/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-sts-embedded/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-sts-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -255,6 +255,9 @@ maven/mavencentral/org.eclipse.edc/identity-did-core/0.10.0-SNAPSHOT, Apache-2.0
 maven/mavencentral/org.eclipse.edc/identity-did-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-did-web/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-sts-core/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-sts-embedded/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
+maven/mavencentral/org.eclipse.edc/identity-trust-sts-spi/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/identity-trust-transform/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-core/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/jersey-providers-lib/0.10.0-SNAPSHOT, Apache-2.0, approved, technology.edc

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -267,7 +267,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
             var publicKey = keyParserRegistry.parse(serialized);
 
             if (publicKey.failed()) {
-                monitor.warning("Error adding KeyPair '%s' to DID Document of participant '%s': %s".formatted(event.getKeyPairResourceId(), event.getParticipantId(), publicKey.getFailureDetail()));
+                monitor.warning("Error adding KeyPair '%s' to DID Document of participant '%s': %s".formatted(event.getKeyPairResource().getId(), event.getParticipantId(), publicKey.getFailureDetail()));
                 return;
             }
 

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -57,16 +57,16 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     private final TransactionContext transactionContext;
     private final DidResourceStore didResourceStore;
     private final DidDocumentPublisherRegistry registry;
-    private final ParticipantContextStore participantcontextStore;
+    private final ParticipantContextStore participantContextStore;
     private final Monitor monitor;
     private final KeyParserRegistry keyParserRegistry;
 
     public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry,
-                                  ParticipantContextStore participantcontextStore, Monitor monitor, KeyParserRegistry keyParserRegistry) {
+                                  ParticipantContextStore participantContextStore, Monitor monitor, KeyParserRegistry keyParserRegistry) {
         this.transactionContext = transactionContext;
         this.didResourceStore = didResourceStore;
         this.registry = registry;
-        this.participantcontextStore = participantcontextStore;
+        this.participantContextStore = participantContextStore;
         this.monitor = monitor;
         this.keyParserRegistry = keyParserRegistry;
     }
@@ -112,7 +112,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
                 return ServiceResult.notFound(notFoundMessage(did));
             }
             var participantId = existingResource.getParticipantId();
-            return ServiceResult.from(participantcontextStore.findById(participantId))
+            return ServiceResult.from(participantContextStore.findById(participantId))
                     .map(ParticipantContext::getStateAsEnum)
                     .compose(state -> {
                         var canPublish = state.equals(ParticipantContextState.ACTIVATED);
@@ -142,7 +142,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
             }
 
             var participantId = existingResource.getParticipantId();
-            return ServiceResult.from(participantcontextStore.findById(participantId))
+            return ServiceResult.from(participantContextStore.findById(participantId))
                     .map(ParticipantContext::getStateAsEnum)
                     .compose(state -> {
                         var canUnpublish = state.equals(ParticipantContextState.DEACTIVATED);

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -24,11 +24,11 @@ import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
-import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
+import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.security.token.jwt.CryptoConverter;
 import org.eclipse.edc.spi.event.Event;
@@ -57,16 +57,16 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     private final TransactionContext transactionContext;
     private final DidResourceStore didResourceStore;
     private final DidDocumentPublisherRegistry registry;
-    private final ParticipantContextService participantContextService;
+    private final ParticipantContextStore participantcontextStore;
     private final Monitor monitor;
     private final KeyParserRegistry keyParserRegistry;
 
     public DidDocumentServiceImpl(TransactionContext transactionContext, DidResourceStore didResourceStore, DidDocumentPublisherRegistry registry,
-                                  ParticipantContextService participantContextService, Monitor monitor, KeyParserRegistry keyParserRegistry) {
+                                  ParticipantContextStore participantcontextStore, Monitor monitor, KeyParserRegistry keyParserRegistry) {
         this.transactionContext = transactionContext;
         this.didResourceStore = didResourceStore;
         this.registry = registry;
-        this.participantContextService = participantContextService;
+        this.participantcontextStore = participantcontextStore;
         this.monitor = monitor;
         this.keyParserRegistry = keyParserRegistry;
     }
@@ -112,7 +112,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
                 return ServiceResult.notFound(notFoundMessage(did));
             }
             var participantId = existingResource.getParticipantId();
-            return participantContextService.getParticipantContext(participantId)
+            return ServiceResult.from(participantcontextStore.findById(participantId))
                     .map(ParticipantContext::getStateAsEnum)
                     .compose(state -> {
                         var canPublish = state.equals(ParticipantContextState.ACTIVATED);
@@ -142,7 +142,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
             }
 
             var participantId = existingResource.getParticipantId();
-            return participantContextService.getParticipantContext(participantId)
+            return ServiceResult.from(participantcontextStore.findById(participantId))
                     .map(ParticipantContext::getStateAsEnum)
                     .compose(state -> {
                         var canUnpublish = state.equals(ParticipantContextState.DEACTIVATED);

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidServicesExtension.java
@@ -19,8 +19,8 @@ import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
-import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
+import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -39,16 +39,13 @@ public class DidServicesExtension implements ServiceExtension {
     private TransactionContext transactionContext;
     @Inject
     private DidResourceStore didResourceStore;
-
     @Inject
     private EventRouter eventRouter;
-
-    private DidDocumentPublisherRegistry didPublisherRegistry;
-
     @Inject
     private KeyParserRegistry keyParserRegistry;
     @Inject
-    private ParticipantContextService participantContextService;
+    private ParticipantContextStore participantContextStore;
+    private DidDocumentPublisherRegistry didPublisherRegistry;
 
     @Override
     public String name() {
@@ -66,7 +63,7 @@ public class DidServicesExtension implements ServiceExtension {
     @Provider
     public DidDocumentService createDidDocumentService(ServiceExtensionContext context) {
         var service = new DidDocumentServiceImpl(transactionContext, didResourceStore,
-                getDidPublisherRegistry(), participantContextService, context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
+                getDidPublisherRegistry(), participantContextStore, context.getMonitor().withPrefix("DidDocumentService"), keyParserRegistry);
         eventRouter.registerSync(ParticipantContextUpdated.class, service);
         eventRouter.registerSync(KeyPairRevoked.class, service);
         eventRouter.registerSync(KeyPairActivated.class, service);

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -28,10 +28,10 @@ import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
-import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
+import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
 import org.eclipse.edc.keys.keyparsers.JwkParser;
 import org.eclipse.edc.keys.keyparsers.PemParser;
@@ -40,7 +40,6 @@ import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +67,7 @@ class DidDocumentServiceImplTest {
     private final DidResourceStore didResourceStoreMock = mock();
     private final DidDocumentPublisherRegistry publisherRegistry = mock();
     private final DidDocumentPublisher publisherMock = mock();
-    private final ParticipantContextService participantContextServiceMock = mock();
+    private final ParticipantContextStore participantContextServiceMock = mock();
     private DidDocumentServiceImpl service;
     private Monitor monitorMock;
 
@@ -83,7 +82,7 @@ class DidDocumentServiceImplTest {
         monitorMock = mock();
         service = new DidDocumentServiceImpl(trx, didResourceStoreMock, publisherRegistry, participantContextServiceMock, monitorMock, registry);
 
-        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+        when(participantContextServiceMock.findById(any())).thenReturn(StoreResult.success(ParticipantContext.Builder.newInstance()
                 .participantId(TEST_PARTICIPANT_ID)
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.ACTIVATED)
@@ -212,7 +211,7 @@ class DidDocumentServiceImplTest {
         var did = doc.getId();
         when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
         when(publisherMock.unpublish(did)).thenReturn(Result.success());
-        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+        when(participantContextServiceMock.findById(any())).thenReturn(StoreResult.success(ParticipantContext.Builder.newInstance()
                 .participantId(TEST_PARTICIPANT_ID)
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.DEACTIVATED)
@@ -243,7 +242,7 @@ class DidDocumentServiceImplTest {
         var did = doc.getId();
         when(publisherRegistry.getPublisher(any())).thenReturn(null);
         when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
-        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+        when(participantContextServiceMock.findById(any())).thenReturn(StoreResult.success(ParticipantContext.Builder.newInstance()
                 .participantId(TEST_PARTICIPANT_ID)
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.DEACTIVATED)
@@ -263,7 +262,7 @@ class DidDocumentServiceImplTest {
         var did = doc.getId();
         when(didResourceStoreMock.findById(eq(did))).thenReturn(DidResource.Builder.newInstance().did(did).state(DidState.PUBLISHED).document(doc).build());
         when(publisherMock.unpublish(did)).thenReturn(Result.failure("test-failure"));
-        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+        when(participantContextServiceMock.findById(any())).thenReturn(StoreResult.success(ParticipantContext.Builder.newInstance()
                 .participantId(TEST_PARTICIPANT_ID)
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.DEACTIVATED)
@@ -435,7 +434,7 @@ class DidDocumentServiceImplTest {
         when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
         when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
 
-        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+        when(participantContextServiceMock.findById(any())).thenReturn(StoreResult.success(ParticipantContext.Builder.newInstance()
                 .participantId(TEST_PARTICIPANT_ID)
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.DEACTIVATED)
@@ -487,7 +486,7 @@ class DidDocumentServiceImplTest {
         when(didResourceStoreMock.query(any())).thenReturn(List.of(didResource));
         when(publisherMock.unpublish(anyString())).thenReturn(Result.success());
 
-        when(participantContextServiceMock.getParticipantContext(any())).thenReturn(ServiceResult.success(ParticipantContext.Builder.newInstance()
+        when(participantContextServiceMock.findById(any())).thenReturn(StoreResult.success(ParticipantContext.Builder.newInstance()
                 .participantId(TEST_PARTICIPANT_ID)
                 .apiTokenAlias("token")
                 .state(ParticipantContextState.DEACTIVATED)

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
@@ -546,7 +547,7 @@ class DidDocumentServiceImplTest {
                 .id(UUID.randomUUID().toString())
                 .payload(KeyPairActivated.Builder.newInstance()
                         .keyId(keyId)
-                        .keyPairResourceId("test-resource-id")
+                        .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                         .participantId("test-participant")
                         .publicKey(key.toPublicJWK().toJSONString(), JSON_WEB_KEY_2020)
                         .build())
@@ -581,7 +582,7 @@ class DidDocumentServiceImplTest {
                 .id(UUID.randomUUID().toString())
                 .payload(KeyPairRevoked.Builder.newInstance()
                         .keyId(keyId)
-                        .keyPairResourceId("test-resource-id")
+                        .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                         .participantId("test-participant")
                         .build())
                 .build();

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairEventPublisher.java
@@ -21,8 +21,10 @@ import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairEventListener;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventRouter;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Clock;
 
@@ -39,7 +41,7 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
     public void added(KeyPairResource keyPair, String type) {
         var event = KeyPairAdded.Builder.newInstance()
                 .participantId(keyPair.getParticipantId())
-                .keyPairResourceId(keyPair.getId())
+                .keyPairResource(keyPair)
                 .keyId(keyPair.getKeyId())
                 .publicKey(keyPair.getSerializedPublicKey(), type)
                 .build();
@@ -47,21 +49,23 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
     }
 
     @Override
-    public void rotated(KeyPairResource keyPair) {
+    public void rotated(KeyPairResource keyPair, @Nullable KeyDescriptor newKeyDesc) {
         var event = KeyPairRotated.Builder.newInstance()
                 .participantId(keyPair.getParticipantId())
-                .keyPairResourceId(keyPair.getId())
+                .keyPairResource(keyPair)
                 .keyId(keyPair.getKeyId())
+                .newKeyDescriptor(newKeyDesc)
                 .build();
         publish(event);
     }
 
     @Override
-    public void revoked(KeyPairResource keyPair) {
+    public void revoked(KeyPairResource keyPair, @Nullable KeyDescriptor newKeyDesc) {
         var event = KeyPairRevoked.Builder.newInstance()
                 .participantId(keyPair.getParticipantId())
-                .keyPairResourceId(keyPair.getId())
+                .keyPairResource(keyPair)
                 .keyId(keyPair.getKeyId())
+                .newKeyDescriptor(newKeyDesc)
                 .build();
         publish(event);
     }
@@ -70,7 +74,7 @@ public class KeyPairEventPublisher implements KeyPairEventListener {
     public void activated(KeyPairResource activatedKeyPair, String type) {
         var event = KeyPairActivated.Builder.newInstance()
                 .participantId(activatedKeyPair.getParticipantId())
-                .keyPairResourceId(activatedKeyPair.getId())
+                .keyPairResource(activatedKeyPair)
                 .publicKey(activatedKeyPair.getSerializedPublicKey(), type)
                 .keyId(activatedKeyPair.getKeyId())
                 .build();

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -139,7 +139,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
             vault.deleteSecret(oldAlias);
             oldKey.rotate(duration);
             var updateResult = ServiceResult.from(keyPairResourceStore.update(oldKey))
-                    .onSuccess(v -> observable.invokeForEach(l -> l.rotated(oldKey)));
+                    .onSuccess(v -> observable.invokeForEach(l -> l.rotated(oldKey, newKeyDesc)));
 
             if (newKeyDesc != null) {
                 return updateResult.compose(v -> addKeyPair(participantId, newKeyDesc, wasDefault));
@@ -150,7 +150,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
     }
 
     @Override
-    public ServiceResult<Void> revokeKey(String id, @Nullable KeyDescriptor newKeySpec) {
+    public ServiceResult<Void> revokeKey(String id, @Nullable KeyDescriptor newKeyDesc) {
         return transactionContext.execute(() -> {
             var oldKey = findById(id);
             if (oldKey == null) {
@@ -165,10 +165,10 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
             vault.deleteSecret(oldAlias);
             oldKey.revoke();
             var updateResult = ServiceResult.from(keyPairResourceStore.update(oldKey))
-                    .onSuccess(v -> observable.invokeForEach(l -> l.revoked(oldKey)));
+                    .onSuccess(v -> observable.invokeForEach(l -> l.revoked(oldKey, newKeyDesc)));
 
-            if (newKeySpec != null) {
-                return updateResult.compose(v -> addKeyPair(participantId, newKeySpec, wasDefault));
+            if (newKeyDesc != null) {
+                return updateResult.compose(v -> addKeyPair(participantId, newKeyDesc, wasDefault));
             }
             monitor.warning("Revoking keys without a successor key may leave the participant without an active keypair.");
             return updateResult;

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -89,7 +89,6 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
             // check if the new key is not active, and no other active key exists
             if (!keyDescriptor.isActive()) {
 
-                //todo: replace this with invocation to activateKeyPair()
                 var hasActiveKeys = keyPairResourceStore.query(ParticipantResource.queryByParticipantId(participantId).build())
                         .orElse(failure -> Collections.emptySet())
                         .stream().filter(kpr -> kpr.getState() == KeyPairState.ACTIVATED.code())

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.participantcontext;
 
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
+import org.eclipse.edc.identityhub.spi.participantcontext.AccountProvisioner;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextObservable;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
@@ -29,6 +30,7 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.identityhub.participantcontext.ParticipantContextExtension.NAME;
 
 @Extension(NAME)
@@ -50,6 +52,9 @@ public class ParticipantContextExtension implements ServiceExtension {
     @Inject
     private DidResourceStore didResourceStore;
 
+    @Inject(required = false)
+    private AccountProvisioner accountProvisioner;
+
     private ParticipantContextObservable participantContextObservable;
 
     @Override
@@ -59,7 +64,7 @@ public class ParticipantContextExtension implements ServiceExtension {
 
     @Provider
     public ParticipantContextService createParticipantService() {
-        return new ParticipantContextServiceImpl(participantContextStore, didResourceStore, vault, transactionContext, participantContextObservable());
+        return new ParticipantContextServiceImpl(participantContextStore, didResourceStore, vault, transactionContext, participantContextObservable(), accountProvisioner());
     }
 
     @Provider
@@ -69,5 +74,10 @@ public class ParticipantContextExtension implements ServiceExtension {
             participantContextObservable.registerListener(new ParticipantContextEventPublisher(clock, eventRouter));
         }
         return participantContextObservable;
+    }
+
+    private AccountProvisioner accountProvisioner() {
+        return ofNullable(accountProvisioner)
+                .orElseGet(() -> manifest -> null); // default is a NOOP
     }
 }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -54,7 +54,12 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     private final ParticipantContextObservable observable;
     private final AccountProvisioner accountProvisioner;
 
-    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, DidResourceStore didResourceStore, Vault vault, TransactionContext transactionContext, ParticipantContextObservable observable, AccountProvisioner accountProvisioner) {
+    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore,
+                                         DidResourceStore didResourceStore,
+                                         Vault vault,
+                                         TransactionContext transactionContext,
+                                         ParticipantContextObservable observable,
+                                         AccountProvisioner accountProvisioner) {
         this.participantContextStore = participantContextStore;
         this.didResourceStore = didResourceStore;
         this.vault = vault;

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -15,12 +15,12 @@
 package org.eclipse.edc.identityhub.participantcontext;
 
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
+import org.eclipse.edc.identityhub.spi.participantcontext.AccountProvisioner;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextObservable;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
-import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.store.ParticipantContextStore;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
@@ -28,7 +28,8 @@ import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.eclipse.edc.spi.result.ServiceResult.conflict;
@@ -51,42 +52,43 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     private final TransactionContext transactionContext;
     private final ApiTokenGenerator tokenGenerator;
     private final ParticipantContextObservable observable;
+    private final AccountProvisioner accountProvisioner;
 
-    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, DidResourceStore didResourceStore, Vault vault, TransactionContext transactionContext, ParticipantContextObservable observable) {
+    public ParticipantContextServiceImpl(ParticipantContextStore participantContextStore, DidResourceStore didResourceStore, Vault vault, TransactionContext transactionContext, ParticipantContextObservable observable, AccountProvisioner accountProvisioner) {
         this.participantContextStore = participantContextStore;
         this.didResourceStore = didResourceStore;
         this.vault = vault;
         this.transactionContext = transactionContext;
         this.observable = observable;
+        this.accountProvisioner = accountProvisioner;
         this.tokenGenerator = new ApiTokenGenerator();
     }
 
     @Override
-    public ServiceResult<String> createParticipantContext(ParticipantManifest manifest) {
+    public ServiceResult<Map<String, Object>> createParticipantContext(ParticipantManifest manifest) {
         return transactionContext.execute(() -> {
             if (didResourceStore.findById(manifest.getDid()) != null) {
                 return ServiceResult.conflict("Another participant with the same DID '%s' already exists.".formatted(manifest.getDid()));
             }
-            var apiKey = new AtomicReference<String>();
+            var response = new HashMap<String, Object>();
             var context = convert(manifest);
             var res = createParticipantContext(context)
-                    .compose(u -> createTokenAndStoreInVault(context)).onSuccess(apiKey::set)
+                    .compose(u -> createTokenAndStoreInVault(context)).onSuccess(k -> response.put("apiKey", k))
+                    .compose(apiKey -> accountProvisioner.create(manifest))
+                    .onSuccess(accountInfo -> {
+                        if (accountInfo != null) {
+                            response.put("clientId", accountInfo.clientId());
+                            response.put("clientSecret", accountInfo.clientSecret());
+                        }
+                    })
                     .onSuccess(apiToken -> observable.invokeForEach(l -> l.created(context, manifest)));
-            return res.map(u -> apiKey.get());
+            return res.map(u -> response);
         });
     }
 
     @Override
     public ServiceResult<ParticipantContext> getParticipantContext(String participantId) {
-        return transactionContext.execute(() -> {
-            var res = participantContextStore.query(ParticipantResource.queryByParticipantId(participantId).build());
-            if (res.succeeded()) {
-                return res.getContent().stream().findFirst()
-                        .map(ServiceResult::success)
-                        .orElse(notFound("ParticipantContext with ID '%s' does not exist.".formatted(participantId)));
-            }
-            return fromFailure(res);
-        });
+        return transactionContext.execute(() -> ServiceResult.from(participantContextStore.findById(participantId)));
     }
 
     @Override
@@ -161,9 +163,8 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
     }
 
     private ParticipantContext findByIdInternal(String participantId) {
-        var resultStream = participantContextStore.query(ParticipantResource.queryByParticipantId(participantId).build());
-        if (resultStream.failed()) return null;
-        return resultStream.getContent().stream().findFirst().orElse(null);
+        var resultStream = participantContextStore.findById(participantId);
+        return resultStream.orElse(f -> null);
     }
 
 

--- a/e2e-tests/api-tests/build.gradle.kts
+++ b/e2e-tests/api-tests/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     testImplementation(libs.edc.sql.pool)
     testImplementation(libs.nimbus.jwt)
     testImplementation(libs.jakarta.rsApi)
+    testImplementation(libs.edc.sts.spi)
 }
 
 edcBuild {

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.tests;
 
 import io.restassured.http.Header;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
 import org.eclipse.edc.identithub.spi.did.events.DidDocumentPublished;
 import org.eclipse.edc.identithub.spi.did.events.DidDocumentUnpublished;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
@@ -52,7 +53,7 @@ public class DidManagementApiEndToEndTest {
     abstract static class Tests {
 
         @AfterEach
-        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore) {
+        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore, StsClientStore stsClientStore) {
             // purge all users, dids, keypairs
 
             pcService.query(QuerySpec.max()).getContent()
@@ -62,6 +63,9 @@ public class DidManagementApiEndToEndTest {
 
             keyPairResourceStore.query(QuerySpec.max()).getContent()
                     .forEach(kpr -> keyPairResourceStore.deleteById(kpr.getId()).getContent());
+
+            stsClientStore.findAll(QuerySpec.max())
+                    .forEach(sts -> stsClientStore.deleteById(sts.getId()).getContent());
         }
 
         @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.tests;
 
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
+import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
 import org.eclipse.edc.identithub.spi.did.events.DidDocumentPublished;
 import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
@@ -63,7 +64,7 @@ public class KeyPairResourceApiEndToEndTest {
     abstract static class Tests {
 
         @AfterEach
-        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore) {
+        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore, StsClientStore stsClientStore) {
             // purge all users, dids, keypairs
 
             pcService.query(QuerySpec.max()).getContent()
@@ -73,6 +74,9 @@ public class KeyPairResourceApiEndToEndTest {
 
             keyPairResourceStore.query(QuerySpec.max()).getContent()
                     .forEach(kpr -> keyPairResourceStore.deleteById(kpr.getId()).getContent());
+
+            stsClientStore.findAll(QuerySpec.max())
+                    .forEach(sts -> stsClientStore.deleteById(sts.getId()).getContent());
         }
 
         @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identithub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
@@ -40,6 +41,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.Base64;
@@ -49,6 +52,7 @@ import java.util.UUID;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -204,7 +208,7 @@ public class KeyPairResourceApiEndToEndTest {
                         verify(subscriber).on(argThat(env -> {
                             var evt = (KeyPairAdded) env.getPayload();
                             return evt.getParticipantId().equals(participantId) &&
-                                    evt.getKeyPairResourceId().equals(keyDesc.getResourceId()) &&
+                                    evt.getKeyPairResource().getId().equals(keyDesc.getResourceId()) &&
                                     evt.getKeyId().equals(keyDesc.getKeyId());
                         }));
                     });
@@ -236,7 +240,7 @@ public class KeyPairResourceApiEndToEndTest {
 
             verify(subscriber, never()).on(argThat(env -> {
                 if (env.getPayload() instanceof KeyPairAdded evt) {
-                    return evt.getKeyPairResourceId().equals(keyDesc.getKeyId());
+                    return evt.getKeyPairResource().equals(keyDesc.getKeyId());
                 }
                 return false;
             }));
@@ -362,31 +366,35 @@ public class KeyPairResourceApiEndToEndTest {
             // verify that the correct "added" event fired
             verify(subscriber).on(argThat(env -> {
                 if (env.getPayload() instanceof KeyPairAdded evt) {
-                    return evt.getKeyPairResourceId().equals(keyDesc.getResourceId()) &&
+                    return evt.getKeyPairResource().getId().equals(keyDesc.getResourceId()) &&
                             evt.getKeyId().equals(keyDesc.getKeyId());
                 }
                 return false;
             }));
         }
 
-        @Test
-        void rotate_withUserToken(IdentityHubEndToEndTestContext context, EventRouter router) {
+        @ParameterizedTest(name = "New KeyID {0}")
+        @ValueSource(strings = { "did:web:user1#new-key-id", "new-key-id" })
+        void rotate_withUserToken(String keyId, IdentityHubEndToEndTestContext context, EventRouter router, StsClientStore clientStore) {
             var subscriber = mock(EventSubscriber.class);
             router.registerSync(KeyPairRotated.class, subscriber);
             router.registerSync(KeyPairAdded.class, subscriber);
 
-            var user1 = "user1";
-            var userToken = context.createParticipant(user1);
+            var participantId = "user1";
+            var userToken = context.createParticipant(participantId);
 
-            var keyPairId = context.createKeyPair(user1).getResourceId();
+            var keyPairId = context.createKeyPair(participantId).getResourceId();
 
             // attempt to publish user1's DID document, which should fail
-            var keyDesc = context.createKeyDescriptor(user1).build();
+            var keyDesc = context.createKeyDescriptor(participantId)
+                    .privateKeyAlias("new-key-alias")
+                    .keyId(keyId)
+                    .build();
             context.getIdentityApiEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(new Header("x-api-key", userToken))
                     .body(keyDesc)
-                    .post("/v1alpha/participants/%s/keypairs/%s/rotate".formatted(toBase64(user1), keyPairId))
+                    .post("/v1alpha/participants/%s/keypairs/%s/rotate".formatted(toBase64(participantId), keyPairId))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(204)
@@ -395,18 +403,66 @@ public class KeyPairResourceApiEndToEndTest {
             // verify that the "rotated" event fired once
             verify(subscriber).on(argThat(env -> {
                 if (env.getPayload() instanceof KeyPairRotated evt) {
-                    return evt.getParticipantId().equals(user1);
+                    return evt.getParticipantId().equals(participantId);
                 }
                 return false;
             }));
             // verify that the correct "added" event fired
             verify(subscriber).on(argThat(env -> {
                 if (env.getPayload() instanceof KeyPairAdded evt) {
-                    return evt.getKeyPairResourceId().equals(keyDesc.getResourceId()) &&
+                    return evt.getKeyPairResource().getId().equals(keyDesc.getResourceId()) &&
                             evt.getKeyId().equals(keyDesc.getKeyId());
                 }
                 return false;
             }));
+
+            // verify that the STS client got updated correctly
+            assertThat(clientStore.findById(participantId)).isSucceeded()
+                    .satisfies(stsClient -> {
+                        assertThat(stsClient.getPrivateKeyAlias()).isEqualTo("new-key-alias");
+                        assertThat(stsClient.getPublicKeyReference()).isEqualTo("did:web:" + participantId + "#new-key-id");
+                    });
+        }
+
+        @Test
+        void rotate_withoutNewKey(IdentityHubEndToEndTestContext context, EventRouter router, StsClientStore clientStore) {
+
+            var participantId = "user1";
+            var userToken = context.createParticipant(participantId);
+
+            var keyPairId = context.createKeyPair(participantId).getResourceId();
+
+            var subscriber = mock(EventSubscriber.class);
+            router.registerSync(KeyPairRotated.class, subscriber);
+            router.registerSync(KeyPairAdded.class, subscriber);
+
+
+            // attempt to publish user1's DID document, which should fail
+            context.getIdentityApiEndpoint().baseRequest()
+                    .contentType(JSON)
+                    .header(new Header("x-api-key", userToken))
+                    .post("/v1alpha/participants/%s/keypairs/%s/rotate".formatted(toBase64(participantId), keyPairId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(204)
+                    .body(notNullValue());
+
+            // verify that the "rotated" event fired once
+            verify(subscriber).on(argThat(env -> {
+                if (env.getPayload() instanceof KeyPairRotated evt) {
+                    return evt.getParticipantId().equals(participantId);
+                }
+                return false;
+            }));
+            // verify that the correct "added" event fired
+            verify(subscriber, never()).on(argThat(env -> env.getPayload() instanceof KeyPairAdded));
+
+            // verify that the STS client got updated correctly
+            assertThat(clientStore.findById(participantId)).isSucceeded()
+                    .satisfies(stsClient -> {
+                        assertThat(stsClient.getPrivateKeyAlias()).isEqualTo("");
+                        assertThat(stsClient.getPublicKeyReference()).isEqualTo("");
+                    });
         }
 
         @Test
@@ -437,7 +493,7 @@ public class KeyPairResourceApiEndToEndTest {
             // make sure that the event to add the _new_ keypair was never fired
             verify(subscriber, never()).on(argThat(env -> {
                 if (env.getPayload() instanceof KeyPairRotated evt) {
-                    return evt.getParticipantId().equals(user1) && evt.getKeyPairResourceId().equals(keyDesc.getKeyId());
+                    return evt.getParticipantId().equals(user1) && evt.getKeyPairResource().equals(keyDesc.getKeyId());
                 }
                 return false;
             }));
@@ -445,13 +501,13 @@ public class KeyPairResourceApiEndToEndTest {
 
         @Test
         void rotate_withNewKey_shouldUpdateDidDocument(IdentityHubEndToEndTestContext context, EventRouter router, Vault vault) {
-            var subscriber = mock(EventSubscriber.class);
-            router.registerSync(KeyPairRotated.class, subscriber);
-            router.registerSync(KeyPairAdded.class, subscriber);
-
             var participantId = "user1";
             var userToken = context.createParticipant(participantId);
             var keyPair = context.getKeyPairsForParticipant(participantId).stream().findFirst().orElseThrow();
+
+            var subscriber = mock(EventSubscriber.class);
+            router.registerSync(KeyPairRotated.class, subscriber);
+            router.registerSync(KeyPairAdded.class, subscriber);
 
             var originalAlias = participantId + "-alias";
             var originalKeyId = participantId + "-key";
@@ -472,6 +528,8 @@ public class KeyPairResourceApiEndToEndTest {
                     .statusCode(204)
                     .body(notNullValue());
 
+            verify(subscriber).on(argThat(evt -> evt.getPayload() instanceof KeyPairRotated));
+            verify(subscriber).on(argThat(evt -> evt.getPayload() instanceof KeyPairAdded));
             var didDoc = context.getDidForParticipant(participantId);
             assertThat(didDoc).isNotEmpty()
                     .allSatisfy(doc -> assertThat(doc.getVerificationMethod()).hasSize(2)
@@ -523,29 +581,80 @@ public class KeyPairResourceApiEndToEndTest {
             verify(subscriber, never()).on(argThat(evt -> evt.getPayload() instanceof DidDocumentPublished));
         }
 
-        @Test
-        void revoke(IdentityHubEndToEndTestContext context) {
+        @ParameterizedTest(name = "New Key-ID: {0}")
+        @ValueSource(strings = { "new-keyId", "did:web:user1#new-keyId" })
+        void revoke(String newKeyId, IdentityHubEndToEndTestContext context, StsClientStore clientStore) {
             var superUserKey = context.createSuperUser();
-            var user1 = "user1";
-            var token = context.createParticipant(user1);
+            var participantId = "user1";
+            var token = context.createParticipant(participantId);
 
-            var keyId = context.createKeyPair(user1).getResourceId();
+            var keyId = context.createKeyPair(participantId).getResourceId();
 
             assertThat(Arrays.asList(token, superUserKey))
                     .allSatisfy(t -> {
-                        var keyDesc = context.createKeyDescriptor(user1).build();
+                        var keyDesc = context.createKeyDescriptor(participantId)
+                                .privateKeyAlias("new-alias")
+                                .keyId(newKeyId)
+                                .build();
+
                         context.getIdentityApiEndpoint().baseRequest()
                                 .contentType(JSON)
                                 .header(new Header("x-api-key", t))
                                 .body(keyDesc)
-                                .post("/v1alpha/participants/%s/keypairs/%s/revoke".formatted(toBase64(user1), keyId))
+                                .post("/v1alpha/participants/%s/keypairs/%s/revoke".formatted(toBase64(participantId), keyId))
                                 .then()
                                 .log().ifValidationFails()
                                 .statusCode(204)
                                 .body(notNullValue());
 
-                        assertThat(context.getDidForParticipant(user1)).hasSize(1)
+                        assertThat(context.getDidForParticipant(participantId)).hasSize(1)
                                 .allSatisfy(dd -> assertThat(dd.getVerificationMethod()).noneMatch(vm -> vm.getId().equals(keyId)));
+
+                        // verify that the STS client got updated correctly
+                        assertThat(clientStore.findById(participantId)).isSucceeded()
+                                .satisfies(stsClient -> {
+                                    assertThat(stsClient.getPrivateKeyAlias()).isEqualTo("new-alias");
+                                    assertThat(stsClient.getPublicKeyReference()).isEqualTo("did:web:" + participantId + "#new-keyId");
+                                });
+                    });
+        }
+
+        @Test
+        void revoke_withoutNewKey(IdentityHubEndToEndTestContext context, EventRouter router, StsClientStore clientStore) {
+            var subscriber = mock(EventSubscriber.class);
+            router.registerSync(KeyPairRotated.class, subscriber);
+            router.registerSync(KeyPairRevoked.class, subscriber);
+
+            var participantId = "user1";
+            var userToken = context.createParticipant(participantId);
+
+            var keyPairId = context.createKeyPair(participantId).getResourceId();
+
+            // attempt to publish user1's DID document, which should fail
+            context.getIdentityApiEndpoint().baseRequest()
+                    .contentType(JSON)
+                    .header(new Header("x-api-key", userToken))
+                    .post("/v1alpha/participants/%s/keypairs/%s/revoke".formatted(toBase64(participantId), keyPairId))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(204)
+                    .body(notNullValue());
+
+            // verify that the "rotated" event fired once
+            verify(subscriber).on(argThat(env -> {
+                if (env.getPayload() instanceof KeyPairRevoked evt) {
+                    return evt.getParticipantId().equals(participantId);
+                }
+                return false;
+            }));
+            // verify that the correct "added" event fired
+            verify(subscriber, never()).on(argThat(env -> env.getPayload() instanceof KeyPairAdded));
+
+            // verify that the STS client got updated correctly
+            assertThat(clientStore.findById(participantId)).isSucceeded()
+                    .satisfies(stsClient -> {
+                        assertThat(stsClient.getPrivateKeyAlias()).isEqualTo("");
+                        assertThat(stsClient.getPublicKeyReference()).isEqualTo("");
                     });
         }
 
@@ -672,7 +781,7 @@ public class KeyPairResourceApiEndToEndTest {
                     .anySatisfy(dd -> assertThat(dd.getVerificationMethod()).hasSize(2).anyMatch(vm -> vm.getId().equals(keyDescriptor.getKeyId())));
 
             assertThat(context.getDidResourceForParticipant("did:web:" + user1).getState()).isEqualTo(DidState.PUBLISHED.code());
-            verify(subscriber).on(argThat(e -> e.getPayload() instanceof KeyPairActivated kpa && kpa.getKeyPairResourceId().equals(keyPairId)));
+            verify(subscriber).on(argThat(e -> e.getPayload() instanceof KeyPairActivated kpa && kpa.getKeyPairResource().getId().equals(keyPairId)));
         }
 
         @Test
@@ -706,7 +815,7 @@ public class KeyPairResourceApiEndToEndTest {
                             .anyMatch(vm -> vm.getId().equals(keyDescriptor.getKeyId())));
 
             assertThat(context.getDidResourceForParticipant("did:web:" + participantId).getState()).isEqualTo(DidState.PUBLISHED.code());
-            verify(subscriber).on(argThat(e -> e.getPayload() instanceof KeyPairActivated kpa && kpa.getKeyPairResourceId().equals(keyPairId)));
+            verify(subscriber).on(argThat(e -> e.getPayload() instanceof KeyPairActivated kpa && kpa.getKeyPairResource().getId().equals(keyPairId)));
             // publishes did when creating the user, and when activating
             verify(subscriber, atLeast(2)).on(argThat(e -> e.getPayload() instanceof DidDocumentPublished));
         }
@@ -742,7 +851,7 @@ public class KeyPairResourceApiEndToEndTest {
             assertThat(context.getKeyPairsForParticipant(user1))
                     .allMatch(kpr -> kpr.getState() == KeyPairState.ACTIVATED.code());
 
-            verify(subscriber).on(argThat(e -> e.getPayload() instanceof KeyPairActivated kpa && kpa.getKeyPairResourceId().equals(keyPairId)));
+            verify(subscriber).on(argThat(e -> e.getPayload() instanceof KeyPairActivated kpa && kpa.getKeyPairResource().getId().equals(keyPairId)));
         }
 
         @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.tests;
 
 import io.restassured.http.Header;
+import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
@@ -46,7 +47,7 @@ public class VerifiableCredentialApiEndToEndTest {
     abstract static class Tests {
 
         @AfterEach
-        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore) {
+        void tearDown(ParticipantContextService pcService, DidResourceStore didResourceStore, KeyPairResourceStore keyPairResourceStore, StsClientStore stsClientStore) {
             // purge all users, dids, keypairs
 
             pcService.query(QuerySpec.max()).getContent()
@@ -56,6 +57,10 @@ public class VerifiableCredentialApiEndToEndTest {
 
             keyPairResourceStore.query(QuerySpec.max()).getContent()
                     .forEach(kpr -> keyPairResourceStore.deleteById(kpr.getId()).getContent());
+
+            stsClientStore.findAll(QuerySpec.max())
+                    .forEach(sts -> stsClientStore.deleteById(sts.getId()).getContent());
+
         }
 
         @Test

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -89,7 +89,7 @@ public class IdentityHubEndToEndTestContext {
                         .build())
                 .build();
         var srv = runtime.getService(ParticipantContextService.class);
-        return srv.createParticipantContext(manifest).orElseThrow(f -> new EdcException(f.getFailureDetail()));
+        return srv.createParticipantContext(manifest).orElseThrow(f -> new EdcException(f.getFailureDetail())).get("apiKey").toString();
     }
 
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubRuntimeConfiguration.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubRuntimeConfiguration.java
@@ -48,6 +48,8 @@ public class IdentityHubRuntimeConfiguration {
                 put("web.http.presentation.path", presentationEndpoint.getUrl().getPath());
                 put("web.http.identity.port", String.valueOf(identityEndpoint.getUrl().getPort()));
                 put("web.http.identity.path", identityEndpoint.getUrl().getPath());
+                put("web.http.sts.port", String.valueOf(getFreePort()));
+                put("web.http.sts.path", "/api/sts");
                 put("edc.runtime.id", name);
                 put("edc.ih.iam.id", "did:web:consumer");
                 put("edc.sql.schema.autocreate", "true");

--- a/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApi.java
+++ b/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApi.java
@@ -31,6 +31,7 @@ import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 @OpenAPIDefinition(info = @Info(description = "This is the Identity API for manipulating ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
 @Tag(name = "Participant Context")
@@ -50,7 +51,7 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    String createParticipant(ParticipantManifest manifest);
+    Map<String, Object> createParticipant(ParticipantManifest manifest);
 
 
     @Operation(description = "Gets ParticipantContexts by ID.",

--- a/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApiController.java
+++ b/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApiController.java
@@ -40,6 +40,7 @@ import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.identityhub.spi.AuthorizationResultHandler.exceptionMapper;
@@ -63,7 +64,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Override
     @POST
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
-    public String createParticipant(ParticipantManifest manifest) {
+    public Map<String, Object> createParticipant(ParticipantManifest manifest) {
         participantManifestValidator.validate(manifest).orElseThrow(ValidationFailureException::new);
         return participantContextService.createParticipantContext(manifest)
                 .orElseThrow(exceptionMapper(ParticipantManifest.class, manifest.getParticipantId()));

--- a/extensions/common/sts-account-provisioner/build.gradle.kts
+++ b/extensions/common/sts-account-provisioner/build.gradle.kts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+dependencies {
+
+    implementation(libs.edc.sts.spi)
+    implementation(libs.edc.spi.core)
+    implementation(project(":spi:participant-context-spi"))
+    implementation(project(":spi:keypair-spi"))
+    implementation(project(":spi:did-spi"))
+    testImplementation(libs.edc.junit)
+}

--- a/extensions/common/sts-account-provisioner/build.gradle.kts
+++ b/extensions/common/sts-account-provisioner/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
 
     implementation(libs.edc.sts.spi)
     implementation(libs.edc.spi.core)
+    implementation(libs.edc.spi.transaction)
     implementation(project(":spi:participant-context-spi"))
     implementation(project(":spi:keypair-spi"))
     implementation(project(":spi:did-spi"))

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisioner.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisioner.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.common.provisioner;
+
+import org.eclipse.edc.iam.identitytrust.sts.spi.model.StsClient;
+import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
+import org.eclipse.edc.identithub.spi.did.DidDocumentService;
+import org.eclipse.edc.identithub.spi.did.events.DidDocumentPublished;
+import org.eclipse.edc.identithub.spi.did.model.DidResource;
+import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairEvent;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.util.Optional.ofNullable;
+
+public class StsAccountProvisioner implements EventSubscriber {
+
+    private final Monitor monitor;
+    private final KeyPairService keyPairService;
+    private final DidDocumentService didDocumentService;
+    private final StsClientStore stsClientStore;
+    private final Vault vault;
+
+    public StsAccountProvisioner(Monitor monitor, KeyPairService keyPairService, DidDocumentService didDocumentService, StsClientStore stsClientStore, Vault vault) {
+        this.monitor = monitor;
+        this.keyPairService = keyPairService;
+        this.didDocumentService = didDocumentService;
+        this.stsClientStore = stsClientStore;
+        this.vault = vault;
+    }
+
+    @Override
+    public <E extends Event> void on(EventEnvelope<E> event) {
+        var payload = event.getPayload();
+        Result<Void> result;
+        if (payload instanceof ParticipantContextCreated createdEvent) {
+            result = createAccount(createdEvent.getManifest());
+        } else if (payload instanceof KeyPairRevoked || payload instanceof KeyPairRotated) {
+            result = setKeyAliases(((KeyPairEvent) payload).getParticipantId(), null, null);
+        } else if (payload instanceof DidDocumentPublished didDocumentPublished) {
+
+            var participantId = didDocumentPublished.getParticipantId();
+            result = getDefaultKeyPair(participantId)
+                    .map(kpr -> {
+                        var alias = kpr.getPrivateKeyAlias();
+                        var publicKeyReference = getVerificationMethodWithId(didDocumentPublished.getDid(), kpr.getKeyId());
+                        return setKeyAliases(participantId, alias, publicKeyReference);
+                    })
+                    .orElse(Result.failure("No default keypair found for participant " + participantId));
+        } else {
+            result = Result.failure("Received event with unexpected payload type: %s".formatted(payload.getClass()));
+        }
+
+        result.onFailure(f -> monitor.warning(f.getFailureDetail()));
+    }
+
+    private String getVerificationMethodWithId(String did, String keyId) {
+        return ofNullable(didDocumentService.findById(did))
+                .map(DidResource::getDocument).flatMap(dd -> dd.getVerificationMethod()
+                        .stream()
+                        .filter(vm -> vm.getId().endsWith(keyId)).findFirst())
+                .map(vm -> {
+                    if (vm.getController() != null && !vm.getId().startsWith(vm.getController())) {
+                        return vm.getController() + "#" + vm.getId();
+                    }
+                    return vm.getId();
+                }).orElse(null);
+    }
+
+    private Optional<KeyPairResource> getDefaultKeyPair(String participantId) {
+        return keyPairService.query(ParticipantResource.queryByParticipantId(participantId).build())
+                .orElse(failure -> Collections.emptySet())
+                .stream()
+                .filter(kpr -> kpr.getState() == KeyPairState.ACTIVATED.code())
+                .filter(KeyPairResource::isDefaultPair)
+                .findAny();
+    }
+
+    private Result<Void> setKeyAliases(String participantId, String privateKeyAlias, String publicKeyReference) {
+        return Result.failure("Updating StsClients is not yet implemented");
+    }
+
+    private Result<Void> createAccount(ParticipantManifest manifest) {
+        var secretAlias = UUID.randomUUID().toString();
+
+        //todo: generate random password and store in vault!
+
+        var client = StsClient.Builder.newInstance()
+                .id(manifest.getParticipantId())
+                .name(manifest.getParticipantId())
+                .clientId(manifest.getDid())
+                .did(manifest.getDid())
+                .privateKeyAlias(manifest.getKey().getPrivateKeyAlias())
+                .publicKeyReference(manifest.getKey().getKeyId())
+                .secretAlias(secretAlias)
+                .build();
+        var createResult = stsClientStore.create(client);
+        return createResult.succeeded() ? Result.success() : Result.failure(createResult.getFailureDetail());
+    }
+}

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
@@ -72,7 +72,7 @@ public class StsAccountProvisionerExtension implements ServiceExtension {
             var monitor = context.getMonitor().withPrefix("STS-Account");
             if (stsClientStore != null) {
                 monitor.debug("This IdentityHub runtime contains an embedded SecureTokenService (STS) instance. ParticipantContexts and STS Clients will be synchronized.");
-                provisioner = new StsAccountProvisioner(monitor, keyPairService, didDocumentService, stsClientStore, vault, stsClientSecretGenerator());
+                provisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator());
                 eventRouter.registerSync(ParticipantContextDeleted.class, provisioner);
                 eventRouter.registerSync(KeyPairRevoked.class, provisioner);
                 eventRouter.registerSync(KeyPairRotated.class, provisioner);

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.common.provisioner;
+
+import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
+import org.eclipse.edc.identithub.spi.did.DidDocumentService;
+import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+
+import static org.eclipse.edc.identityhub.common.provisioner.StsAccountProvisionerExtension.NAME;
+
+@Extension(value = NAME)
+public class StsAccountProvisionerExtension implements ServiceExtension {
+    public static final String NAME = "STS Account Provisioner Extension";
+
+    @Inject
+    private EventRouter eventRouter;
+    @Inject
+    private KeyPairService keyPairService;
+    @Inject
+    private DidDocumentService didDocumentService;
+    @Inject(required = false)
+    private StsClientStore stsClientStore;
+    @Inject
+    private Vault vault;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        var monitor = context.getMonitor().withPrefix("STS-Account");
+        if (stsClientStore != null) {
+            var provisioner = new StsAccountProvisioner(monitor, keyPairService, didDocumentService, stsClientStore, vault);
+            eventRouter.registerSync(ParticipantContextCreated.class, provisioner);
+            eventRouter.registerSync(KeyPairAdded.class, provisioner);
+            eventRouter.registerSync(KeyPairRevoked.class, provisioner);
+            eventRouter.registerSync(KeyPairRotated.class, provisioner);
+            eventRouter.registerSync(KeyPairActivated.class, provisioner);
+        } else {
+            monitor.warning("STS Client Store not available (are you using a standalone STS?). Synchronizing ParticipantContexts with STS not possible.");
+        }
+    }
+}

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.jetbrains.annotations.Nullable;
 
 import java.security.SecureRandom;
@@ -51,6 +52,8 @@ public class StsAccountProvisionerExtension implements ServiceExtension {
     private Vault vault;
     @Inject(required = false)
     private StsClientSecretGenerator stsClientSecretGenerator;
+    @Inject
+    private TransactionContext transactionContext;
 
     private StsAccountProvisioner provisioner;
 
@@ -72,7 +75,7 @@ public class StsAccountProvisionerExtension implements ServiceExtension {
             var monitor = context.getMonitor().withPrefix("STS-Account");
             if (stsClientStore != null) {
                 monitor.debug("This IdentityHub runtime contains an embedded SecureTokenService (STS) instance. ParticipantContexts and STS Clients will be synchronized.");
-                provisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator());
+                provisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator(), transactionContext);
                 eventRouter.registerSync(ParticipantContextDeleted.class, provisioner);
                 eventRouter.registerSync(KeyPairRevoked.class, provisioner);
                 eventRouter.registerSync(KeyPairRotated.class, provisioner);

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairAdded;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.event.EventRouter;
@@ -57,6 +58,7 @@ public class StsAccountProvisionerExtension implements ServiceExtension {
         if (stsClientStore != null) {
             var provisioner = new StsAccountProvisioner(monitor, keyPairService, didDocumentService, stsClientStore, vault);
             eventRouter.registerSync(ParticipantContextCreated.class, provisioner);
+            eventRouter.registerSync(ParticipantContextDeleted.class, provisioner);
             eventRouter.registerSync(KeyPairAdded.class, provisioner);
             eventRouter.registerSync(KeyPairRevoked.class, provisioner);
             eventRouter.registerSync(KeyPairRotated.class, provisioner);

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerExtension.java
@@ -74,14 +74,14 @@ public class StsAccountProvisionerExtension implements ServiceExtension {
         if (provisioner == null) {
             var monitor = context.getMonitor().withPrefix("STS-Account");
             if (stsClientStore != null) {
-                monitor.debug("This IdentityHub runtime contains an embedded SecureTokenService (STS) instance. ParticipantContexts and STS Clients will be synchronized.");
+                monitor.info("This IdentityHub runtime contains an embedded SecureTokenService (STS) instance. That means ParticipantContexts and STS Accounts will be synchronized automatically.");
                 provisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator(), transactionContext);
                 eventRouter.registerSync(ParticipantContextDeleted.class, provisioner);
                 eventRouter.registerSync(KeyPairRevoked.class, provisioner);
                 eventRouter.registerSync(KeyPairRotated.class, provisioner);
             } else {
                 monitor.warning("This IdentityHub runtime does NOT contain an embedded SecureTokenService (STS) instance. " +
-                        "Synchronizing ParticipantContexts and STS clients must be handled out-of-band.");
+                        "Synchronizing ParticipantContexts and STS Accounts must be handled out-of-band.");
             }
         }
         return provisioner;

--- a/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsClientSecretGenerator.java
+++ b/extensions/common/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsClientSecretGenerator.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.common.provisioner;
+
+import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
+import org.jetbrains.annotations.Nullable;
+
+@ExtensionPoint
+@FunctionalInterface
+public interface StsClientSecretGenerator {
+    /**
+     * Generates a client secret as string, taking an optional argument. By default,
+     *
+     * @param parameters Optional generator arguments, such as a salt value
+     * @return a randomly generated client secret.
+     */
+    String generateClientSecret(@Nullable Object parameters);
+}

--- a/extensions/common/sts-account-provisioner/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/common/sts-account-provisioner/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2024 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.common.provisioner.StsAccountProvisionerExtension

--- a/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
+++ b/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.identithub.spi.did.DidDocumentService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
@@ -29,6 +30,7 @@ import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -56,7 +58,7 @@ class StsAccountProvisionerTest {
     private final Vault vault = mock();
     private final Monitor monitor = mock();
     private final StsClientSecretGenerator stsClientSecretGenerator = parameters -> UUID.randomUUID().toString();
-    private final StsAccountProvisioner accountProvisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator);
+    private final StsAccountProvisioner accountProvisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator, new NoopTransactionContext());
 
     @Test
     void create() {
@@ -88,7 +90,7 @@ class StsAccountProvisionerTest {
         when(stsClientStore.update(any())).thenAnswer(a -> StoreResult.success(a.getArguments()[0]));
         accountProvisioner.on(event(KeyPairRevoked.Builder.newInstance()
                 .participantId(PARTICIPANT_CONTEXT_ID)
-                .keyPairResourceId(UUID.randomUUID().toString())
+                .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .keyId(KEY_ID)
                 .build()));
 
@@ -104,7 +106,7 @@ class StsAccountProvisionerTest {
 
         accountProvisioner.on(event(KeyPairRotated.Builder.newInstance()
                 .participantId(PARTICIPANT_CONTEXT_ID)
-                .keyPairResourceId(UUID.randomUUID().toString())
+                .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .keyId(KEY_ID)
                 .build()));
 

--- a/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
+++ b/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
@@ -14,36 +14,23 @@
 
 package org.eclipse.edc.identityhub.common.provisioner;
 
-import org.eclipse.edc.iam.did.spi.document.DidDocument;
-import org.eclipse.edc.iam.did.spi.document.Service;
-import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
 import org.eclipse.edc.iam.identitytrust.sts.spi.model.StsClient;
 import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
 import org.eclipse.edc.identithub.spi.did.DidDocumentService;
-import org.eclipse.edc.identithub.spi.did.events.DidDocumentPublished;
-import org.eclipse.edc.identithub.spi.did.model.DidResource;
-import org.eclipse.edc.identithub.spi.did.model.DidState;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
-import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
-import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
 import org.eclipse.edc.spi.event.Event;
 import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.monitor.Monitor;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.security.Vault;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -51,12 +38,11 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class StsAccountProvisionerTest {
@@ -70,19 +56,11 @@ class StsAccountProvisionerTest {
     private final Vault vault = mock();
     private final Monitor monitor = mock();
     private final StsClientSecretGenerator stsClientSecretGenerator = parameters -> UUID.randomUUID().toString();
-    private final StsAccountProvisioner accountProvisioner = new StsAccountProvisioner(monitor, keyPairService, didDocumentService, stsClientStore, vault, stsClientSecretGenerator);
+    private final StsAccountProvisioner accountProvisioner = new StsAccountProvisioner(monitor, stsClientStore, vault, stsClientSecretGenerator);
 
     @Test
     void create() {
-        when(stsClientStore.create(any())).thenReturn(StoreResult.success(StsClient.Builder.newInstance()
-                .id("test-id")
-                .name("test-name")
-                .did("did:web:" + PARTICIPANT_CONTEXT_ID)
-                .secretAlias("test-secret")
-                .publicKeyReference("public-key-ref")
-                .privateKeyAlias("private-key-alias")
-                .clientId("client-id")
-                .build()));
+        when(stsClientStore.create(any())).thenReturn(StoreResult.success(createStsClient().build()));
         when(vault.storeSecret(anyString(), anyString())).thenReturn(Result.success());
 
         assertThat(accountProvisioner.create(createManifest().build())).isSucceeded();
@@ -106,89 +84,44 @@ class StsAccountProvisionerTest {
 
     @Test
     void onKeyRevoked_shouldUpdate() {
+        when(stsClientStore.findById(PARTICIPANT_CONTEXT_ID)).thenReturn(StoreResult.success(createStsClient().build()));
+        when(stsClientStore.update(any())).thenAnswer(a -> StoreResult.success(a.getArguments()[0]));
         accountProvisioner.on(event(KeyPairRevoked.Builder.newInstance()
                 .participantId(PARTICIPANT_CONTEXT_ID)
                 .keyPairResourceId(UUID.randomUUID().toString())
                 .keyId(KEY_ID)
                 .build()));
 
-        verify(monitor).warning(contains("not yet implemented"));
-        verifyNoInteractions(stsClientStore, didDocumentService, keyPairService);
+        verify(stsClientStore).findById(PARTICIPANT_CONTEXT_ID);
+        verify(stsClientStore).update(any());
+        verifyNoMoreInteractions(stsClientStore, didDocumentService, keyPairService);
     }
 
     @Test
     void onKeyRotated_withNewKey_shouldUpdate() {
+        when(stsClientStore.findById(PARTICIPANT_CONTEXT_ID)).thenReturn(StoreResult.success(createStsClient().build()));
+        when(stsClientStore.update(any())).thenAnswer(a -> StoreResult.success(a.getArguments()[0]));
+
         accountProvisioner.on(event(KeyPairRotated.Builder.newInstance()
                 .participantId(PARTICIPANT_CONTEXT_ID)
                 .keyPairResourceId(UUID.randomUUID().toString())
                 .keyId(KEY_ID)
                 .build()));
 
-        verify(monitor).warning(contains("not yet implemented"));
-        verifyNoInteractions(stsClientStore, didDocumentService, keyPairService);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "key-1", PARTICIPANT_DID + "#key-1" })
-    void onDidPublished_shouldUpdate(String keyId) {
-        when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(KeyPairResource.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .keyId(keyId)
-                .isDefaultPair(true)
-                .privateKeyAlias(keyId + "-alias")
-                .state(KeyPairState.ACTIVATED.code())
-                .build())));
-
-        var doc = DidDocument.Builder.newInstance()
-                .id(PARTICIPANT_DID)
-                .service(List.of(new Service("test-service", "test-service", "https://test.service.com/")))
-                .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
-                        .id(keyId)
-                        .publicKeyMultibase("saflasjdflaskjdflasdkfj")
-                        .controller(PARTICIPANT_DID)
-                        .build()))
-                .build();
-        var res = DidResource.Builder.newInstance().did(doc.getId()).state(DidState.PUBLISHED).document(doc).build();
-        when(didDocumentService.findById(eq(PARTICIPANT_DID))).thenReturn(res);
-
-        accountProvisioner.on(event(DidDocumentPublished.Builder.newInstance()
-                .participantId(PARTICIPANT_CONTEXT_ID)
-                .did(PARTICIPANT_DID)
-                .build()));
-
-        verify(monitor).warning(contains("not yet implemented"));
-        verify(keyPairService).query(any(QuerySpec.class));
-        verify(didDocumentService).findById(eq(PARTICIPANT_DID));
-        verifyNoInteractions(stsClientStore);
-    }
-
-    @Test
-    void onDidPublished_noDefaultKey_shouldUpdate() {
-        when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(KeyPairResource.Builder.newInstance()
-                .id(UUID.randomUUID().toString())
-                .isDefaultPair(false)
-                .privateKeyAlias(KEY_ID + "-alias")
-                .state(KeyPairState.ACTIVATED.code())
-                .build())));
-        accountProvisioner.on(event(DidDocumentPublished.Builder.newInstance()
-                .participantId(PARTICIPANT_CONTEXT_ID)
-                .did(PARTICIPANT_DID)
-                .build()));
-
-        verify(monitor).warning(contains("No default keypair found for participant " + PARTICIPANT_CONTEXT_ID));
-        verify(keyPairService).query(any(QuerySpec.class));
-        verifyNoInteractions(stsClientStore, didDocumentService);
-
+        verify(stsClientStore).findById(PARTICIPANT_CONTEXT_ID);
+        verify(stsClientStore).update(any());
+        verifyNoMoreInteractions(stsClientStore, didDocumentService, keyPairService);
     }
 
     @Test
     void onParticipantDeleted_shouldDelete() {
+        when(stsClientStore.deleteById(PARTICIPANT_CONTEXT_ID)).thenReturn(StoreResult.success());
         accountProvisioner.on(event(ParticipantContextDeleted.Builder.newInstance()
                 .participantId(PARTICIPANT_CONTEXT_ID)
                 .build()));
 
-        verify(monitor).warning(eq("Deleting StsClients is not yet implemented"));
-        verifyNoInteractions(keyPairService, didDocumentService, stsClientStore);
+        verify(stsClientStore).deleteById(PARTICIPANT_CONTEXT_ID);
+        verifyNoMoreInteractions(keyPairService, didDocumentService, stsClientStore);
     }
 
     @Test
@@ -196,6 +129,17 @@ class StsAccountProvisionerTest {
         accountProvisioner.on(event(new DummyEvent()));
         verify(monitor).warning(startsWith("Received event with unexpected payload"));
         verifyNoInteractions(keyPairService, didDocumentService, stsClientStore, vault);
+    }
+
+    private StsClient.Builder createStsClient() {
+        return StsClient.Builder.newInstance()
+                .id("test-id")
+                .name("test-name")
+                .did("did:web:" + PARTICIPANT_CONTEXT_ID)
+                .secretAlias("test-secret")
+                .publicKeyReference("public-key-ref")
+                .privateKeyAlias("private-key-alias")
+                .clientId("client-id");
     }
 
     private ParticipantManifest.Builder createManifest() {

--- a/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
+++ b/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
@@ -28,6 +28,7 @@ import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextDeleted;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
 import org.eclipse.edc.spi.event.Event;
@@ -168,6 +169,16 @@ class StsAccountProvisionerTest {
         verify(keyPairService).query(any(QuerySpec.class));
         verifyNoInteractions(stsClientStore, didDocumentService);
 
+    }
+
+    @Test
+    void onParticipantDeleted_shouldDelete() {
+        accountProvisioner.on(event(ParticipantContextDeleted.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .build()));
+
+        verify(monitor).warning(eq("Deleting StsClients is not yet implemented"));
+        verifyNoInteractions(keyPairService, didDocumentService, stsClientStore);
     }
 
     @Test

--- a/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
+++ b/extensions/common/sts-account-provisioner/src/test/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerTest.java
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.common.provisioner;
+
+import org.eclipse.edc.iam.did.spi.document.DidDocument;
+import org.eclipse.edc.iam.did.spi.document.Service;
+import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
+import org.eclipse.edc.iam.identitytrust.sts.spi.store.StsClientStore;
+import org.eclipse.edc.identithub.spi.did.DidDocumentService;
+import org.eclipse.edc.identithub.spi.did.events.DidDocumentPublished;
+import org.eclipse.edc.identithub.spi.did.model.DidResource;
+import org.eclipse.edc.identithub.spi.did.model.DidState;
+import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRotated;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextCreated;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.security.Vault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class StsAccountProvisionerTest {
+
+    private static final String PARTICIPANT_CONTEXT_ID = "test-participant";
+    private static final String PARTICIPANT_DID = "did:web:" + PARTICIPANT_CONTEXT_ID;
+    private static final String KEY_ID = "test-key-id";
+    private final KeyPairService keyPairService = mock();
+    private final DidDocumentService didDocumentService = mock();
+    private final StsClientStore stsClientStore = mock();
+    private final Vault vault = mock();
+    private final Monitor monitor = mock();
+    private final StsAccountProvisioner accountProvisioner = new StsAccountProvisioner(monitor, keyPairService, didDocumentService, stsClientStore, vault);
+
+    @Test
+    void onParticipantCreated() {
+        when(stsClientStore.create(any())).thenReturn(StoreResult.success());
+
+        accountProvisioner.on(event(ParticipantContextCreated.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .manifest(createManifest().build())
+                .build()));
+
+        verify(stsClientStore).create(any());
+        verifyNoInteractions(keyPairService, didDocumentService);
+    }
+
+    @Test
+    void onParticipantCreated_whenClientAlreadyExists() {
+        when(stsClientStore.create(any())).thenReturn(StoreResult.alreadyExists("foo"));
+
+        accountProvisioner.on(event(ParticipantContextCreated.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .manifest(createManifest().build())
+                .build()));
+
+        verify(monitor).warning(eq("foo"));
+        verify(stsClientStore).create(any());
+        verifyNoInteractions(keyPairService, didDocumentService);
+    }
+
+    @Test
+    void onKeyRevoked_shouldUpdate() {
+        accountProvisioner.on(event(KeyPairRevoked.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .keyPairResourceId(UUID.randomUUID().toString())
+                .keyId(KEY_ID)
+                .build()));
+
+        verify(monitor).warning(contains("not yet implemented"));
+        verifyNoInteractions(stsClientStore, didDocumentService, keyPairService);
+    }
+
+    @Test
+    void onKeyRotated_withNewKey_shouldUpdate() {
+        accountProvisioner.on(event(KeyPairRotated.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .keyPairResourceId(UUID.randomUUID().toString())
+                .keyId(KEY_ID)
+                .build()));
+
+        verify(monitor).warning(contains("not yet implemented"));
+        verifyNoInteractions(stsClientStore, didDocumentService, keyPairService);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "key-1", PARTICIPANT_DID + "#key-1" })
+    void onDidPublished_shouldUpdate(String keyId) {
+        when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(KeyPairResource.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .keyId(keyId)
+                .isDefaultPair(true)
+                .privateKeyAlias(keyId + "-alias")
+                .state(KeyPairState.ACTIVATED.code())
+                .build())));
+
+        var doc = DidDocument.Builder.newInstance()
+                .id(PARTICIPANT_DID)
+                .service(List.of(new Service("test-service", "test-service", "https://test.service.com/")))
+                .verificationMethod(List.of(VerificationMethod.Builder.newInstance()
+                        .id(keyId)
+                        .publicKeyMultibase("saflasjdflaskjdflasdkfj")
+                        .controller(PARTICIPANT_DID)
+                        .build()))
+                .build();
+        var res = DidResource.Builder.newInstance().did(doc.getId()).state(DidState.PUBLISHED).document(doc).build();
+        when(didDocumentService.findById(eq(PARTICIPANT_DID))).thenReturn(res);
+
+        accountProvisioner.on(event(DidDocumentPublished.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .did(PARTICIPANT_DID)
+                .build()));
+
+        verify(monitor).warning(contains("not yet implemented"));
+        verify(keyPairService).query(any(QuerySpec.class));
+        verify(didDocumentService).findById(eq(PARTICIPANT_DID));
+        verifyNoInteractions(stsClientStore);
+    }
+
+    @Test
+    void onDidPublished_noDefaultKey_shouldUpdate() {
+        when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(KeyPairResource.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .isDefaultPair(false)
+                .privateKeyAlias(KEY_ID + "-alias")
+                .state(KeyPairState.ACTIVATED.code())
+                .build())));
+        accountProvisioner.on(event(DidDocumentPublished.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .did(PARTICIPANT_DID)
+                .build()));
+
+        verify(monitor).warning(contains("No default keypair found for participant " + PARTICIPANT_CONTEXT_ID));
+        verify(keyPairService).query(any(QuerySpec.class));
+        verifyNoInteractions(stsClientStore, didDocumentService);
+
+    }
+
+    @Test
+    void onOtherEvent_shouldLogWarning() {
+        accountProvisioner.on(event(new DummyEvent()));
+        verify(monitor).warning(startsWith("Received event with unexpected payload"));
+        verifyNoInteractions(keyPairService, didDocumentService, stsClientStore, vault);
+    }
+
+    private ParticipantManifest.Builder createManifest() {
+        return ParticipantManifest.Builder.newInstance()
+                .participantId(PARTICIPANT_CONTEXT_ID)
+                .active(true)
+                .did(PARTICIPANT_DID)
+                .key(KeyDescriptor.Builder.newInstance()
+                        .privateKeyAlias(KEY_ID + "-alias")
+                        .keyGeneratorParams(Map.of("algorithm", "EdDSA", "curve", "Ed25519"))
+                        .keyId(KEY_ID)
+                        .build()
+                );
+    }
+
+    @SuppressWarnings("unchecked")
+    private EventEnvelope<Event> event(Event event) {
+        return EventEnvelope.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .at(System.currentTimeMillis())
+                .payload(event)
+                .build();
+    }
+
+    private static class DummyEvent extends Event {
+        @Override
+        public String name() {
+            return "dummy";
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,8 @@ edc-core-jerseyproviders = { module = "org.eclipse.edc:jersey-providers-lib", ve
 # EDC STS dependencies
 edc-sts-spi = { module = "org.eclipse.edc:identity-trust-sts-spi", version.ref = "edc" }
 edc-sts-core = { module = "org.eclipse.edc:identity-trust-sts-core", version.ref = "edc" }
+edc-sts = { module = "org.eclipse.edc:identity-trust-sts-embedded", version.ref = "edc" }
+edc-sts-api = { module = "org.eclipse.edc:identity-trust-sts-api", version.ref = "edc" }
 
 # Third party libs
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,9 @@ edc-lib-json = { module = "org.eclipse.edc:json-lib", version.ref = "edc" }
 edc-lib-common-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
 edc-core-jerseyproviders = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
 
+# EDC STS dependencies
+edc-sts-spi = { module = "org.eclipse.edc:identity-trust-sts-spi", version.ref = "edc" }
+edc-sts-core = { module = "org.eclipse.edc:identity-trust-sts-core", version.ref = "edc" }
 
 # Third party libs
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     runtimeOnly(libs.edc.core.token)
     runtimeOnly(libs.edc.api.version)
     runtimeOnly(libs.edc.sts.core)
+    runtimeOnly(libs.edc.sts)
+    runtimeOnly(libs.edc.sts.api)
 
     runtimeOnly(libs.edc.identity.did.web)
     runtimeOnly(libs.bundles.connector)

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly(project(":core:identity-hub-keypairs"))
     runtimeOnly(project(":extensions:did:local-did-publisher"))
     runtimeOnly(project(":extensions:common:credential-watchdog"))
+    runtimeOnly(project(":extensions:common:sts-account-provisioner"))
     runtimeOnly(project(":extensions:api:identity-api:did-api"))
     runtimeOnly(project(":extensions:api:identity-api:participant-context-api"))
     runtimeOnly(project(":extensions:api:identity-api:verifiable-credentials-api"))
@@ -36,6 +37,7 @@ dependencies {
     runtimeOnly(libs.edc.identity.did.core)
     runtimeOnly(libs.edc.core.token)
     runtimeOnly(libs.edc.api.version)
+    runtimeOnly(libs.edc.sts.core)
 
     runtimeOnly(libs.edc.identity.did.web)
     runtimeOnly(libs.bundles.connector)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,6 +50,7 @@ include(":extensions:store:sql:identity-hub-participantcontext-store-sql")
 include(":extensions:store:sql:identity-hub-keypair-store-sql")
 include(":extensions:did:local-did-publisher")
 include(":extensions:common:credential-watchdog")
+include(":extensions:common:sts-account-provisioner")
 
 // Identity APIs
 include(":extensions:api:identity-api:validators")

--- a/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/ParticipantContextStore.java
+++ b/spi/identity-hub-store-spi/src/main/java/org/eclipse/edc/identityhub/spi/store/ParticipantContextStore.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.spi.store;
 
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.StoreResult;
 
@@ -62,5 +63,15 @@ public interface ParticipantContextStore {
 
     default String notFoundErrorMessage(String id) {
         return "A ParticipantContext with ID '%s' does not exist.".formatted(id);
+    }
+
+    default StoreResult<ParticipantContext> findById(String participantId) {
+        var res = query(ParticipantResource.queryByParticipantId(participantId).build());
+        if (res.succeeded()) {
+            return res.getContent().stream().findFirst()
+                    .map(StoreResult::success)
+                    .orElse(StoreResult.notFound("ParticipantContext with ID '%s' does not exist.".formatted(participantId)));
+        }
+        return StoreResult.generalError(res.getFailureDetail());
     }
 }

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEvent.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEvent.java
@@ -25,14 +25,14 @@ import java.util.Objects;
  */
 public abstract class KeyPairEvent extends Event {
     protected String participantId;
-    protected String keyPairResourceId;
+    protected KeyPairResource keyPairResource;
     protected String keyId;
 
     /**
-     * The ID of the {@link KeyPairResource}. This is the internal database ID.
+     * The {@link KeyPairResource} that this event refers to.
      */
-    public String getKeyPairResourceId() {
-        return keyPairResourceId;
+    public KeyPairResource getKeyPairResource() {
+        return keyPairResource;
     }
 
     /**
@@ -69,8 +69,8 @@ public abstract class KeyPairEvent extends Event {
             return self();
         }
 
-        public B keyPairResourceId(String keyPairResourceId) {
-            event.keyPairResourceId = keyPairResourceId;
+        public B keyPairResource(KeyPairResource keyPairResource) {
+            event.keyPairResource = keyPairResource;
             return self();
         }
 

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEventListener.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairEventListener.java
@@ -15,8 +15,10 @@
 package org.eclipse.edc.identityhub.spi.keypair.events;
 
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.spi.observe.Observable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Interface implemented by listeners registered to observe key pair resource changes via {@link Observable#registerListener}.
@@ -39,9 +41,10 @@ public interface KeyPairEventListener {
      * A {@link KeyPairResource} was rotated (=phased out). If the rotation was done with a successor keypair, this would be communicated using the {@link KeyPairEventListener#added(KeyPairResource, String)}
      * callback.
      *
-     * @param keyPair the old (outgoing) {@link KeyPairResource}
+     * @param keyPair    the old (outgoing) {@link KeyPairResource}
+     * @param newKeyDesc The {@link KeyDescriptor} of the new Key pair. can be null.
      */
-    default void rotated(KeyPairResource keyPair) {
+    default void rotated(KeyPairResource keyPair, @Nullable KeyDescriptor newKeyDesc) {
 
     }
 
@@ -49,9 +52,10 @@ public interface KeyPairEventListener {
      * A {@link KeyPairResource} was revoked (=deleted). If the revocation was done with a successor keypair, this would be communicated using the {@link KeyPairEventListener#added(KeyPairResource, String)}
      * callback.
      *
-     * @param keyPair the old (outgoing) {@link KeyPairResource}
+     * @param keyPair    the old (outgoing) {@link KeyPairResource}
+     * @param newKeyDesc The {@link KeyDescriptor} of the new Key pair. can be null.
      */
-    default void revoked(KeyPairResource keyPair) {
+    default void revoked(KeyPairResource keyPair, @Nullable KeyDescriptor newKeyDesc) {
 
     }
 

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRevoked.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRevoked.java
@@ -17,15 +17,23 @@ package org.eclipse.edc.identityhub.spi.keypair.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Event that signals that a KeyPair was revoked.
  */
 @JsonDeserialize(builder = KeyPairRevoked.Builder.class)
 public class KeyPairRevoked extends KeyPairEvent {
+    private @Nullable KeyDescriptor newKeyDescriptor;
+
     @Override
     public String name() {
         return "keypair.revoked";
+    }
+
+    public @Nullable KeyDescriptor getNewKeyDescriptor() {
+        return newKeyDescriptor;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -42,6 +50,11 @@ public class KeyPairRevoked extends KeyPairEvent {
 
         @Override
         public KeyPairRevoked.Builder self() {
+            return this;
+        }
+
+        public Builder newKeyDescriptor(@Nullable KeyDescriptor newKeyDescriptor) {
+            event.newKeyDescriptor = newKeyDescriptor;
             return this;
         }
     }

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRotated.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRotated.java
@@ -17,15 +17,23 @@ package org.eclipse.edc.identityhub.spi.keypair.events;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Event that signals that a KeyPair was rotated.
  */
 @JsonDeserialize(builder = KeyPairRotated.Builder.class)
 public class KeyPairRotated extends KeyPairEvent {
+    private @Nullable KeyDescriptor newKeyDescriptor;
+
     @Override
     public String name() {
         return "keypair.rotated";
+    }
+
+    public @Nullable KeyDescriptor getNewKeyDescriptor() {
+        return newKeyDescriptor;
     }
 
     @JsonPOJOBuilder(withPrefix = "")
@@ -42,6 +50,11 @@ public class KeyPairRotated extends KeyPairEvent {
 
         @Override
         public KeyPairRotated.Builder self() {
+            return this;
+        }
+
+        public Builder newKeyDescriptor(@Nullable KeyDescriptor newKeyDesc) {
+            event.newKeyDescriptor = newKeyDesc;
             return this;
         }
     }

--- a/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairResource.java
+++ b/spi/keypair-spi/src/main/java/org/eclipse/edc/identityhub/spi/keypair/model/KeyPairResource.java
@@ -17,6 +17,8 @@ package org.eclipse.edc.identityhub.spi.keypair.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.security.Vault;
 
 import java.time.Duration;
@@ -40,6 +42,10 @@ public class KeyPairResource extends ParticipantResource {
     private int state;
 
     private KeyPairResource() {
+    }
+
+    public static QuerySpec.Builder queryById(String id) {
+        return QuerySpec.Builder.newInstance().filter(new Criterion("id", "=", id));
     }
 
     public String getGroupName() {

--- a/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairAddedTest.java
+++ b/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairAddedTest.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.edc.identityhub.spi.keypair.events;
 
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +30,7 @@ class KeyPairAddedTest {
     @Test
     void verify_serDes() {
         var evt = KeyPairAdded.Builder.newInstance()
-                .keyPairResourceId("resource-id")
+                .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .keyId("key-id")
                 .participantId("participant-id")
                 .build();

--- a/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRevokedTest.java
+++ b/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRevokedTest.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.edc.identityhub.spi.keypair.events;
 
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +30,7 @@ class KeyPairRevokedTest {
     @Test
     void verify_serDes() {
         var evt = KeyPairRevoked.Builder.newInstance()
-                .keyPairResourceId("resource-id")
+                .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .keyId("key-id")
                 .participantId("participant-id")
                 .build();

--- a/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRotatedTest.java
+++ b/spi/keypair-spi/src/test/java/org/eclipse/edc/identityhub/spi/keypair/events/KeyPairRotatedTest.java
@@ -14,9 +14,12 @@
 
 package org.eclipse.edc.identityhub.spi.keypair.events;
 
+import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +30,7 @@ class KeyPairRotatedTest {
     @Test
     void verify_serDes() {
         var evt = KeyPairRotated.Builder.newInstance()
-                .keyPairResourceId("resource-id")
+                .keyPairResource(KeyPairResource.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .keyId("key-id")
                 .participantId("participant-id")
                 .build();

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/AccountInfo.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/AccountInfo.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.participantcontext;
+
+public record AccountInfo(String clientId, String clientSecret) {
+}

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/AccountProvisioner.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/AccountProvisioner.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.participantcontext;
+
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+public interface AccountProvisioner {
+    ServiceResult<AccountInfo> create(ParticipantManifest manifest);
+}

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/ParticipantContextService.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/ParticipantContextService.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -34,7 +35,7 @@ public interface ParticipantContextService {
      * @param manifest The new participant context
      * @return success if created, or a failure if already exists.
      */
-    ServiceResult<String> createParticipantContext(ParticipantManifest manifest);
+    ServiceResult<Map<String, Object>> createParticipantContext(ParticipantManifest manifest);
 
     /**
      * Fetches the {@link ParticipantContext} by ID.


### PR DESCRIPTION
## What this PR changes/adds

Implements the `StsAccountProvisioner` which creates, updates and deletes `StsClient` entries as a result of certain IdentityHub management actions.

Here's how it works:

- the STS client is generated explicitly when a `ParticipantContext` is created
- `revoked` and `rotated` events are synchronized to the STS client 
- deleting a ParticipantContext deletes the StsClient

## Why it does that

convenience and comfort

## Further notes

- `KeyPairAdded` and `KeyPairRevoked` now carry the `KeyPairResource` instead of just the ID
- `KeyPairAdded` and `KeyPairRevoked` now carry the (nullable) description of the new key

## Linked Issue(s)

Closes #456

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
