### PR TITLE
feat: validate 'jti' claims in `AccessTokenVerifier`

### DIFF
--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.edc.spi.token)
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)
+    implementation(libs.edc.vc.jwt)
     implementation(libs.edc.core.token)
     implementation(libs.edc.verifiablecredentials) // revocation list service
 

--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(libs.edc.spi.token)
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)
-    implementation(libs.edc.vc.jwt)
+    implementation(libs.edc.vc.jwt) // JtiValidationRule
     implementation(libs.edc.core.token)
     implementation(libs.edc.verifiablecredentials) // revocation list service
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/DefaultServicesExtensionTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/DefaultServicesExtensionTest.java
@@ -18,15 +18,19 @@ import org.eclipse.edc.identityhub.accesstoken.rules.ClaimIsPresentRule;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.JtiValidationRule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static org.eclipse.edc.identityhub.DefaultServicesExtension.ACCESSTOKEN_JTI_VALIDATION_ACTIVATE;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(DependencyInjectionExtension.class)
 class DefaultServicesExtensionTest {
@@ -42,6 +46,17 @@ class DefaultServicesExtensionTest {
         extension.initialize(context);
         verify(registry).addRule(eq("dcp-si"), isA(ClaimIsPresentRule.class));
         verify(registry).addRule(eq("dcp-access-token"), isA(ClaimIsPresentRule.class));
+        verifyNoMoreInteractions(registry);
+    }
+
+    @Test
+    void initialize_verifyTokenRules_withJtiRule(DefaultServicesExtension extension, ServiceExtensionContext context) {
+        when(context.getSetting(eq(ACCESSTOKEN_JTI_VALIDATION_ACTIVATE), anyBoolean()))
+                .thenReturn(true);
+        extension.initialize(context);
+        verify(registry).addRule(eq("dcp-si"), isA(ClaimIsPresentRule.class));
+        verify(registry).addRule(eq("dcp-access-token"), isA(ClaimIsPresentRule.class));
+        verify(registry).addRule(eq("dcp-access-token"), isA(JtiValidationRule.class));
         verifyNoMoreInteractions(registry);
     }
 }

--- a/core/lib/accesstoken-lib/build.gradle.kts
+++ b/core/lib/accesstoken-lib/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     testImplementation(libs.edc.junit)
     testImplementation(libs.edc.core.token)
     testImplementation(libs.nimbus.jwt)
+    testImplementation(libs.edc.vc.jwt) // JtiValidationRule
     testImplementation(testFixtures(project(":spi:verifiable-credential-spi")))
 }

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubRuntimeConfiguration.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubRuntimeConfiguration.java
@@ -50,12 +50,13 @@ public class IdentityHubRuntimeConfiguration {
                 put("web.http.identity.path", identityEndpoint.getUrl().getPath());
                 put("web.http.sts.port", String.valueOf(getFreePort()));
                 put("web.http.sts.path", "/api/sts");
-                put("web.http.acounts.port", String.valueOf(getFreePort()));
+                put("web.http.accounts.port", String.valueOf(getFreePort()));
                 put("web.http.accounts.path", "/api/accounts");
                 put("edc.runtime.id", name);
                 put("edc.ih.iam.id", "did:web:consumer");
                 put("edc.sql.schema.autocreate", "true");
                 put("edc.api.accounts.key", "password");
+                put("edc.iam.accesstoken.jti.validation", String.valueOf(true));
             }
         };
     }


### PR DESCRIPTION
## What this PR changes/adds

add validation for the JWT Token IDs (`jti` claim) when verifying Access tokens.

to do that, the `JtiValidationRule` has been registered for the `"dcp-access-token"` validation context.

Note that by default this check is **deactivated** to avoid unexpected breakages in existing applications.

set `edc.iam.accesstoken.jti.validation=true` to enable it.

## Why it does that

protection against replay attacks

## Linked Issue(s)

Closes https://github.com/eclipse-edc/Connector/issues/3749

**DEPENDS ON https://github.com/eclipse-edc/Connector/pull/4560**

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
