### PR TITLE
fix: compile error after EDC module split

### DIFF
--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     implementation(project(":core:lib:accesstoken-lib"))
     implementation(project(":core:lib:credential-query-lib"))
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
+    implementation(libs.edc.spi.jwt.signer)
     implementation(libs.edc.core.connector) // for the CriterionToPredicateConverterImpl
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)
@@ -17,6 +18,7 @@ dependencies {
     implementation(libs.edc.lib.query)
     implementation(libs.edc.lib.jws2020)
     implementation(libs.edc.lib.common.crypto)
+    implementation(libs.edc.lib.token)
     implementation(libs.edc.spi.token)
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)

--- a/core/lib/accesstoken-lib/build.gradle.kts
+++ b/core/lib/accesstoken-lib/build.gradle.kts
@@ -9,8 +9,8 @@ dependencies {
     implementation(libs.edc.spi.jwt)
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.core.token)
     testImplementation(libs.nimbus.jwt)
     testImplementation(libs.edc.vc.jwt) // JtiValidationRule
+    testImplementation(libs.edc.lib.token) // TokenValidationServiceImpl
     testImplementation(testFixtures(project(":spi:verifiable-credential-spi")))
 }

--- a/core/lib/verifiable-presentation-lib/build.gradle.kts
+++ b/core/lib/verifiable-presentation-lib/build.gradle.kts
@@ -8,8 +8,9 @@ dependencies {
     api(project(":spi:keypair-spi"))
     implementation(libs.edc.spi.token)
     implementation(libs.edc.spi.vc)
+    implementation(libs.edc.spi.jwt)
     implementation(libs.edc.spi.jsonld)
-    implementation(libs.edc.core.token) // for Jwt generation service, token validation service and rule registry impl
+    implementation(libs.edc.lib.token) // for Jwt generation service, token validation service and rule registry impl
     implementation(libs.edc.lib.common.crypto) // for the CryptoConverter
     implementation(libs.edc.lib.jws2020)
     implementation(libs.edc.vc.ldp)

--- a/e2e-tests/runtimes/sts/build.gradle.kts
+++ b/e2e-tests/runtimes/sts/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     runtimeOnly(libs.edc.sts.api)
     runtimeOnly(libs.edc.sts.api.accounts)
     runtimeOnly(libs.edc.sts.core)
+    runtimeOnly(libs.edc.core.token)
 
     // optional modules
     runtimeOnly(libs.edc.api.version)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-config-fs = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-spi-jwt = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
+edc-spi-jwt-signer = { module = "org.eclipse.edc:jwt-signer-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-spi-policy-engine = { module = "org.eclipse.edc:policy-engine-spi", version.ref = "edc" }
 edc-spi-transaction = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
@@ -70,6 +71,7 @@ edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "e
 edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
 edc-lib-json = { module = "org.eclipse.edc:json-lib", version.ref = "edc" }
 edc-lib-common-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
+edc-lib-token = { module = "org.eclipse.edc:token-lib", version.ref = "edc" }
 edc-core-jerseyproviders = { module = "org.eclipse.edc:jersey-providers-lib", version.ref = "edc" }
 
 # SQL dependencies


### PR DESCRIPTION
## What this PR changes/adds

fixes compile errors after the split of `token-core` into `token-lib`

## Why it does that

compile errors :)

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
