### PR TITLE
fix(api): gracefully handle missing type in query credential by type

### DIFF
--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
@@ -160,6 +160,46 @@ public class VerifiableCredentialApiEndToEndTest {
                     });
         }
 
+        @Test
+        void queryByType(IdentityHubEndToEndTestContext context) {
+            var superUserKey = context.createSuperUser();
+            var user = "user1";
+            var token = context.createParticipant(user);
+
+            var credential = context.createCredential();
+            context.storeCredential(credential, user);
+
+            assertThat(Arrays.asList(token, superUserKey))
+                    .allSatisfy(t -> context.getIdentityApiEndpoint().baseRequest()
+                            .contentType(JSON)
+                            .header(new Header("x-api-key", t))
+                            .get("/v1alpha/participants/%s/credentials?type=%s".formatted(toBase64(user), credential.getType().get(0)))
+                            .then()
+                            .log().ifValidationFails()
+                            .statusCode(200)
+                            .body(notNullValue()));
+        }
+
+        @Test
+        void queryByTyp_noTypeSpecified(IdentityHubEndToEndTestContext context) {
+            var superUserKey = context.createSuperUser();
+            var user = "user1";
+            var token = context.createParticipant(user);
+
+            var credential = context.createCredential();
+            context.storeCredential(credential, user);
+
+            assertThat(Arrays.asList(token, superUserKey))
+                    .allSatisfy(t -> context.getIdentityApiEndpoint().baseRequest()
+                            .contentType(JSON)
+                            .header(new Header("x-api-key", t))
+                            .get("/v1alpha/participants/%s/credentials".formatted(toBase64(user)))
+                            .then()
+                            .log().ifValidationFails()
+                            .statusCode(200)
+                            .body(notNullValue()));
+        }
+
         private String toBase64(String s) {
             return Base64.getUrlEncoder().encodeToString(s.getBytes());
         }

--- a/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static java.lang.String.valueOf;

--- a/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -58,17 +58,23 @@ public class BomSmokeTests {
         @RegisterExtension
         protected RuntimeExtension runtime =
                 new RuntimePerMethodExtension(new EmbeddedRuntime("identityhub-bom",
-                        Map.of(
-                                "web.http.port", DEFAULT_PORT,
-                                "web.http.path", DEFAULT_PATH,
-                                "edc.ih.iam.id", "did:web:test",
-                                "edc.ih.iam.publickey.path", "/some/path/to/key.pem",
-                                "web.http.presentation.port", valueOf(getFreePort()),
-                                "web.http.presentation.path", "/api/resolution",
-                                "web.http.identity.port", valueOf(getFreePort()),
-                                "web.http.identity.path", "/api/identity",
-                                "edc.sts.account.api.url", "https://sts.com/accounts",
-                                "edc.sts.accounts.api.auth.header.value", "password"),
+                        new HashMap<>() {
+
+                            {
+                                put("web.http.port", DEFAULT_PORT);
+                                put("web.http.path", DEFAULT_PATH);
+                                put("edc.ih.iam.id", "did:web:test");
+                                put("edc.ih.iam.publickey.path", "/some/path/to/key.pem");
+                                put("web.http.presentation.port", valueOf(getFreePort()));
+                                put("web.http.presentation.path", "/api/resolution");
+                                put("web.http.identity.port", valueOf(getFreePort()));
+                                put("web.http.identity.path", "/api/identity");
+                                put("web.http.version.port", valueOf(getFreePort()));
+                                put("web.http.version.path", "/api/version");
+                                put("edc.sts.account.api.url", "https://sts.com/accounts");
+                                put("edc.sts.accounts.api.auth.header.value", "password");
+                            }
+                        },
                         ":dist:bom:identityhub-bom"
                 ));
     }
@@ -92,6 +98,8 @@ public class BomSmokeTests {
                                 put("web.http.identity.path", "/api/identity");
                                 put("web.http.accounts.port", valueOf(getFreePort()));
                                 put("web.http.accounts.path", "/api/accounts");
+                                put("web.http.version.port", valueOf(getFreePort()));
+                                put("web.http.version.path", "/api/version");
                                 put("edc.api.accounts.key", "password");
                             }
                         },

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApi.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApi.java
@@ -95,7 +95,8 @@ public interface VerifiableCredentialsApi {
     @Operation(description = "Query VerifiableCredentials by type.",
             operationId = "queryCredentialsByType",
             parameters = {
-                    @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH)
+                    @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH),
+                    @Parameter(name = "type", description = "Credential type. If omitted, all credentials are returned (limited to 50 elements).")
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "The list of VerifiableCredentials.",
@@ -114,7 +115,7 @@ public interface VerifiableCredentialsApi {
                     @Parameter(name = "participantId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH),
             },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "The VerifiableCredential was deleted successfully", content = {@Content(schema = @Schema(implementation = String.class))}),
+                    @ApiResponse(responseCode = "200", description = "The VerifiableCredential was deleted successfully", content = { @Content(schema = @Schema(implementation = String.class)) }),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "403", description = "The request could not be completed, because either the authentication was missing or was not valid.",

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
@@ -46,7 +46,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
-import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.identityhub.spi.AuthorizationResultHandler.exceptionMapper;
 import static org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextId.onEncoded;
 import static org.eclipse.edc.spi.result.ServiceResult.badRequest;
@@ -112,7 +111,7 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
     public Collection<VerifiableCredentialResource> queryCredentialsByType(@Nullable @QueryParam("type") String type, @Context SecurityContext securityContext) {
         var query = QuerySpec.Builder.newInstance();
 
-        if(!StringUtils.isNullOrEmpty(type)){
+        if (!StringUtils.isNullOrEmpty(type)) {
             query.filter(new Criterion("verifiableCredential.credential.types", "contains", type));
         }
 

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
@@ -37,13 +37,16 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.util.string.StringUtils;
 import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectNotFoundException;
 import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.identityhub.spi.AuthorizationResultHandler.exceptionMapper;
 import static org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextId.onEncoded;
 import static org.eclipse.edc.spi.result.ServiceResult.badRequest;
@@ -106,12 +109,14 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
 
     @GET
     @Override
-    public Collection<VerifiableCredentialResource> queryCredentialsByType(@QueryParam("type") String type, @Context SecurityContext securityContext) {
-        var query = QuerySpec.Builder.newInstance()
-                .filter(new Criterion("verifiableCredential.credential.types", "contains", type))
-                .build();
+    public Collection<VerifiableCredentialResource> queryCredentialsByType(@Nullable @QueryParam("type") String type, @Context SecurityContext securityContext) {
+        var query = QuerySpec.Builder.newInstance();
 
-        return credentialStore.query(query)
+        if(!StringUtils.isNullOrEmpty(type)){
+            query.filter(new Criterion("verifiableCredential.credential.types", "contains", type));
+        }
+
+        return credentialStore.query(query.build())
                 .orElseThrow(InvalidRequestException::new)
                 .stream()
                 .filter(vcr -> authorizationService.isAuthorized(securityContext, vcr.getId(), VerifiableCredentialResource.class).succeeded())

--- a/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
@@ -317,7 +317,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         }
 
         @Test
-        void typeNotSpecified_returnsAllCredentials(){
+        void typeNotSpecified_returnsAllCredentials() {
             var credential1 = createCredentialResource("test-type").build();
             var credential2 = createCredentialResource("test-type").build();
             when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(credential1, credential2)));

--- a/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
@@ -317,6 +317,24 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         }
 
         @Test
+        void typeNotSpecified_returnsAllCredentials(){
+            var credential1 = createCredentialResource("test-type").build();
+            var credential2 = createCredentialResource("test-type").build();
+            when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(credential1, credential2)));
+
+            var result = baseRequest()
+                    .get()
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .extract().body().as(VerifiableCredentialResource[].class);
+
+            assertThat(result).usingRecursiveFieldByFieldElementComparatorIgnoringFields("clock").containsExactlyInAnyOrder(credential1, credential2);
+            verify(credentialStore).query(any());
+            verifyNoMoreInteractions(credentialStore);
+        }
+
+        @Test
         void emptyResult() {
             when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of()));
 


### PR DESCRIPTION
## What this PR changes/adds

The "query-by-credential-type" endpoint now gracefully handles the case where the credential type is not specified.
In that case, all credentials are returned (within the constraints of the default QuerySpec).

## Why it does that

providing an incomplete criterion caused a Nullpointer Exception

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
