### PR TITLE
refactor: introduce record to represent create participant response

### DIFF
--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -89,7 +89,9 @@ public class IdentityHubEndToEndTestContext {
                         .build())
                 .build();
         var srv = runtime.getService(ParticipantContextService.class);
-        return srv.createParticipantContext(manifest).orElseThrow(f -> new EdcException(f.getFailureDetail())).get("apiKey").toString();
+        return srv.createParticipantContext(manifest)
+                .orElseThrow(f -> new EdcException(f.getFailureDetail()))
+                .apiKey();
     }
 
 

--- a/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/PostgresSqlService.java
+++ b/e2e-tests/api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/PostgresSqlService.java
@@ -73,7 +73,7 @@ public class PostgresSqlService {
     }
 
     private void createDatabase() {
-        var postgres = new PostgresqlLocalInstance(PostgresqlEndToEndInstance.USER, PostgresqlEndToEndInstance.PASSWORD, baseJdbcUrl(hostPort), dbName);
-        postgres.createDatabase();
+        var postgres = new PostgresqlLocalInstance(PostgresqlEndToEndInstance.USER, PostgresqlEndToEndInstance.PASSWORD, baseJdbcUrl(hostPort));
+        postgres.createDatabase(dbName);
     }
 }

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2024-10-02T12:00:00Z",
+    "lastUpdated": "2024-12-05T14:13:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApi.java
+++ b/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApi.java
@@ -25,13 +25,13 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.core.SecurityContext;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.CreateParticipantContextResponse;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 @OpenAPIDefinition(info = @Info(description = "This is the Identity API for manipulating ParticipantContexts", title = "ParticipantContext Management API", version = "1"))
 @Tag(name = "Participant Context")
@@ -42,7 +42,8 @@ public interface ParticipantContextApi {
             operationId = "createParticipant",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = ParticipantManifest.class), mediaType = "application/json")),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "The ParticipantContext was created successfully, its API token is returned in the response body."),
+                    @ApiResponse(responseCode = "200", description = "The ParticipantContext was created successfully, its API token is returned in the response body.",
+                            content = @Content(schema = @Schema(implementation = CreateParticipantContextResponse.class))),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
@@ -51,7 +52,7 @@ public interface ParticipantContextApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    Map<String, Object> createParticipant(ParticipantManifest manifest);
+    CreateParticipantContextResponse createParticipant(ParticipantManifest manifest);
 
 
     @Operation(description = "Gets ParticipantContexts by ID.",

--- a/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApiController.java
+++ b/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/participantcontext/v1/unstable/ParticipantContextApiController.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.identityhub.api.v1.validation.ParticipantManifestValidato
 import org.eclipse.edc.identityhub.spi.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.authentication.ServicePrincipal;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.CreateParticipantContextResponse;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -40,7 +41,6 @@ import org.eclipse.edc.web.spi.exception.ValidationFailureException;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.identityhub.spi.AuthorizationResultHandler.exceptionMapper;
@@ -64,7 +64,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Override
     @POST
     @RolesAllowed(ServicePrincipal.ROLE_ADMIN)
-    public Map<String, Object> createParticipant(ParticipantManifest manifest) {
+    public CreateParticipantContextResponse createParticipant(ParticipantManifest manifest) {
         participantManifestValidator.validate(manifest).orElseThrow(ValidationFailureException::new);
         return participantContextService.createParticipantContext(manifest)
                 .orElseThrow(exceptionMapper(ParticipantManifest.class, manifest.getParticipantId()));

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/ParticipantContextService.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/ParticipantContextService.java
@@ -14,13 +14,13 @@
 
 package org.eclipse.edc.identityhub.spi.participantcontext;
 
+import org.eclipse.edc.identityhub.spi.participantcontext.model.CreateParticipantContextResponse;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -28,14 +28,13 @@ import java.util.function.Consumer;
  */
 public interface ParticipantContextService {
 
-
     /**
      * Creates a new participant context from a manifest. If one with the same ID exists, a failure is returned.
      *
      * @param manifest The new participant context
      * @return success if created, or a failure if already exists.
      */
-    ServiceResult<Map<String, Object>> createParticipantContext(ParticipantManifest manifest);
+    ServiceResult<CreateParticipantContextResponse> createParticipantContext(ParticipantManifest manifest);
 
     /**
      * Fetches the {@link ParticipantContext} by ID.

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/CreateParticipantContextResponse.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/CreateParticipantContextResponse.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2024 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.participantcontext.model;
+
+/**
+ * Response representation for the {@link ParticipantContext} creation
+ */
+public record CreateParticipantContextResponse(String apiKey, String clientId, String clientSecret) {
+}


### PR DESCRIPTION
## What this PR changes/adds

Introduce a `CreateParticipantContextResponse` record that replaces the generic `Map` used.
Add it to the openapi documentation (as currently it shows an empty body)

## Why it does that

Enhance domain model, fix documentation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #497

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
