### PR TITLE
fix: remove any reference to the Admin/Super user

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ java -Dweb.http.presentation.port=10001 \
      -Dweb.http.path="/api" \
      -Dweb.http.identity.port=8182 \
      -Dweb.http.identity.path="/api/identity" \
-     -Dedc.ih.api.superuser.key="c3VwZXItdXNlcgo=c3VwZXItc2VjcmV0Cg==" \
      -jar launcher/identityhub/build/libs/identity-hub.jar
 ```
 
@@ -90,7 +89,6 @@ docker run --rm --name identity-hub \
             -e "WEB_HTTP_PORT=8181" \
             -e "WEB_HTTP_IDENTITY_PORT=8182" \
             -e "WEB_HTTP_IDENTITY_PATH=/api/identity" \
-            -e "EDC_IH_API_SUPERUSER_KEY=c3VwZXItdXNlcgo=c3VwZXItc2VjcmV0Cg==" \
             identity-hub:latest
 ```
 


### PR DESCRIPTION
## What this PR changes/adds

removes any references to the admin user 

## Why it does that

while the role definition of a super user exists, no such user is generated by identity hub. This is the job of downstream distributions.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #512

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
