### PR TITLE
chore: fix object mapper after upstream changes

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -161,7 +161,7 @@ public class CoreServicesExtension implements ServiceExtension {
 
             var monitor = context.getMonitor();
             var ldpIssuer = LdpIssuer.Builder.newInstance().jsonLd(jsonLd).monitor(monitor).build();
-            presentationCreatorRegistry.addCreator(new LdpPresentationGenerator(privateKeyResolver, signatureSuiteRegistry, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer, typeManager.getMapper(JSON_LD)),
+            presentationCreatorRegistry.addCreator(new LdpPresentationGenerator(privateKeyResolver, signatureSuiteRegistry, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer, typeManager, JSON_LD),
                     CredentialFormat.VC1_0_LD);
 
             presentationCreatorRegistry.addCreator(new JwtEnvelopedPresentationGenerator(monitor, jwtGenerationService), CredentialFormat.VC2_0_JOSE);

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGeneratorTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGeneratorTest.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.junit.testfixtures.TestUtils;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.security.signature.jws2020.Jws2020SignatureSuite;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.verifiablecredentials.jwt.JwtCreationUtils;
 import org.eclipse.edc.verifiablecredentials.jwt.TestConstants;
 import org.eclipse.edc.verifiablecredentials.linkeddata.LdpIssuer;
@@ -58,7 +59,7 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
     );
 
     private final PrivateKeyResolver privateKeyResolver = mock();
-
+    private final TypeManager typeManager = mock();
     private LdpPresentationGenerator creator;
 
     @BeforeEach
@@ -79,7 +80,9 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
                 .monitor(mock())
                 .build();
         creator = new LdpPresentationGenerator(privateKeyResolver, signatureSuiteRegistryMock, IdentityHubConstants.JWS_2020_SIGNATURE_SUITE, ldpIssuer,
-                JacksonJsonLd.createObjectMapper());
+                typeManager, "test");
+
+        when(typeManager.getMapper("test")).thenReturn(JacksonJsonLd.createObjectMapper());
     }
 
     @Override

--- a/extensions/protocols/dcp/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/extensions/protocols/dcp/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -99,19 +99,17 @@ public class PresentationApiExtension implements ServiceExtension {
         portMappingRegistry.register(new PortMapping(contextString, apiConfiguration.port(), apiConfiguration.path()));
         validatorRegistry.register(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TYPE_PROPERTY, new PresentationQueryValidator());
 
-        var jsonLdMapper = typeManager.getMapper(JSON_LD);
-
 
         var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, selfIssuedTokenVerifier, verifiablePresentationService, context.getMonitor(), participantContextService);
-        webService.registerResource(contextString, new ObjectMapperProvider(jsonLdMapper));
-        webService.registerResource(contextString, new JerseyJsonLdInterceptor(jsonLd, jsonLdMapper, PRESENTATION_SCOPE));
+        webService.registerResource(contextString, new ObjectMapperProvider(typeManager, JSON_LD));
+        webService.registerResource(contextString, new JerseyJsonLdInterceptor(jsonLd, typeManager, JSON_LD, PRESENTATION_SCOPE));
         webService.registerResource(contextString, controller);
 
         jsonLd.registerContext(DCP_CONTEXT_URL, PRESENTATION_SCOPE);
 
         // register transformer -- remove once registration is handled in EDC
-        typeTransformer.register(new JsonObjectToPresentationQueryTransformer(jsonLdMapper));
-        typeTransformer.register(new JsonValueToGenericTypeTransformer(jsonLdMapper));
+        typeTransformer.register(new JsonObjectToPresentationQueryTransformer(typeManager, JSON_LD));
+        typeTransformer.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
         typeTransformer.register(new JsonObjectFromPresentationResponseMessageTransformer());
 
         registerVersionInfo(getClass().getClassLoader());


### PR DESCRIPTION
## What this PR changes/adds

fix object mapper after upstream changes

## Why it does that

compile errrors



_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
