### PR TITLE
feat: adds support for dcp v1.0

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -63,6 +63,7 @@ import java.net.URISyntaxException;
 import java.time.Clock;
 
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DCP_CONTEXT_URL;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
 import static org.eclipse.edc.identityhub.core.CoreServicesExtension.NAME;
 import static org.eclipse.edc.identityhub.spi.model.IdentityHubConstants.DID_CONTEXT_URL;
 import static org.eclipse.edc.identityhub.spi.model.IdentityHubConstants.JWS_2020_URL;
@@ -81,6 +82,7 @@ public class CoreServicesExtension implements ServiceExtension {
 
     public static final String PRESENTATION_EXCHANGE_V_1_JSON = "presentation-exchange.v1.json";
     public static final String PRESENTATION_QUERY_V_08_JSON = "dcp.v08.json";
+    public static final String DSPACE_DCP_V_1_0_JSON_LD = "dcp.v1.0.jsonld";
     public static final String PRESENTATION_SUBMISSION_V1_JSON = "presentation-submission.v1.json";
     public static final String DID_JSON = "did.json";
     public static final String JWS_2020_JSON = "jws2020.json";
@@ -185,6 +187,7 @@ public class CoreServicesExtension implements ServiceExtension {
         try {
             jsonLd.registerCachedDocument(PRESENTATION_EXCHANGE_URL, classLoader.getResource(PRESENTATION_EXCHANGE_V_1_JSON).toURI());
             jsonLd.registerCachedDocument(DCP_CONTEXT_URL, classLoader.getResource(PRESENTATION_QUERY_V_08_JSON).toURI());
+            jsonLd.registerCachedDocument(DSPACE_DCP_V_1_0_CONTEXT, classLoader.getResource(DSPACE_DCP_V_1_0_JSON_LD).toURI());
             jsonLd.registerCachedDocument(DID_CONTEXT_URL, classLoader.getResource(DID_JSON).toURI());
             jsonLd.registerCachedDocument(JWS_2020_URL, classLoader.getResource(JWS_2020_JSON).toURI());
             jsonLd.registerCachedDocument(W3C_CREDENTIALS_URL, classLoader.getResource(CREDENTIALS_V_1_JSON).toURI());

--- a/core/identity-hub-core/src/main/resources/dcp.v1.0.jsonld
+++ b/core/identity-hub-core/src/main/resources/dcp.v1.0.jsonld
@@ -1,0 +1,137 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "dcp": "https://w3id.org/dspace-dcp/v1.0/",
+    "cred": "https://www.w3.org/2018/credentials/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "id": "@id",
+    "type": "@type",
+    "CredentialContainer": {
+      "@id": "dcp:CredentialContainer",
+      "@context": {
+        "payload": {
+          "@id": "dcp:payload",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "CredentialMessage": {
+      "@id": "dcp:CredentialMessage",
+      "@context": {
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@container": "@set"
+        },
+        "requestId": {
+          "@id": "dcp:requestId",
+          "@type": "@id"
+        }
+      }
+    },
+    "CredentialObject": {
+      "@id": "dcp:CredentialObject",
+      "@context": {
+        "credentialType": {
+          "@id": "dcp:credentialType",
+          "@container": "@set"
+        },
+        "offerReason": {
+          "@id": "dcp:offerReason",
+          "@type": "xsd:string"
+        },
+        "bindingMethods": {
+          "@id": "dcp:bindingMethods",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "profiles": {
+          "@id": "dcp:profiles",
+          "@type": "xsd:string",
+          "@container": "@set"
+        },
+        "issuancePolicy": {
+          "@id": "dcp:issuancePolicy",
+          "@type": "@json"
+        }
+      }
+    },
+    "CredentialOfferMessage": {
+      "@id": "dcp:CredentialOfferMessage",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentials": {
+          "@id": "dcp:credentials",
+          "@container": "@set"
+        }
+      }
+    },
+    "CredentialRequestMessage": {
+      "@id": "dcp:CredentialRequestMessage",
+      "@context": {
+        "format": "dcp:format",
+        "credentialType": {
+          "@id": "dcp:credentialType",
+          "@type": "@vocab",
+          "@container": "@set"
+        }
+      }
+    },
+    "CredentialService": "dcp:CredentialService",
+    "CredentialStatus": {
+      "@id": "dcp:CredentialStatus",
+      "@context": {
+        "requestId": {
+          "@id": "dcp:requestId",
+          "@type": "@id"
+        },
+        "status": {
+          "@id": "dcp:status",
+          "@type": "@vocab"
+        },
+        "RECEIVED": "dcp:RECEIVED",
+        "REJECTED": "dcp:REJECTED",
+        "ISSUED": "dcp:ISSUED"
+      }
+    },
+    "IssuerMetadata": {
+      "@id": "dcp:IssuerMetadata",
+      "@context": {
+        "credentialIssuer": "cred:issuer",
+        "credentialsSupported": {
+          "@id": "dcp:credentialsSupported",
+          "@container": "@set"
+        }
+      }
+    },
+    "IssuerService": "dcp:IssuerService",
+    "PresentationQueryMessage": {
+      "@id": "dcp:PresentationQueryMessage",
+      "@context": {
+        "presentationDefinition": {
+          "@id": "dcp:presentationDefinition",
+          "@type": "@json"
+        },
+        "scope": {
+          "@id": "dcp:scope",
+          "@type": "xsd:string",
+          "@container": "@set"
+        }
+      }
+    },
+    "PresentationResponseMessage": {
+      "@id": "dcp:PresentationResponseMessage",
+      "@context": {
+        "presentation": {
+          "@id": "dcp:presentation",
+          "@container": "@set",
+          "@type": "@json"
+        },
+        "presentationSubmission": {
+          "@id": "dcp:presentationSubmission",
+          "@type": "@json"
+        }
+      }
+    }
+  }
+}

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-01-17T12:00:00Z",
+    "lastUpdated": "2025-01-31T12:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/protocols/dcp/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/DcpApiConstants.java
+++ b/extensions/protocols/dcp/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/DcpApiConstants.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api;
+
+public interface DcpApiConstants {
+
+    String V_1_0 = "v1.0";
+    @Deprecated(since = "0.12.0")
+    String V_0_8 = "v0.8";
+    String DCP_SCOPE_SEPARATOR = ":";
+    String DCP_SCOPE_PREFIX = "dcp-api";
+    @Deprecated(since = "0.12.0")
+    String DCP_SCOPE_V_0_8 = DCP_SCOPE_PREFIX + DCP_SCOPE_SEPARATOR + V_0_8;
+    String DCP_SCOPE_V_1_0 = DCP_SCOPE_PREFIX + DCP_SCOPE_SEPARATOR + V_1_0;
+}

--- a/extensions/protocols/dcp/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/validation/PresentationQueryValidator.java
+++ b/extensions/protocols/dcp/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/validation/PresentationQueryValidator.java
@@ -19,9 +19,12 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_SCOPE_TERM;
 import static org.eclipse.edc.validator.spi.ValidationResult.failure;
 import static org.eclipse.edc.validator.spi.ValidationResult.success;
 import static org.eclipse.edc.validator.spi.Violation.violation;
@@ -31,14 +34,21 @@ import static org.eclipse.edc.validator.spi.Violation.violation;
  * <em>or</em> a {@code presentationDefinition} query.
  */
 public class PresentationQueryValidator implements Validator<JsonObject> {
+
+    private final JsonLdNamespace namespace;
+
+    public PresentationQueryValidator(JsonLdNamespace namespace) {
+        this.namespace = namespace;
+    }
+
     @Override
     public ValidationResult validate(JsonObject input) {
         if (input == null) {
             return failure(violation("Presentation query was null", "."));
         }
-        var scope = input.get(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_SCOPE_PROPERTY);
+        var scope = input.get(namespace.toIri(PRESENTATION_QUERY_MESSAGE_SCOPE_TERM));
 
-        var presentationDef = input.get(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_DEFINITION_PROPERTY);
+        var presentationDef = input.get(namespace.toIri(PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM));
 
         if (isNullObject(scope) && isNullObject(presentationDef)) {
             return failure(violation("Must contain either a 'scope' or a 'presentationDefinition' property.", null));

--- a/extensions/protocols/dcp/presentation-api/src/test/java/org/eclipse/edc/identityservice/api/validation/PresentationQueryValidatorTest.java
+++ b/extensions/protocols/dcp/presentation-api/src/test/java/org/eclipse/edc/identityservice/api/validation/PresentationQueryValidatorTest.java
@@ -36,12 +36,13 @@ import java.util.UUID;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_0_8;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 class PresentationQueryValidatorTest {
     public static final ObjectMapper MAPPER = JacksonJsonLd.createObjectMapper();
-    private final PresentationQueryValidator validator = new PresentationQueryValidator();
+    private final PresentationQueryValidator validator = new PresentationQueryValidator(DSPACE_DCP_NAMESPACE_V_0_8);
     private final JsonLd jsonLd = new TitaniumJsonLd(mock());
 
 


### PR DESCRIPTION
## What this PR changes/adds

adds support for dcp v1.0


The `JerseyJsonLdInterceptor` that automatically expand and compact JSON-LD has been removed. In the `PresentationController` since we need to guarantee backward compatibility we first manually expand JSON-LD which is an operation not tied to a specific protocol, then we detect the used namespace from the `@type` field of the expanded JSON-LD and we use the protocol specific transformer registry and JSON-LD scope for handling the request.   

## Why it does that

dcp v1.0 support

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #531 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
