### PR TITLE
chore: re-use existing DataModelVersion

### DIFF
--- a/docs/developer/architecture/issuer/issuance/issuance.process.md
+++ b/docs/developer/architecture/issuer/issuance/issuance.process.md
@@ -144,18 +144,16 @@ This is deserialized to:
 
 ```java
 public class CredentialDefinition {
-    public enum DataModelType {VCDM_1_1, VCDM_2_0}
-
     private String credentialType;
     private String schema;
     private String format;
     private long validity;
 
-    private DataModelType dataModel = DataModelType.VCDM_1_1;
+    private DataModelVersion dataModel = DataModelVersion.V_1_1;
 
     private List<String> attestations = new ArrayList<>();
     private List<CredentialRuleDefinition> rules = new ArrayList<>();
-    private List<MappingDefinition> mappings = new ArrayList<>();
+    private final List<MappingDefinition> mappings = new ArrayList<>();
 }
 ```
 
@@ -343,7 +341,7 @@ public class IssuanceProcess {
         SUBMITTED, APPROVED, DELIVERED, ERRORED
     }
 
-    private State state = State.SUBMITTED;
+    private final State state = State.SUBMITTED;
     private long stateTimestamp;
     private int retries;
     private int errorCode;

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-01-31T12:00:00Z",
+    "lastUpdated": "2025-02-06T12:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-02-03T10:00:00Z",
+    "lastUpdated": "2025-02-06T10:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/issuance/issuance-credentials/src/test/java/org/eclipse/edc/identityhub/issuance/credentials/attestation/AttestationPipelineImplTest.java
+++ b/extensions/issuance/issuance-credentials/src/test/java/org/eclipse/edc/identityhub/issuance/credentials/attestation/AttestationPipelineImplTest.java
@@ -21,6 +21,8 @@ import org.eclipse.edc.identityhub.spi.issuance.credentials.attestation.Attestat
 import org.eclipse.edc.identityhub.spi.issuance.credentials.model.AttestationDefinition;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -85,7 +87,7 @@ class AttestationPipelineImplTest {
 
         pipeline.registerFactory("testType1", sourceFactory);
 
-        var results = pipeline.evaluate(Set.of("a123", "a456"), new DefaultAttestationContext("123", emptyMap()));
+        var results = pipeline.evaluate(new LinkedHashSet<>(List.of("a123", "a456")), new DefaultAttestationContext("123", emptyMap()));
         assertThat(results.failed()).isTrue();
 
         verify(store).resolveDefinition("a123");

--- a/spi/issuance-credentials-spi/build.gradle.kts
+++ b/spi/issuance-credentials-spi/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 dependencies {
     api(libs.edc.spi.core)
     api(libs.edc.spi.validator)
+    api(libs.edc.spi.vc)
 
     testImplementation(libs.edc.lib.json)
 

--- a/spi/issuance-credentials-spi/src/main/java/org/eclipse/edc/identityhub/spi/issuance/credentials/model/CredentialDefinition.java
+++ b/spi/issuance-credentials-spi/src/main/java/org/eclipse/edc/identityhub/spi/issuance/credentials/model/CredentialDefinition.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.spi.issuance.credentials.model;
 
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.DataModelVersion;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -24,23 +26,23 @@ import static java.util.Objects.requireNonNull;
  * Defines credential type that can be issued, its schema, and requirements for issuance.
  */
 public class CredentialDefinition {
-    public enum DataModelType { VCDM_1_1, VCDM_2_0 }
 
+    private final List<String> attestations = new ArrayList<>();
+    private final List<CredentialRuleDefinition> rules = new ArrayList<>();
+    private final List<MappingDefinition> mappings = new ArrayList<>();
     private String credentialType;
     private String schema;
     private long validity;
+    private DataModelVersion dataModel = DataModelVersion.V_1_1;
 
-    private DataModelType dataModel = DataModelType.VCDM_1_1;
-
-    private List<String> attestations = new ArrayList<>();
-    private List<CredentialRuleDefinition> rules = new ArrayList<>();
-    private List<MappingDefinition> mappings = new ArrayList<>();
+    private CredentialDefinition() {
+    }
 
     public String getCredentialType() {
         return credentialType;
     }
 
-    public DataModelType getDataModel() {
+    public DataModelVersion getDataModel() {
         return dataModel;
     }
 
@@ -64,11 +66,12 @@ public class CredentialDefinition {
         return mappings;
     }
 
-    private CredentialDefinition() {
-    }
-
     public static final class Builder {
-        private CredentialDefinition definition;
+        private final CredentialDefinition definition;
+
+        private Builder() {
+            definition = new CredentialDefinition();
+        }
 
         public static Builder newInstance() {
             return new Builder();
@@ -89,7 +92,7 @@ public class CredentialDefinition {
             return this;
         }
 
-        public Builder dataModel(DataModelType dataModel) {
+        public Builder dataModel(DataModelVersion dataModel) {
             this.definition.dataModel = dataModel;
             return this;
         }
@@ -128,10 +131,6 @@ public class CredentialDefinition {
             requireNonNull(definition.credentialType, "credentialType");
             requireNonNull(definition.schema, "schema");
             return definition;
-        }
-
-        private Builder() {
-            definition = new CredentialDefinition();
         }
 
     }


### PR DESCRIPTION
## What this PR changes/adds

this PR makes use of the existing `DataModelVersion` instead of declaring a new `DataModelType`

## Why it does that

avoid duplication

## Further notes

had to fix a test, otherwise the CI would fail sometimes.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
