### PR TITLE
chore: cleanup dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@
 
 plugins {
     `java-library`
-    id("com.autonomousapps.dependency-analysis") version ("2.8.1")
 }
 
 val edcScmConnection: String by project
@@ -29,7 +28,6 @@ buildscript {
 
 allprojects {
     apply(plugin = "${group}.edc-build")
-    apply(plugin = "com.autonomousapps.dependency-analysis")
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
         pom {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@
 
 plugins {
     `java-library`
-
+    id("com.autonomousapps.dependency-analysis") version ("2.8.1")
 }
 
 val edcScmConnection: String by project
@@ -29,6 +29,7 @@ buildscript {
 
 allprojects {
     apply(plugin = "${group}.edc-build")
+    apply(plugin = "com.autonomousapps.dependency-analysis")
 
     configure<org.eclipse.edc.plugins.edcbuild.extensions.BuildExtension> {
         pom {

--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
     implementation(libs.edc.spi.transaction)
     implementation(libs.edc.spi.jwt.signer)
-//    implementation(libs.edc.core.connector) // for the CriterionToPredicateConverterImpl
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)
     implementation(libs.edc.lib.store)
@@ -26,8 +25,6 @@ dependencies {
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)
     implementation(libs.edc.vc.jwt) // JtiValidationRule
-//    implementation(libs.edc.core.token)
-    implementation(libs.edc.verifiablecredentials) // revocation list service
 
 
     testImplementation(libs.edc.junit)

--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
     implementation(libs.edc.spi.transaction)
     implementation(libs.edc.spi.jwt.signer)
+    implementation(libs.edc.verifiablecredentials)
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)
     implementation(libs.edc.lib.store)

--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -11,8 +11,9 @@ dependencies {
     implementation(project(":core:lib:accesstoken-lib"))
     implementation(project(":core:lib:common-lib"))
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
+    implementation(libs.edc.spi.transaction)
     implementation(libs.edc.spi.jwt.signer)
-    implementation(libs.edc.core.connector) // for the CriterionToPredicateConverterImpl
+//    implementation(libs.edc.core.connector) // for the CriterionToPredicateConverterImpl
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)
     implementation(libs.edc.lib.store)
@@ -25,7 +26,7 @@ dependencies {
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)
     implementation(libs.edc.vc.jwt) // JtiValidationRule
-    implementation(libs.edc.core.token)
+//    implementation(libs.edc.core.token)
     implementation(libs.edc.verifiablecredentials) // revocation list service
 
 

--- a/core/identity-hub-did/build.gradle.kts
+++ b/core/identity-hub-did/build.gradle.kts
@@ -3,19 +3,17 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:identity-hub-spi"))
     api(project(":spi:did-spi"))
+    api(project(":spi:participant-context-spi"))
 
     implementation(project(":spi:keypair-spi"))
-    implementation(project(":spi:participant-context-spi"))
-    implementation(libs.edc.core.connector) // for the reflection-based query resolver
+    implementation(libs.edc.spi.transaction)
     implementation(libs.edc.lib.common.crypto)
     implementation(libs.edc.lib.store)
-    implementation(libs.edc.lib.query)
 
+    testImplementation(libs.edc.lib.query)
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.jsonld)
     testImplementation(libs.edc.lib.keys)
-    testImplementation(testFixtures(project(":spi:identity-hub-spi")))
     testImplementation(testFixtures(project(":spi:did-spi")))
+    testRuntimeOnly(libs.edc.jsonld)
 }

--- a/core/identity-hub-keypairs/build.gradle.kts
+++ b/core/identity-hub-keypairs/build.gradle.kts
@@ -17,11 +17,10 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:identity-hub-spi"))
     api(project(":spi:keypair-spi"))
     api(libs.edc.spi.transaction)
     implementation(project(":core:lib:keypair-lib"))
     implementation(libs.edc.lib.common.crypto)
-    implementation(libs.edc.core.connector)
+    runtimeOnly(libs.edc.core.connector)
     testImplementation(libs.edc.junit)
 }

--- a/core/identity-hub-participants/build.gradle.kts
+++ b/core/identity-hub-participants/build.gradle.kts
@@ -3,15 +3,12 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:identity-hub-spi"))
     api(project(":spi:did-spi"))
     api(project(":spi:participant-context-spi"))
-    api(project(":spi:keypair-spi"))
+    implementation(project(":spi:keypair-spi"))
     api(libs.edc.spi.transaction)
-    implementation(project(":core:lib:keypair-lib"))
-    implementation(libs.edc.lib.common.crypto)
-    implementation(libs.edc.core.connector)
-
+    runtimeOnly(libs.bouncyCastle.bcprovJdk18on)
+    
     testImplementation(libs.edc.lib.keys)
     testImplementation(libs.edc.junit)
 }

--- a/core/issuerservice/issuerservice-core/build.gradle.kts
+++ b/core/issuerservice/issuerservice-core/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 dependencies {
     api(project(":spi:issuerservice:issuerservice-participant-spi"))
     api(project(":spi:issuerservice:issuerservice-credential-definition-spi"))
+    api(project(":core:lib:common-lib"))
 
-    implementation(project(":core:lib:common-lib"))
     implementation(libs.edc.lib.store)
     testImplementation(libs.edc.junit)
     testImplementation(testFixtures(project(":spi:issuerservice:issuerservice-participant-spi")))

--- a/core/issuerservice/issuerservice-credentials/build.gradle.kts
+++ b/core/issuerservice/issuerservice-credentials/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
 
 
     implementation(libs.edc.spi.transaction)
-    implementation(libs.edc.lib.store)
     testImplementation(libs.edc.junit)
 
 }

--- a/core/issuerservice/issuerservice-participants/build.gradle.kts
+++ b/core/issuerservice/issuerservice-participants/build.gradle.kts
@@ -9,5 +9,4 @@ dependencies {
     implementation(libs.edc.lib.store)
     testImplementation(libs.edc.junit)
     testImplementation(testFixtures(project(":spi:issuerservice:issuerservice-participant-spi")))
-
 }

--- a/core/lib/accesstoken-lib/build.gradle.kts
+++ b/core/lib/accesstoken-lib/build.gradle.kts
@@ -3,13 +3,11 @@ plugins {
 }
 
 dependencies {
-    api(project(":spi:identity-hub-spi"))
     api(project(":core:lib:keypair-lib")) // for the KeyPairResourcePublicKeyResolver
-    implementation(libs.edc.spi.token)
+    api(libs.edc.spi.token)
     implementation(libs.edc.spi.jwt)
 
     testImplementation(libs.edc.junit)
     testImplementation(libs.nimbus.jwt)
     testImplementation(libs.edc.vc.jwt) // JtiValidationRule
-    testImplementation(libs.edc.lib.token) // TokenValidationServiceImpl
 }

--- a/core/lib/keypair-lib/build.gradle.kts
+++ b/core/lib/keypair-lib/build.gradle.kts
@@ -3,10 +3,11 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.lib.keys)
-    implementation(project(":spi:keypair-spi"))
+    api(project(":spi:keypair-spi"))
+    api(libs.edc.spi.keys)
     implementation(libs.edc.spi.core)
     implementation(libs.edc.lib.util)
+    testImplementation(libs.edc.lib.keys)
     testImplementation(libs.edc.junit)
     testImplementation(libs.nimbus.jwt)
 }

--- a/extensions/api/identity-api/participant-context-api/build.gradle.kts
+++ b/extensions/api/identity-api/participant-context-api/build.gradle.kts
@@ -21,13 +21,11 @@ plugins {
 dependencies {
     api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
-    api(project(":spi:did-spi"))
     implementation(project(":extensions:api:identity-api:api-configuration"))
     implementation(project(":extensions:api:identity-api:validators:participant-context-validators"))
     implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
     implementation(libs.edc.lib.util)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
     implementation(libs.jakarta.annotation)
 
@@ -35,7 +33,6 @@ dependencies {
     testImplementation(libs.edc.junit)
     testImplementation(libs.edc.jsonld)
     testImplementation(testFixtures(libs.edc.core.jersey))
-    testImplementation(testFixtures(project(":spi:identity-hub-spi")))
     testImplementation(libs.nimbus.jwt)
     testImplementation(libs.restAssured)
     testImplementation(libs.tink)

--- a/extensions/api/identity-api/validators/keypair-validators/build.gradle.kts
+++ b/extensions/api/identity-api/validators/keypair-validators/build.gradle.kts
@@ -4,10 +4,8 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.spi.core)
-    api(project(":spi:identity-hub-spi"))
     api(project(":spi:did-spi"))
-    api(project(":spi:verifiable-credential-spi"))
+    api(libs.edc.spi.validator)
     implementation(libs.edc.lib.util)
 
     testImplementation(libs.edc.junit)

--- a/extensions/api/identity-api/validators/participant-context-validators/build.gradle.kts
+++ b/extensions/api/identity-api/validators/participant-context-validators/build.gradle.kts
@@ -4,10 +4,6 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.spi.core)
-    api(project(":spi:identity-hub-spi"))
-    api(project(":spi:did-spi"))
-    api(project(":spi:verifiable-credential-spi"))
     implementation(project(":extensions:api:identity-api:validators:keypair-validators"))
     implementation(libs.edc.lib.util)
 

--- a/extensions/api/identity-api/validators/verifiable-credential-validators/build.gradle.kts
+++ b/extensions/api/identity-api/validators/verifiable-credential-validators/build.gradle.kts
@@ -4,9 +4,7 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.spi.core)
-    api(project(":spi:identity-hub-spi"))
-    api(project(":spi:did-spi"))
+    api(libs.edc.spi.validator)
     api(project(":spi:verifiable-credential-spi"))
     implementation(libs.edc.lib.util)
 

--- a/extensions/api/identity-api/verifiable-credentials-api/build.gradle.kts
+++ b/extensions/api/identity-api/verifiable-credentials-api/build.gradle.kts
@@ -5,14 +5,11 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.spi.core)
-    api(project(":spi:identity-hub-spi"))
     api(project(":spi:verifiable-credential-spi"))
     implementation(project(":extensions:api:identity-api:api-configuration"))
     implementation(project(":extensions:api:identity-api:validators:verifiable-credential-validators"))
-    implementation(libs.edc.spi.transform)
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.util)
+    implementation(libs.edc.lib.util) // StringUtils
     implementation(libs.jakarta.rsApi)
     implementation(libs.jakarta.annotation)
 

--- a/extensions/api/identityhub-api-authentication/build.gradle.kts
+++ b/extensions/api/identityhub-api-authentication/build.gradle.kts
@@ -20,10 +20,8 @@ plugins {
 dependencies {
     api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
-    api(project(":spi:did-spi"))
 
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
     implementation(libs.jakarta.annotation)
 

--- a/extensions/api/identityhub-api-authorization/build.gradle.kts
+++ b/extensions/api/identityhub-api-authorization/build.gradle.kts
@@ -20,11 +20,7 @@ plugins {
 dependencies {
     api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
-    api(project(":spi:did-spi"))
 
-    implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.jerseyproviders)
-    implementation(libs.jakarta.rsApi)
 
     testImplementation(libs.edc.junit)
     testRuntimeOnly(libs.jersey.common) // needs the RuntimeDelegate

--- a/extensions/api/issuer-admin-api/attestation-api/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/attestation-api/build.gradle.kts
@@ -21,21 +21,15 @@ plugins {
 dependencies {
     api(libs.edc.spi.core)
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-configuration"))
-    implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.util)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
-    implementation(libs.jakarta.annotation)
 
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.jsonld)
     testImplementation(testFixtures(libs.edc.core.jersey))
     testImplementation(testFixtures(project(":spi:identity-hub-spi")))
     testImplementation(libs.nimbus.jwt)
     testImplementation(libs.restAssured)
-    testImplementation(libs.tink)
 }
 
 edcBuild {

--- a/extensions/api/issuer-admin-api/credential-definition-api/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/credential-definition-api/build.gradle.kts
@@ -21,20 +21,14 @@ plugins {
 dependencies {
     api(project(":spi:issuerservice:issuerservice-credential-definition-spi"))
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-configuration"))
-    implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.util)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
     implementation(libs.jakarta.annotation)
 
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.jsonld)
     testImplementation(testFixtures(libs.edc.core.jersey))
-    testImplementation(libs.nimbus.jwt)
     testImplementation(libs.restAssured)
-    testImplementation(libs.tink)
 }
 
 edcBuild {

--- a/extensions/api/issuer-admin-api/credentials-api/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/credentials-api/build.gradle.kts
@@ -22,21 +22,13 @@ dependencies {
     api(libs.edc.spi.core)
     api(project(":spi:issuerservice:issuerservice-credential-spi"))
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-configuration"))
-    implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.util)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
-    implementation(libs.jakarta.annotation)
 
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.jsonld)
     testImplementation(testFixtures(libs.edc.core.jersey))
-    testImplementation(testFixtures(project(":spi:identity-hub-spi")))
-    testImplementation(libs.nimbus.jwt)
     testImplementation(libs.restAssured)
-    testImplementation(libs.tink)
 }
 
 edcBuild {

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/build.gradle.kts
@@ -18,10 +18,9 @@ plugins {
 }
 
 dependencies {
-    api(libs.edc.spi.core)
     api(project(":spi:identity-hub-spi"))
+    implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.web)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
 
     testImplementation(libs.edc.junit)

--- a/extensions/api/issuer-admin-api/participant-api/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/participant-api/build.gradle.kts
@@ -21,20 +21,14 @@ plugins {
 dependencies {
     api(project(":spi:issuerservice:issuerservice-participant-spi"))
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-configuration"))
-    implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
     implementation(libs.edc.lib.util)
-    implementation(libs.edc.lib.jerseyproviders)
     implementation(libs.jakarta.rsApi)
-    implementation(libs.jakarta.annotation)
 
 
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.jsonld)
     testImplementation(testFixtures(libs.edc.core.jersey))
-    testImplementation(libs.nimbus.jwt)
     testImplementation(libs.restAssured)
-    testImplementation(libs.tink)
 }
 
 edcBuild {

--- a/extensions/did/local-did-publisher/build.gradle.kts
+++ b/extensions/did/local-did-publisher/build.gradle.kts
@@ -18,8 +18,6 @@ plugins {
     `maven-publish`
 }
 
-val swagger: String by project
-
 dependencies {
 
     api(project(":spi:did-spi"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ format.version = "1.1"
 [versions]
 assertj = "3.27.3"
 awaitility = "4.2.2"
+bouncyCastle-jdk18on = "1.80"
 edc = "0.12.0-SNAPSHOT"
 jackson = "2.18.2"
 jakarta-annotation = "2.1.1"
@@ -27,6 +28,7 @@ edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-spi-jwt = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
 edc-spi-jwt-signer = { module = "org.eclipse.edc:jwt-signer-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
+edc-spi-keys = { module = "org.eclipse.edc:keys-spi", version.ref = "edc" }
 edc-spi-transaction = { module = "org.eclipse.edc:transaction-spi", version.ref = "edc" }
 edc-spi-transform = { module = "org.eclipse.edc:transform-spi", version.ref = "edc" }
 edc-spi-transaction-datasource = { module = "org.eclipse.edc:transaction-datasource-spi", version.ref = "edc" }
@@ -87,6 +89,8 @@ edc-sts-api-accounts = { module = "org.eclipse.edc:identity-trust-sts-accounts-a
 # Third party libs
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
+
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,6 @@ include(":spi:issuance-credentials-spi")
 // IssuerService SPI modules
 include(":spi:issuerservice:issuerservice-participant-spi")
 include(":spi:issuerservice:issuerservice-credential-spi")
-include(":spi:issuerservice:credential-revocation-spi")
 include(":spi:issuerservice:issuerservice-credential-definition-spi")
 
 // IdentityHub core modules

--- a/spi/identity-hub-spi/build.gradle.kts
+++ b/spi/identity-hub-spi/build.gradle.kts
@@ -18,7 +18,6 @@ plugins {
     `maven-publish`
 }
 
-val swagger: String by project
 
 dependencies {
     api(libs.edc.spi.core)


### PR DESCRIPTION
## What this PR changes/adds

cleans up the gradle dependencies to avoid unnecessary dependencies

## Why it does that

keep the dependency tree clean

## Further notes

- temporarily applied this [dependency analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) dependency-analysis-gradle-plugin

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #557

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
