### PR TITLE
chore: improves issuance process query on credentialDefinitions field

### DIFF
--- a/extensions/store/sql/issuance-process-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/SqlIssuanceProcessStoreExtension.java
+++ b/extensions/store/sql/issuance-process-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/SqlIssuanceProcessStoreExtension.java
@@ -68,7 +68,7 @@ public class SqlIssuanceProcessStoreExtension implements ServiceExtension {
     }
 
     private IssuanceProcessStoreStatements getStatementImpl() {
-        return statements != null ? statements : new PostgresDialectStatements(typemanager.getMapper());
+        return statements != null ? statements : new PostgresDialectStatements();
     }
 
 }

--- a/extensions/store/sql/issuance-process-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/schema/postgres/IssuanceProcessMapping.java
+++ b/extensions/store/sql/issuance-process-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/schema/postgres/IssuanceProcessMapping.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.issuerservice.store.sql.issuanceprocess.schema.postgres;
 
 import org.eclipse.edc.issuerservice.store.sql.issuanceprocess.IssuanceProcessStoreStatements;
 import org.eclipse.edc.sql.lease.StatefulEntityMapping;
+import org.eclipse.edc.sql.translation.JsonArrayTranslator;
 import org.eclipse.edc.sql.translation.JsonFieldTranslator;
 
 
@@ -34,6 +35,6 @@ public class IssuanceProcessMapping extends StatefulEntityMapping {
         add(FIELD_ID, statements.getIdColumn());
         add(FIELD_PARTICIPANT_ID, statements.getParticipantIdColumn());
         add(FIELD_CLAIMS, new JsonFieldTranslator(FIELD_CLAIMS));
-        add(FIELD_CREDENTIAL_DEFINITIONS, statements.getCredentialDefinitionsColumn());
+        add(FIELD_CREDENTIAL_DEFINITIONS, new JsonArrayTranslator(statements.getCredentialDefinitionsColumn()));
     }
 }

--- a/extensions/store/sql/issuance-process-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/schema/postgres/PostgresDialectStatements.java
+++ b/extensions/store/sql/issuance-process-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/schema/postgres/PostgresDialectStatements.java
@@ -14,27 +14,17 @@
 
 package org.eclipse.edc.issuerservice.store.sql.issuanceprocess.schema.postgres;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.issuerservice.store.sql.issuanceprocess.BaseSqlDialectStatements;
-import org.eclipse.edc.spi.persistence.EdcPersistenceException;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.sql.dialect.PostgresDialect;
 import org.eclipse.edc.sql.translation.PostgresqlOperatorTranslator;
-import org.eclipse.edc.sql.translation.SqlQueryStatement;
-
-import static org.eclipse.edc.issuerservice.store.sql.issuanceprocess.schema.postgres.IssuanceProcessMapping.FIELD_CREDENTIAL_DEFINITIONS;
 
 /**
  * Postgres-specific specialization for creating queries based on Postgres JSON operators
  */
 public class PostgresDialectStatements extends BaseSqlDialectStatements {
 
-    private final ObjectMapper mapper;
-
-    public PostgresDialectStatements(ObjectMapper mapper) {
+    public PostgresDialectStatements() {
         super(new PostgresqlOperatorTranslator());
-        this.mapper = mapper;
     }
 
 
@@ -43,33 +33,4 @@ public class PostgresDialectStatements extends BaseSqlDialectStatements {
         return PostgresDialect.getJsonCastOperator();
     }
 
-    @Override
-    public SqlQueryStatement createQuery(QuerySpec querySpec) {
-
-        // if any criterion credentialDefinition array field, we need to slightly adapt the FROM clause
-        // by including a JSONB containment operator
-        if (querySpec.containsAnyLeftOperand(FIELD_CREDENTIAL_DEFINITIONS)) {
-            var select = "SELECT * FROM %s ".formatted(getIssuanceProcessTable());
-
-            var criteria = querySpec.getFilterExpression();
-            var filteredCriteria = criteria.stream()
-                    .filter(c -> c.getOperandLeft().toString().startsWith(FIELD_CREDENTIAL_DEFINITIONS))
-                    .toList();
-
-            criteria.removeAll(filteredCriteria);
-            var stmt = new SqlQueryStatement(select, querySpec, new IssuanceProcessMapping(this), operatorTranslator);
-            filteredCriteria.forEach(c -> {
-                var rightOperand = c.getOperandRight();
-                try {
-                    var rightOperandJson = mapper.writeValueAsString(rightOperand);
-                    stmt.addWhereClause("%s @> ?::jsonb".formatted(getCredentialDefinitionsColumn()), rightOperandJson);
-                } catch (JsonProcessingException e) {
-                    throw new EdcPersistenceException(e);
-                }
-
-            });
-            return stmt;
-        }
-        return super.createQuery(querySpec);
-    }
 }

--- a/extensions/store/sql/issuance-process-store-sql/src/test/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/SqlIssuanceProcessStoreTest.java
+++ b/extensions/store/sql/issuance-process-store-sql/src/test/java/org/eclipse/edc/issuerservice/store/sql/issuanceprocess/SqlIssuanceProcessStoreTest.java
@@ -42,7 +42,7 @@ class SqlIssuanceProcessStoreTest extends IssuanceProcessStoreTestBase {
     void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
         var typeManager = new JacksonTypeManager();
 
-        statements = new PostgresDialectStatements(typeManager.getMapper());
+        statements = new PostgresDialectStatements();
         store = new SqlIssuanceProcessStore(extension.getDataSourceRegistry(), extension.getDatasourceName(),
                 extension.getTransactionContext(), typeManager.getMapper(), queryExecutor, statements, RUNTIME_ID, Clock.systemUTC());
 

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/attestationdefinition/schema/postgres/CredentialDefinitionMapping.java
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/attestationdefinition/schema/postgres/CredentialDefinitionMapping.java
@@ -50,7 +50,7 @@ public class CredentialDefinitionMapping extends TranslationMapping {
         add(FIELD_JSON_SCHEMA_URL, statements.getJsonSchemaUrlColumn());
         add(FIELD_VALIDITY, statements.getValidityColumn());
         add(FIELD_DATAMODEL, statements.getDataModelColumn());
-        add(FIELD_ATTESTATIONS, new JsonArrayTranslator());
+        add(FIELD_ATTESTATIONS, new JsonArrayTranslator(statements.getAttestationsColumn()));
         add(FIELD_RULES, new JsonFieldTranslator(RULES_ALIAS));
         add(FIELD_MAPPINGS, new JsonFieldTranslator(MAPPING_ALIAS));
     }

--- a/extensions/store/sql/issuerservice-participant-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/participant/schema/postgres/ParticipantMapping.java
+++ b/extensions/store/sql/issuerservice-participant-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/participant/schema/postgres/ParticipantMapping.java
@@ -37,6 +37,6 @@ public class ParticipantMapping extends TranslationMapping {
         add(FIELD_LASTMODIFIED_TIMESTAMP, statements.getLastModifiedTimestampColumn());
         add(FIELD_NAME, statements.getParticipantNameColumn());
         add(FIELD_DID, statements.getDidColumn());
-        add(FIELD_ATTESTATIONS, new JsonArrayTranslator());
+        add(FIELD_ATTESTATIONS, new JsonArrayTranslator(statements.getAttestationsColumn()));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Removes the not needed complexity when querying `credentialDefinitions` by switching to `JsonArrayTranslator`


## Why it does that

refactoring

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
