### PR TITLE
feat: implement CredentialMessage transformers

### DIFF
--- a/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/build.gradle.kts
+++ b/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/build.gradle.kts
@@ -18,6 +18,11 @@ plugins {
 }
 
 dependencies {
-    api(libs.jackson.annotation) // JsonProperty
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.dcp)
+    api(project(":extensions:protocols:dcp:dcp-spi"))
+    testImplementation(libs.edc.lib.jsonld)
+    testImplementation(libs.edc.lib.transform)
+
 }
 

--- a/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/from/JsonObjectFromCredentialMessageTransformer.java
+++ b/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/from/JsonObjectFromCredentialMessageTransformer.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.issuer.transform.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromCredentialMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<CredentialMessage, JsonObject> {
+
+    private final TypeManager typeManager;
+    private final String typeContext;
+
+    public JsonObjectFromCredentialMessageTransformer(TypeManager typeManager, String typeContext, JsonLdNamespace namespace) {
+        super(CredentialMessage.class, JsonObject.class, namespace);
+        this.typeManager = typeManager;
+        this.typeContext = typeContext;
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull CredentialMessage credentialRequestMessage, @NotNull TransformerContext transformerContext) {
+
+        var credentials = typeManager.getMapper(typeContext).convertValue(credentialRequestMessage.getCredentials(), JsonArray.class);
+
+        var jsonCredentials = Json.createArrayBuilder().add(Json.createObjectBuilder()
+                        .add(JsonLdKeywords.TYPE, JsonLdKeywords.JSON)
+                        .add(JsonLdKeywords.VALUE, credentials))
+                .build();
+
+        return Json.createObjectBuilder()
+                .add(TYPE, forNamespace(CredentialMessage.CREDENTIAL_MESSAGE_TERM))
+                .add(forNamespace(CredentialMessage.CREDENTIALS_TERM), jsonCredentials)
+                .build();
+    }
+
+}

--- a/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/to/JsonObjectToCredentialMessageTransformer.java
+++ b/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/to/JsonObjectToCredentialMessageTransformer.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.issuer.transform.to;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialContainer;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.REQUEST_ID_TERM;
+
+
+public class JsonObjectToCredentialMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, CredentialMessage> {
+
+    private final TypeManager typeManager;
+    private final String typeContext;
+
+    public JsonObjectToCredentialMessageTransformer(TypeManager typeManager, String typeContext, JsonLdNamespace namespace) {
+        super(JsonObject.class, CredentialMessage.class, namespace);
+        this.typeManager = typeManager;
+        this.typeContext = typeContext;
+    }
+
+    @Override
+    public @Nullable CredentialMessage transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext transformerContext) {
+
+        var requestMessage = CredentialMessage.Builder.newInstance();
+        var credentials = jsonObject.get(forNamespace(CREDENTIALS_TERM));
+        var requestId = jsonObject.getString(forNamespace(REQUEST_ID_TERM));
+        requestMessage.requestId(requestId);
+        if (credentials != null) {
+            ofNullable(readCredentialContainers(credentials, transformerContext))
+                    .map(requestMessage::credentials);
+        }
+        return requestMessage.build();
+    }
+
+    private List<CredentialContainer> readCredentialContainers(JsonValue v, TransformerContext context) {
+        var rawJson = getCredentials(v);
+        if (rawJson.isEmpty()) {
+            return Collections.emptyList();
+        }
+        try {
+            return typeManager.getMapper(typeContext).readValue(rawJson.toString(), new TypeReference<>() {
+            });
+        } catch (JsonProcessingException e) {
+            context.reportProblem("Error reading JSON literal: %s".formatted(e.getMessage()));
+            return null;
+        }
+    }
+
+    private JsonArray getCredentials(JsonValue jsonValue) {
+        JsonObject jsonObject;
+        if (jsonValue.getValueType() == JsonValue.ValueType.ARRAY) {
+            if (((JsonArray) jsonValue).isEmpty()) {
+                return JsonArray.EMPTY_JSON_ARRAY;
+            }
+            jsonObject = jsonValue.asJsonArray().getJsonObject(0);
+        } else {
+            jsonObject = jsonValue.asJsonObject();
+        }
+        return jsonObject.getJsonArray(JsonLdKeywords.VALUE);
+    }
+
+}

--- a/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/from/JsonObjectFromCredentialMessageTransformerTest.java
+++ b/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/from/JsonObjectFromCredentialMessageTransformerTest.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.issuer.transform.from;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialContainer;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JsonObjectFromCredentialMessageTransformerTest {
+
+    private final TransformerContext context = mock();
+    private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
+    private final TypeManager typeManager = mock();
+    private final JsonObjectFromCredentialMessageTransformer transformer = new JsonObjectFromCredentialMessageTransformer(typeManager, "test", DSPACE_DCP_NAMESPACE_V_1_0);
+
+    @BeforeEach
+    void setUp() {
+        when(typeManager.getMapper("test")).thenReturn(mapper);
+    }
+
+    @Test
+    void transform() {
+
+        when(context.transform(isA(CredentialMessage.class), eq(JsonObject.class))).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+        var status = CredentialMessage.Builder.newInstance()
+                .requestId("requestId")
+                .credential(new CredentialContainer("MembershipCredential", "myFormat", "SOMEPAYLOAD"))
+                .build();
+
+        var jsonLd = transformer.transform(status, context);
+
+        assertThat(jsonLd).isNotNull();
+        assertThat(jsonLd.getString(TYPE)).isEqualTo(toIri(CredentialMessage.CREDENTIAL_MESSAGE_TERM));
+        assertThat(jsonLd.getJsonArray(toIri(CredentialMessage.CREDENTIALS_TERM))).hasSize(1)
+                .first().satisfies(jsonValue -> {
+                    var credentials = jsonValue.asJsonObject().getJsonArray(JsonLdKeywords.VALUE);
+                    assertThat(credentials).hasSize(1);
+                    var credential = credentials.getJsonObject(0);
+                    assertThat(credential.getString("credentialType")).isEqualTo("MembershipCredential");
+                    assertThat(credential.getString("format")).isEqualTo("myFormat");
+                    assertThat(credential.get("payload")).isNotNull();
+                });
+    }
+
+    @Test
+    void transform_noCredentials() {
+
+        when(context.transform(isA(CredentialMessage.class), eq(JsonObject.class))).thenReturn(JsonObject.EMPTY_JSON_OBJECT);
+        var status = CredentialMessage.Builder.newInstance()
+                .requestId("requestId")
+                .build();
+
+        var jsonLd = transformer.transform(status, context);
+
+        assertThat(jsonLd).isNotNull();
+        assertThat(jsonLd.getString(TYPE)).isEqualTo(toIri(CredentialMessage.CREDENTIAL_MESSAGE_TERM));
+        assertThat(jsonLd.getJsonArray(toIri(CredentialMessage.CREDENTIALS_TERM))).hasSize(1)
+                .first().satisfies(jsonValue -> {
+                    var credentials = jsonValue.asJsonObject().getJsonArray(JsonLdKeywords.VALUE);
+                    assertThat(credentials).isEmpty();
+                });
+    }
+
+    private String toIri(String term) {
+        return DSPACE_DCP_NAMESPACE_V_1_0.toIri(term);
+    }
+}

--- a/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/to/JsonObjectToCredentialMessageTransformerTest.java
+++ b/extensions/protocols/dcp/dcp-identityhub/dcp-identityhub-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/transform/to/JsonObjectToCredentialMessageTransformerTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.issuer.transform.to;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.util.JacksonJsonLd;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class JsonObjectToCredentialMessageTransformerTest {
+
+    private final TransformerContext context = mock();
+    private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
+    private final TypeManager typeManager = mock();
+    private final JsonObjectToCredentialMessageTransformer transformer = new JsonObjectToCredentialMessageTransformer(typeManager, "test", DSPACE_DCP_NAMESPACE_V_1_0);
+
+    @BeforeEach
+    void setUp() {
+        when(typeManager.getMapper("test")).thenReturn(mapper);
+    }
+
+
+    @Test
+    void transform() {
+
+        var credentialContainers = Json.createArrayBuilder().add(Json.createObjectBuilder()
+                        .add("credentialType", "MembershipCredential")
+                        .add("payload", "test-payload")
+                        .add("format", "myFormat")
+                        .build())
+                .build();
+
+        var credentialsJsonArray = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add(JsonLdKeywords.TYPE, JsonLdKeywords.JSON)
+                        .add(JsonLdKeywords.VALUE, credentialContainers));
+
+        var input = Json.createObjectBuilder()
+                .add(toIri(CredentialMessage.REQUEST_ID_TERM), "test-request-id")
+                .add(toIri(CredentialMessage.CREDENTIALS_TERM), credentialsJsonArray)
+                .build();
+
+        var credentialRequestMessage = transformer.transform(input, context);
+
+        assertThat(credentialRequestMessage).isNotNull();
+        assertThat(credentialRequestMessage.getCredentials()).hasSize(1).first().satisfies(credentialRequest -> {
+            assertThat(credentialRequest.credentialType()).isEqualTo("MembershipCredential");
+            assertThat(credentialRequest.format()).isEqualTo("myFormat");
+            assertThat(credentialRequest.payload()).isNotNull();
+        });
+    }
+
+    @Test
+    void transform_noCredentials() {
+
+        var credentialsJsonArray = Json.createArrayBuilder().build();
+
+        var input = Json.createObjectBuilder()
+                .add(toIri(CredentialMessage.REQUEST_ID_TERM), "test-request-id")
+                .add(toIri(CredentialMessage.CREDENTIALS_TERM), credentialsJsonArray)
+                .build();
+
+        var credentialRequestMessage = transformer.transform(input, context);
+
+        assertThat(credentialRequestMessage).isNotNull();
+        assertThat(credentialRequestMessage.getCredentials()).isEmpty();
+    }
+
+    @Test
+    void transform_invalidCredentialsJson() {
+        var credentialContainers = Json.createArrayBuilder().add(Json.createObjectBuilder()
+                        .add("someProperty", "MembershipCredential")
+                        .add("whoNeedsThisProperty", "test-payload")
+                        .add("alsoNotValid", "myFormat")
+                        .build())
+                .build();
+
+        var credentialsJsonArray = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add(JsonLdKeywords.TYPE, JsonLdKeywords.JSON)
+                        .add(JsonLdKeywords.VALUE, credentialContainers));
+
+        var input = Json.createObjectBuilder()
+                .add(toIri(CredentialMessage.REQUEST_ID_TERM), "test-request-id")
+                .add(toIri(CredentialMessage.CREDENTIALS_TERM), credentialsJsonArray)
+                .build();
+
+        var credentialRequestMessage = transformer.transform(input, context);
+
+        assertThat(credentialRequestMessage).isNotNull();
+        assertThat(credentialRequestMessage.getCredentials()).isEmpty();
+        verify(context).reportProblem(contains("Error reading JSON literal"));
+    }
+
+    private String toIri(String term) {
+        return DSPACE_DCP_NAMESPACE_V_1_0.toIri(term);
+    }
+}

--- a/extensions/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialContainer.java
+++ b/extensions/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialContainer.java
@@ -14,6 +14,10 @@
 
 package org.eclipse.edc.identityhub.protocols.dcp.spi.model;
 
-public record CredentialContainer(String credentialType, String format, String payload) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CredentialContainer(@JsonProperty(required = true) String credentialType,
+                                  @JsonProperty(required = true) String format,
+                                  @JsonProperty(required = true) String payload) {
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" 
 bouncyCastle-bcprovJdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncyCastle-jdk18on" }
 
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-annotation = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -77,6 +77,7 @@ include(":extensions:protocols:dcp:dcp-issuer:dcp-issuer-core")
 
 include(":extensions:protocols:dcp:dcp-identityhub:presentation-api")
 include(":extensions:protocols:dcp:dcp-identityhub:storage-api")
+include(":extensions:protocols:dcp:dcp-identityhub:dcp-identityhub-transform-lib")
 
 
 // Identity APIs


### PR DESCRIPTION
## What this PR changes/adds

adds transformers JsonObject <> CredentialMessage

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #570

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
