### PR TITLE
feat: add attestation validation on AttestationDefinitionService

### DIFF
--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/IssuanceServicesExtension.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/IssuanceServicesExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.issuerservice.issuance;
 
 import org.eclipse.edc.issuerservice.issuance.attestation.AttestationDefinitionServiceImpl;
+import org.eclipse.edc.issuerservice.issuance.attestation.AttestationDefinitionValidatorRegistryImpl;
 import org.eclipse.edc.issuerservice.issuance.attestation.AttestationPipelineImpl;
 import org.eclipse.edc.issuerservice.issuance.credentialdefinition.CredentialDefinitionServiceImpl;
 import org.eclipse.edc.issuerservice.issuance.rule.CredentialRuleDefinitionEvaluatorImpl;
@@ -22,6 +23,7 @@ import org.eclipse.edc.issuerservice.issuance.rule.CredentialRuleDefinitionValid
 import org.eclipse.edc.issuerservice.issuance.rule.CredentialRuleFactoryRegistryImpl;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionService;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionStore;
+import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionValidatorRegistry;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationPipeline;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationSourceFactoryRegistry;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.CredentialDefinitionService;
@@ -56,6 +58,8 @@ public class IssuanceServicesExtension implements ServiceExtension {
 
     private CredentialRuleDefinitionValidatorRegistry ruleDefinitionValidatorRegistry;
 
+    private AttestationDefinitionValidatorRegistry attestationDefinitionValidatorRegistry;
+
     @Provider
     public CredentialDefinitionService createParticipantService() {
         return new CredentialDefinitionServiceImpl(transactionContext, store, attestationDefinitionStore, credentialRuleDefinitionValidatorRegistry());
@@ -63,7 +67,7 @@ public class IssuanceServicesExtension implements ServiceExtension {
 
     @Provider
     public AttestationDefinitionService createAttestationService() {
-        return new AttestationDefinitionServiceImpl(transactionContext, attestationDefinitionStore, participantStore);
+        return new AttestationDefinitionServiceImpl(transactionContext, attestationDefinitionStore, participantStore, createAttestationDefinitionValidatorRegistry());
     }
 
     @Provider
@@ -98,6 +102,14 @@ public class IssuanceServicesExtension implements ServiceExtension {
         }
 
         return ruleDefinitionValidatorRegistry;
+    }
+
+    @Provider
+    public AttestationDefinitionValidatorRegistry createAttestationDefinitionValidatorRegistry() {
+        if (attestationDefinitionValidatorRegistry == null) {
+            attestationDefinitionValidatorRegistry = new AttestationDefinitionValidatorRegistryImpl();
+        }
+        return attestationDefinitionValidatorRegistry;
     }
 
     private AttestationPipelineImpl createAttestationPipelineImpl() {

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/attestation/AttestationDefinitionValidatorRegistryImpl.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/attestation/AttestationDefinitionValidatorRegistryImpl.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.issuance.attestation;
+
+import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionValidatorRegistry;
+import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Validator;
+import org.eclipse.edc.validator.spi.Violation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AttestationDefinitionValidatorRegistryImpl implements AttestationDefinitionValidatorRegistry {
+
+    private final Map<String, Validator<AttestationDefinition>> validators = new HashMap<>();
+
+    @Override
+    public void registerValidator(String type, Validator<AttestationDefinition> validator) {
+        validators.put(type, validator);
+    }
+
+    @Override
+    public ValidationResult validateDefinition(AttestationDefinition definition) {
+        return Optional.ofNullable(validators.get(definition.attestationType()))
+                .map(validator -> validator.validate(definition))
+                .orElseGet(() -> ValidationResult.failure(Violation.violation("Unknown attestation type: " + definition.attestationType(), null)));
+    }
+}

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/attestation/AttestationDefinitionValidatorRegistryImplTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/attestation/AttestationDefinitionValidatorRegistryImplTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.issuance.attestation;
+
+import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionValidatorRegistry;
+import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class AttestationDefinitionValidatorRegistryImplTest {
+
+    protected AttestationDefinitionValidatorRegistry registry = new AttestationDefinitionValidatorRegistryImpl();
+
+    @Test
+    void validateDefinition() {
+        registry.registerValidator("test", def -> ValidationResult.success());
+        var result = registry.validateDefinition(new AttestationDefinition("id", "test", Map.of("key", "value")));
+        assertThat(result).isSucceeded();
+    }
+
+
+    @Test
+    void validateDefinition_shouldFails_whenTypeNotFound() {
+        var result = registry.validateDefinition(new AttestationDefinition("id", "test", Map.of("key", "value")));
+        assertThat(result).isFailed().detail().contains("Unknown attestation type: test");
+    }
+}

--- a/extensions/issuance/issuerservice-issuance-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/attestations/IssuanceAttestationsExtension.java
+++ b/extensions/issuance/issuerservice-issuance-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/attestations/IssuanceAttestationsExtension.java
@@ -15,6 +15,8 @@
 package org.eclipse.edc.issuerservice.issuance.attestations;
 
 import org.eclipse.edc.issuerservice.issuance.attestations.presentation.PresentationAttestationSourceFactory;
+import org.eclipse.edc.issuerservice.issuance.attestations.presentation.PresentationAttestatonSourceValidator;
+import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionValidatorRegistry;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationSourceFactoryRegistry;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -31,8 +33,12 @@ public class IssuanceAttestationsExtension implements ServiceExtension {
     @Inject
     private AttestationSourceFactoryRegistry registry;
 
+    @Inject
+    private AttestationDefinitionValidatorRegistry validatorRegistry;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         registry.registerFactory("presentation", new PresentationAttestationSourceFactory());
+        validatorRegistry.registerValidator("presentation", new PresentationAttestatonSourceValidator());
     }
 }

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/attestation/AttestationDefinitionValidatorRegistry.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/attestation/AttestationDefinitionValidatorRegistry.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.issuerservice.spi.issuance.attestation;
 
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
+import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
 
@@ -31,6 +32,6 @@ public interface AttestationDefinitionValidatorRegistry {
     /**
      * Validates the definition.
      */
-    void validateDefinition(AttestationDefinition definition);
+    ValidationResult validateDefinition(AttestationDefinition definition);
 
 }


### PR DESCRIPTION
## What this PR changes/adds

add attestation validation on AttestationDefinitionService

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #577 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
