### PR TITLE
fix: use transactions in credential request

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -220,7 +220,8 @@ public class CoreServicesExtension implements ServiceExtension {
                 typeTransformerRegistry.forContext(DCP_SCOPE_V_1_0),
                 httpClient,
                 secureTokenService,
-                ownDid
+                ownDid,
+                transactionContext
         );
     }
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestServiceImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestServiceImplTest.java
@@ -27,6 +27,7 @@ import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMess
 import org.eclipse.edc.identityhub.spi.credential.request.store.HolderCredentialRequestStore;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ class CredentialRequestServiceImplTest {
     private final TypeTransformerRegistry transformerRegistry = mock();
     private final EdcHttpClient httpClient = mock();
     private final SecureTokenService sts = mock();
-    private final CredentialRequestServiceImpl credentialRequestService = new CredentialRequestServiceImpl(store, resolver, transformerRegistry, httpClient, sts, OWN_DID);
+    private final CredentialRequestServiceImpl credentialRequestService = new CredentialRequestServiceImpl(store, resolver, transformerRegistry, httpClient, sts, OWN_DID, new NoopTransactionContext());
 
     @BeforeEach
     void setUp() {

--- a/dist/bom/identityhub-feature-sql-bom/build.gradle.kts
+++ b/dist/bom/identityhub-feature-sql-bom/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":extensions:store:sql:identity-hub-did-store-sql"))
     api(project(":extensions:store:sql:identity-hub-keypair-store-sql"))
     api(project(":extensions:store:sql:identity-hub-participantcontext-store-sql"))
+    api(project(":extensions:store:sql:holder-credential-request-store-sql"))
 
     api(libs.edc.sql.core)
     api(libs.edc.transaction.local)


### PR DESCRIPTION
## What this PR changes/adds

add transactional storing in the CredentialRequestService. Also, the Postgres tests now actually uses PG persistence...

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
