### PR TITLE
chore: serialize holder and issuer PID as @id

### DIFF
--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.api;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import jakarta.json.Json;
 import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiableCredentialTransformer;
 import org.eclipse.edc.identityhub.api.storage.StorageApiController;
 import org.eclipse.edc.identityhub.api.validation.CredentialMessageValidator;
@@ -46,6 +47,7 @@ import org.eclipse.edc.web.spi.configuration.PortMapping;
 import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
@@ -111,11 +113,13 @@ public class StorageApiExtension implements ServiceExtension {
     }
 
     void registerTransformers(String scope, JsonLdNamespace namespace) {
+
+        var factory = Json.createBuilderFactory(Map.of());
         var scopedTransformerRegistry = typeTransformer.forContext(scope);
         scopedTransformerRegistry.register(new JsonObjectToCredentialMessageTransformer(typeManager, JSON_LD, namespace));
         scopedTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
-        scopedTransformerRegistry.register(new JsonObjectFromCredentialMessageTransformer(typeManager, JSON_LD, namespace));
-        scopedTransformerRegistry.register(new JsonObjectFromCredentialRequestMessageTransformer(typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
+        scopedTransformerRegistry.register(new JsonObjectFromCredentialMessageTransformer(factory, typeManager, JSON_LD, namespace));
+        scopedTransformerRegistry.register(new JsonObjectFromCredentialRequestMessageTransformer(factory, typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
 
         typeTransformer.register(new JwtToVerifiableCredentialTransformer(monitor));
 

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialMessageTransformer.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.protocols.dcp.transform.from;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
@@ -26,17 +27,23 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIAL_MESSAGE_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.HOLDER_PID_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.ISSUER_PID_TERM;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 public class JsonObjectFromCredentialMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<CredentialMessage, JsonObject> {
 
     private final TypeManager typeManager;
     private final String typeContext;
+    private final JsonBuilderFactory factory;
 
-    public JsonObjectFromCredentialMessageTransformer(TypeManager typeManager, String typeContext, JsonLdNamespace namespace) {
+    public JsonObjectFromCredentialMessageTransformer(JsonBuilderFactory factory, TypeManager typeManager, String typeContext, JsonLdNamespace namespace) {
         super(CredentialMessage.class, JsonObject.class, namespace);
         this.typeManager = typeManager;
         this.typeContext = typeContext;
+        this.factory = factory;
     }
 
     @Override
@@ -50,8 +57,10 @@ public class JsonObjectFromCredentialMessageTransformer extends AbstractNamespac
                 .build();
 
         return Json.createObjectBuilder()
-                .add(TYPE, forNamespace(CredentialMessage.CREDENTIAL_MESSAGE_TERM))
-                .add(forNamespace(CredentialMessage.CREDENTIALS_TERM), jsonCredentials)
+                .add(TYPE, forNamespace(CREDENTIAL_MESSAGE_TERM))
+                .add(forNamespace(HOLDER_PID_TERM), createId(factory, credentialRequestMessage.getHolderPid()))
+                .add(forNamespace(ISSUER_PID_TERM), createId(factory, credentialRequestMessage.getIssuerPid()))
+                .add(forNamespace(CREDENTIALS_TERM), jsonCredentials)
                 .build();
     }
 

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialRequestMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialRequestMessageTransformer.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.protocols.dcp.transform.from;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
@@ -33,11 +34,13 @@ import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 
 public class JsonObjectFromCredentialRequestMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<CredentialRequestMessage, JsonObject> {
 
+    private final JsonBuilderFactory factory;
     private final TypeManager typeManager;
     private final String typeContext;
 
-    public JsonObjectFromCredentialRequestMessageTransformer(TypeManager typeManager, String typeContext, JsonLdNamespace namespace) {
+    public JsonObjectFromCredentialRequestMessageTransformer(JsonBuilderFactory factory, TypeManager typeManager, String typeContext, JsonLdNamespace namespace) {
         super(CredentialRequestMessage.class, JsonObject.class, namespace);
+        this.factory = factory;
         this.typeManager = typeManager;
         this.typeContext = typeContext;
     }
@@ -54,7 +57,7 @@ public class JsonObjectFromCredentialRequestMessageTransformer extends AbstractN
         return Json.createObjectBuilder()
                 .add(TYPE, forNamespace(CREDENTIAL_REQUEST_MESSAGE_TERM))
                 .add(forNamespace(CREDENTIAL_REQUEST_MESSAGE_CREDENTIALS_TERM), jsonCredentials)
-                .add(forNamespace(CREDENTIAL_REQUEST_MESSAGE_HOLDER_PID_TERM), credentialRequestMessage.getHolderPid())
+                .add(forNamespace(CREDENTIAL_REQUEST_MESSAGE_HOLDER_PID_TERM), createId(factory, credentialRequestMessage.getHolderPid()))
                 .build();
     }
 

--- a/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialRequestMessageTransformerTest.java
+++ b/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialRequestMessageTransformerTest.java
@@ -15,6 +15,8 @@
 package org.eclipse.edc.identityhub.protocols.dcp.transform.from;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
 import jakarta.json.JsonObject;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequest;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage;
@@ -25,11 +27,14 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage.CREDENTIAL_REQUEST_MESSAGE_CREDENTIALS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage.CREDENTIAL_REQUEST_MESSAGE_HOLDER_PID_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage.CREDENTIAL_REQUEST_MESSAGE_TERM;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.ID;
 import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -41,7 +46,8 @@ public class JsonObjectFromCredentialRequestMessageTransformerTest {
     private final TransformerContext context = mock();
     private final ObjectMapper mapper = JacksonJsonLd.createObjectMapper();
     private final TypeManager typeManager = mock();
-    private final JsonObjectFromCredentialRequestMessageTransformer transformer = new JsonObjectFromCredentialRequestMessageTransformer(typeManager, "test", DSPACE_DCP_NAMESPACE_V_1_0);
+    private final JsonBuilderFactory factory = Json.createBuilderFactory(Map.of());
+    private final JsonObjectFromCredentialRequestMessageTransformer transformer = new JsonObjectFromCredentialRequestMessageTransformer(factory, typeManager, "test", DSPACE_DCP_NAMESPACE_V_1_0);
 
     @BeforeEach
     void setUp() {
@@ -61,7 +67,7 @@ public class JsonObjectFromCredentialRequestMessageTransformerTest {
 
         assertThat(jsonLd).isNotNull();
         assertThat(jsonLd.getString(TYPE)).isEqualTo(toIri(CREDENTIAL_REQUEST_MESSAGE_TERM));
-        assertThat(jsonLd.getString(toIri(CREDENTIAL_REQUEST_MESSAGE_HOLDER_PID_TERM))).isEqualTo("test-request-id");
+        assertThat(jsonLd.getJsonObject(toIri(CREDENTIAL_REQUEST_MESSAGE_HOLDER_PID_TERM)).getString(ID)).isEqualTo("test-request-id");
         assertThat(jsonLd.getJsonArray(toIri(CREDENTIAL_REQUEST_MESSAGE_CREDENTIALS_TERM))).hasSize(1)
                 .first().satisfies(jsonValue -> {
                     var credentials = jsonValue.asJsonObject().getJsonArray(JsonLdKeywords.VALUE);


### PR DESCRIPTION
## What this PR changes/adds

serialize holder and issuer pid as @id

## Why it does that

JSON LD compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
