### PR TITLE
refactor: rename requestId and issuanceProcessId

### DIFF
--- a/core/common-core/src/test/java/org/eclipse/edc/identityhub/defaults/store/InMemoryHolderCredentialRequestStoreTest.java
+++ b/core/common-core/src/test/java/org/eclipse/edc/identityhub/defaults/store/InMemoryHolderCredentialRequestStoreTest.java
@@ -35,7 +35,7 @@ class InMemoryHolderCredentialRequestStoreTest extends HolderCredentialRequestSt
     }
 
     @Override
-    protected void leaseEntity(String requestId, String owner, Duration duration) {
-        store.acquireLease(requestId, owner, duration);
+    protected void leaseEntity(String holderPid, String owner, Duration duration) {
+        store.acquireLease(holderPid, owner, duration);
     }
 }

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
@@ -162,7 +162,7 @@ class CredentialRequestManagerImplTest {
                 inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTING.code()));
                 inOrder.verify(sts).createToken(anyMap(), ArgumentMatchers.isNull());
                 inOrder.verify(httpClient).execute(any(), (Function<Response, Result<String>>) any());
-                inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTED.code() && r.getIssuanceProcessId() != null));
+                inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTED.code() && r.getIssuerPid() != null));
             });
         }
 
@@ -278,7 +278,7 @@ class CredentialRequestManagerImplTest {
                                 "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
                               ],
                               "type": "CredentialStatus",
-                              "requestId": "test-request",
+                              "holderPid": "test-request",
                               "status": "RECEIVED"
                             }
                             """));
@@ -306,7 +306,7 @@ class CredentialRequestManagerImplTest {
                                 "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
                               ],
                               "type": "CredentialStatus",
-                              "requestId": "test-request",
+                              "holderPid": "test-request",
                               "status": "REJECTED"
                             }
                             """));
@@ -331,7 +331,7 @@ class CredentialRequestManagerImplTest {
                                 "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
                               ],
                               "type": "CredentialStatus",
-                              "requestId": "test-request",
+                              "holderPid": "test-request",
                               "status": "ISSUED"
                             }
                             """));
@@ -356,7 +356,7 @@ class CredentialRequestManagerImplTest {
                                 "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
                               ],
                               "type": "CredentialStatus",
-                              "requestId": "test-request",
+                              "holderPid": "test-request",
                               "status": "FOOBAR"
                             }
                             """));
@@ -409,7 +409,7 @@ class CredentialRequestManagerImplTest {
                     .state(REQUESTED.code())
                     .id("test-request")
                     .issuerDid(ISSUER_DID)
-                    .participantContext("test-participant");
+                    .participantContextId("test-participant");
         }
 
         private Criterion[] stateIs(int state) {

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/DcpIssuanceApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/DcpIssuanceApiEndToEndTest.java
@@ -161,12 +161,12 @@ public class DcpIssuanceApiEndToEndTest {
 
             try (var mockedCredentialService = ClientAndServer.startClientAndServer(port)) {
 
-                var issuanceProcessId = "dummy-issuance-id";
+                var issuerPid = "dummy-issuance-id";
                 mockedCredentialService.when(request()
                                 .withMethod("POST")
                                 .withPath("/api/credentials"))
                         .respond(response()
-                                .withBody(issuanceProcessId)
+                                .withBody(issuerPid)
                                 .withStatusCode(201));
 
 

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
@@ -228,19 +228,19 @@ public class VerifiableCredentialApiEndToEndTest {
         void createCredentialRequest(IdentityHubEndToEndTestContext context, HolderCredentialRequestStore store) {
             var port = getFreePort();
             try (var mockedIssuer = ClientAndServer.startClientAndServer(port)) {
-                var issuanceProcessId = "dummy-issuance-id";
+                var issuerPid = "dummy-issuance-id";
                 // prepare DCP credential requests
                 mockedIssuer.when(request()
                                 .withMethod("POST")
                                 .withPath("/api/issuance/credentials"))
                         .respond(response()
-                                .withBody(issuanceProcessId)
+                                .withBody(issuerPid)
                                 .withStatusCode(201));
 
                 // prepare DCP credential status requests. The state machine is so fast, that it may tick over
                 mockedIssuer.when(request()
                                 .withMethod("GET")
-                                .withPath("/api/issuance/request/" + issuanceProcessId))
+                                .withPath("/api/issuance/request/" + issuerPid))
                         .respond(response()
                                 .withBody("""
                                         {
@@ -248,7 +248,7 @@ public class VerifiableCredentialApiEndToEndTest {
                                             "https://w3id.org/dspace-dcp/v1.0/dcp.jsonld"
                                           ],
                                           "type": "CredentialStatus",
-                                          "requestId": "requestId",
+                                          "holderPid": "holderPid",
                                           "status": "RECEIVED"
                                         }
                                         """)
@@ -267,7 +267,7 @@ public class VerifiableCredentialApiEndToEndTest {
                         """
                                 {
                                   "issuerDid": "did:web:issuer",
-                                  "requestId": "test-request-id",
+                                  "holderPid": "test-request-id",
                                   "credentials": [{ "format": "VC1_0_JWT", "credentialType": "TestCredential"}]
                                 }
                                 """;
@@ -289,8 +289,8 @@ public class VerifiableCredentialApiEndToEndTest {
                             assertThat(requests).hasSize(1)
                                     .allSatisfy(t -> {
                                         assertThat(t.getState()).isEqualTo(HolderRequestState.REQUESTED.code());
-                                        assertThat(t.getIssuanceProcessId()).isEqualTo(issuanceProcessId);
-                                        assertThat(t.getRequestId()).isEqualTo("test-request-id");
+                                        assertThat(t.getIssuerPid()).isEqualTo(issuerPid);
+                                        assertThat(t.getHolderPid()).isEqualTo("test-request-id");
                                     });
                         });
             }

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-02-13T12:00:00Z",
+    "lastUpdated": "2025-02-21T12:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApi.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApi.java
@@ -136,7 +136,7 @@ public interface VerifiableCredentialsApi {
             },
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = CredentialRequestDto.class))),
             responses = {
-                    @ApiResponse(responseCode = "201", description = "The request was processed and sent to the issuer. The issuer-created ID is returned in the response.",
+                    @ApiResponse(responseCode = "201", description = "The request was processed and sent to the issuer. The issuer-created ID (\"issuerPid\") is returned in the response.",
                             content = {@Content(schema = @Schema(implementation = String.class))}),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
@@ -152,7 +152,7 @@ public interface VerifiableCredentialsApi {
             operationId = "getCredentialRequest",
             parameters = {
                     @Parameter(name = "participantContextId", description = "Base64-Url encode Participant Context ID", required = true, in = ParameterIn.PATH),
-                    @Parameter(name = "issuanceProcessId", description = "The issuer-assigned ID of the issuance process", required = true, in = ParameterIn.PATH),
+                    @Parameter(name = "issuerPid", description = "The issuer-assigned ID of the issuance process", required = true, in = ParameterIn.PATH),
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "The VerifiableCredential.",
@@ -165,5 +165,5 @@ public interface VerifiableCredentialsApi {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    HolderCredentialRequestDto getCredentialRequest(String participantContextId, String issuanceProcessId, SecurityContext securityContext);
+    HolderCredentialRequestDto getCredentialRequest(String participantContextId, String issuerPid, SecurityContext securityContext);
 }

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
@@ -161,11 +161,11 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
         authorizationService.isAuthorized(securityContext, participantId, ParticipantContext.class)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
 
-        var requestId = ofNullable(credentialRequestDto.requestId());
+        var holderPid = ofNullable(credentialRequestDto.holderPid());
         var requestParameters = credentialRequestDto.credentials().stream().collect(Collectors.toMap(CredentialDescriptor::credentialType, CredentialDescriptor::format));
 
         var credentialRequestResult = credentialRequestService.initiateRequest(participantId, credentialRequestDto.issuerDid(),
-                requestId.orElseGet(() -> UUID.randomUUID().toString()),
+                holderPid.orElseGet(() -> UUID.randomUUID().toString()),
                 requestParameters);
 
         return credentialRequestResult.map(id -> Response.status(201).entity(id).build())
@@ -178,10 +178,10 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
     }
 
     @GET
-    @Path("/request/{issuanceProcessId}")
+    @Path("/request/{issuerPid}")
     @Override
     public HolderCredentialRequestDto getCredentialRequest(@PathParam("participantContextId") String participantContextId,
-                                                           @PathParam("issuanceProcessId") String issuanceProcessId,
+                                                           @PathParam("issuerPid") String issuerPid,
                                                            @Context SecurityContext securityContext) {
 
         var participantId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/model/CredentialRequestDto.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/model/CredentialRequestDto.java
@@ -23,10 +23,10 @@ import java.util.List;
  * Represents a credential request
  *
  * @param issuerDid   The DID of the issuer.
- * @param requestId   A client-assigned request ID. A random ID will be assigned if null
+ * @param holderPid   A client-assigned request ID. A random ID will be assigned if null
  * @param credentials A list of credential descriptors
  */
 public record CredentialRequestDto(@JsonProperty(required = true) String issuerDid,
-                                   @JsonProperty(required = true) @Nullable String requestId,
+                                   @JsonProperty @Nullable String holderPid,
                                    @JsonProperty(required = true) List<CredentialDescriptor> credentials) {
 }

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/model/HolderCredentialRequestDto.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/model/HolderCredentialRequestDto.java
@@ -19,14 +19,14 @@ import java.util.List;
 /**
  * Represents a credential request of the holder.
  *
- * @param issuerDid         The DID of the issuer, to whom the request was originally sent.
- * @param requestId         the request ID assigned by the holder
- * @param issuanceProcessId the process ID returned from the issuer
- * @param status            REQUESTED, ISSUED, etc.
- * @param credentialIds     after the credentials are issued, their IDs are stored here
- * @param credentialTypes   list of credential types/formats that were originally requested
+ * @param issuerDid       The DID of the issuer, to whom the request was originally sent.
+ * @param holderPid       the request ID assigned by the holder
+ * @param issuerPid       the process ID returned from the issuer
+ * @param status          REQUESTED, ISSUED, etc.
+ * @param credentialIds   after the credentials are issued, their IDs are stored here
+ * @param credentialTypes list of credential types/formats that were originally requested
  */
 // todo: this DTO might get removed again later, when we have a HolderCredentialRequest entity, which will likely have the same signature
-public record HolderCredentialRequestDto(String issuerDid, String requestId, String issuanceProcessId, String status,
+public record HolderCredentialRequestDto(String issuerDid, String holderPid, String issuerPid, String status,
                                          List<String> credentialIds, List<CredentialDescriptor> credentialTypes) {
 }

--- a/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/BaseSqlDialectStatements.java
@@ -43,7 +43,7 @@ public class BaseSqlDialectStatements implements HolderCredentialRequestStoreSta
                 .column(getErrorDetailColumn())
                 .column(getParticipantIdColumn())
                 .column(getIssuerDidColumn())
-                .column(getIssuanceProcessIdColumn())
+                .column(getissuerPidColumn())
                 .jsonColumn(getCredentialTypesColumn())
                 .insertInto(getHolderCredentialRequestTable());
     }
@@ -58,7 +58,7 @@ public class BaseSqlDialectStatements implements HolderCredentialRequestStoreSta
                 .jsonColumn(getTraceContextColumn())
                 .column(getErrorDetailColumn())
                 .column(getIssuerDidColumn())
-                .column(getIssuanceProcessIdColumn())
+                .column(getissuerPidColumn())
                 .jsonColumn(getCredentialTypesColumn())
                 .update(getHolderCredentialRequestTable(), getIdColumn());
     }

--- a/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/HolderCredentialRequestStoreStatements.java
+++ b/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/HolderCredentialRequestStoreStatements.java
@@ -59,8 +59,8 @@ public interface HolderCredentialRequestStoreStatements extends StatefulEntitySt
 
     String getSelectStatement();
 
-    default String getIssuanceProcessIdColumn() {
-        return "issuance_process_id";
+    default String getissuerPidColumn() {
+        return "issuer_pid";
     }
 
     default String getPendingColumn() {

--- a/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/SqlHolderCredentialRequestStore.java
+++ b/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/SqlHolderCredentialRequestStore.java
@@ -160,7 +160,7 @@ public class SqlHolderCredentialRequestStore extends AbstractSqlStore implements
                 process.getErrorDetail(),
                 process.getParticipantContextId(),
                 process.getIssuerDid(),
-                process.getIssuanceProcessId(),
+                process.getIssuerPid(),
                 toJson(process.getTypesAndFormats()));
     }
 
@@ -174,7 +174,7 @@ public class SqlHolderCredentialRequestStore extends AbstractSqlStore implements
                 toJson(process.getTraceContext()),
                 process.getErrorDetail(),
                 process.getIssuerDid(),
-                process.getIssuanceProcessId(),
+                process.getIssuerPid(),
                 toJson(process.getTypesAndFormats()),
                 process.getId());
 
@@ -200,8 +200,8 @@ public class SqlHolderCredentialRequestStore extends AbstractSqlStore implements
                 .errorDetail(resultSet.getString(statements.getErrorDetailColumn()))
                 .typesAndFormats(fromJson(resultSet.getString(statements.getCredentialTypesColumn()), getTypeRef()))
                 .issuerDid(resultSet.getString(statements.getIssuerDidColumn()))
-                .issuanceProcessId(resultSet.getString(statements.getIssuanceProcessIdColumn()))
-                .participantContext(resultSet.getString(statements.getParticipantIdColumn()))
+                .issuerPid(resultSet.getString(statements.getissuerPidColumn()))
+                .participantContextId(resultSet.getString(statements.getParticipantIdColumn()))
                 .build();
     }
 }

--- a/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/schema/postgres/HolderCredentialRequestMapping.java
+++ b/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/schema/postgres/HolderCredentialRequestMapping.java
@@ -28,7 +28,7 @@ public class HolderCredentialRequestMapping extends StatefulEntityMapping {
     public static final String FIELD_PARTICIPANT_ID = "participantContextId";
     public static final String FIELD_ISSUER_DID = "issuerDid";
     public static final String FIELD_CREDENTIAL_TYPES = "typesAndFormats";
-    public static final String FIELD_ISSUANCE_PROCESS = "issuanceProcessId";
+    public static final String FIELD_ISSUANCE_PROCESS = "issuerPid";
     public static final String FIELD_PENDING_ISSUANCE = "pending";
 
     public HolderCredentialRequestMapping(HolderCredentialRequestStoreStatements statements) {
@@ -36,7 +36,7 @@ public class HolderCredentialRequestMapping extends StatefulEntityMapping {
         add(FIELD_PARTICIPANT_ID, statements.getParticipantIdColumn());
         add(FIELD_ISSUER_DID, statements.getIssuerDidColumn());
         add(FIELD_CREDENTIAL_TYPES, new JsonFieldTranslator(statements.getCredentialTypesColumn()));
-        add(FIELD_ISSUANCE_PROCESS, statements.getIssuanceProcessIdColumn());
+        add(FIELD_ISSUANCE_PROCESS, statements.getissuerPidColumn());
         add(FIELD_PENDING_ISSUANCE, statements.getPendingColumn());
     }
 }

--- a/extensions/store/sql/holder-credential-request-store-sql/src/main/resources/holder-credential-request-schema.sql
+++ b/extensions/store/sql/holder-credential-request-store-sql/src/main/resources/holder-credential-request-schema.sql
@@ -30,7 +30,7 @@ COMMENT ON COLUMN edc_lease.lease_duration IS 'duration of lease in milliseconds
 
 CREATE TABLE IF NOT EXISTS edc_holder_credentialrequest
 (
-    id                          VARCHAR           NOT NULL PRIMARY KEY,
+    id                          VARCHAR           NOT NULL PRIMARY KEY, -- this is also the holderPid
     state                       INTEGER           NOT NULL,
     state_count                 INTEGER DEFAULT 0 NOT NULL,
     state_time_stamp            BIGINT,
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS edc_holder_credentialrequest
     participant_context_id      VARCHAR           NOT NULL,
     issuer_did                  VARCHAR           NOT NULL,
     types_and_formats            JSON              NOT NULL,
-    issuance_process_id         VARCHAR
+    issuer_pid         VARCHAR
 );
 
 

--- a/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderCredentialRequest.java
+++ b/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderCredentialRequest.java
@@ -35,7 +35,7 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
     private String participantContextId;
     private String issuerDid;
     private Map<String, String> typesAndFormats = new HashMap<>();
-    private String issuanceProcessId;
+    private String issuerPid;
 
     private HolderCredentialRequest() {
         this.state = HolderRequestState.CREATED.code();
@@ -50,9 +50,9 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
     }
 
     /**
-     * This is the unique ID of this request. Identical to {@link HolderCredentialRequest#getId()}
+     * This is the unique ID of this request on the holder side.. Identical to {@link HolderCredentialRequest#getId()}
      */
-    public String getRequestId() {
+    public String getHolderPid() {
         return getId();
     }
 
@@ -67,8 +67,8 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
                 .id(id)
                 .typesAndFormats(Map.copyOf(typesAndFormats))
                 .issuerDid(issuerDid)
-                .participantContext(participantContextId)
-                .issuanceProcessId(issuanceProcessId)
+                .participantContextId(participantContextId)
+                .issuerPid(issuerPid)
                 .errorDetail(errorDetail)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
@@ -110,8 +110,8 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
      * The process ID that the issuer returned in the response to the credential request. Note that this is <strong>not</strong>
      * the ID assigned by the holder, when <em>making</em> the request! This ID is needed for status inquiries, etc.
      */
-    public String getIssuanceProcessId() {
-        return issuanceProcessId;
+    public String getIssuerPid() {
+        return issuerPid;
     }
 
     public static final class Builder extends StatefulEntity.Builder<HolderCredentialRequest, Builder> {
@@ -127,6 +127,11 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
         @Override
         public Builder id(String id) {
             this.entity.id = id;
+            return this;
+        }
+
+        @Override
+        public Builder self() {
             return this;
         }
 
@@ -150,18 +155,13 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
             return this;
         }
 
-        public Builder participantContext(String participantContextId) {
+        public Builder participantContextId(String participantContextId) {
             this.entity.participantContextId = participantContextId;
             return this;
         }
 
-        public Builder issuanceProcessId(String issuanceProcessId) {
-            this.entity.issuanceProcessId = issuanceProcessId;
-            return this;
-        }
-
-        @Override
-        public Builder self() {
+        public Builder issuerPid(String issuerPid) {
+            this.entity.issuerPid = issuerPid;
             return this;
         }
 

--- a/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderRequestState.java
+++ b/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderRequestState.java
@@ -29,7 +29,7 @@ public enum HolderRequestState {
      */
     REQUESTING(200),
     /**
-     * The Issuer sent a response to the {@link HolderCredentialRequest}, and the {@link HolderCredentialRequest#getIssuanceProcessId()}
+     * The Issuer sent a response to the {@link HolderCredentialRequest}, and the {@link HolderCredentialRequest#getIssuerPid()}
      * contains the Issuer-side ID.
      * Note that failed requests transition to the {@link HolderRequestState#ERROR} state
      */

--- a/spi/holder-credential-request-spi/src/testFixtures/java/org/eclipse/edc/identityhub/credential/request/test/HolderCredentialRequestStoreTestBase.java
+++ b/spi/holder-credential-request-spi/src/testFixtures/java/org/eclipse/edc/identityhub/credential/request/test/HolderCredentialRequestStoreTestBase.java
@@ -87,7 +87,7 @@ public abstract class HolderCredentialRequestStoreTestBase {
                 .credentialType("TestCredential", "VC1_0_JWT")
                 .state(CREATED.code())
                 .id("test-id")
-                .participantContext("test-participant")
+                .participantContextId("test-participant")
                 .issuerDid("did:web:testissuer");
     }
 
@@ -441,12 +441,12 @@ public abstract class HolderCredentialRequestStoreTestBase {
         void queryByParticipantContextId() {
 
             range(0, 10)
-                    .mapToObj(i -> createHolderRequestBuilder().id("id" + i).participantContext("participantContext").build())
+                    .mapToObj(i -> createHolderRequestBuilder().id("id" + i).participantContextId("participantContext").build())
                     .forEach(getStore()::save);
 
             var request = createHolderRequestBuilder()
                     .id("testprocess1")
-                    .participantContext("another-participant-context").build();
+                    .participantContextId("another-participant-context").build();
 
             getStore().save(request);
 
@@ -459,7 +459,7 @@ public abstract class HolderCredentialRequestStoreTestBase {
         }
 
         @Test
-        void queryByIssuanceProcessId() {
+        void queryByissuerPid() {
 
             range(0, 10)
                     .mapToObj(i -> createHolderRequest("id" + i))
@@ -467,12 +467,12 @@ public abstract class HolderCredentialRequestStoreTestBase {
 
             var request = createHolderRequestBuilder()
                     .id("testprocess1")
-                    .issuanceProcessId("test-issuance-process").build();
+                    .issuerPid("test-issuance-process").build();
 
             getStore().save(request);
 
             var query = QuerySpec.Builder.newInstance()
-                    .filter(List.of(new Criterion("issuanceProcessId", "=", request.getIssuanceProcessId())))
+                    .filter(List.of(new Criterion("issuerPid", "=", request.getIssuerPid())))
                     .build();
 
             var result = getStore().query(query);

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/CredentialRequestManager.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/CredentialRequestManager.java
@@ -35,9 +35,9 @@ public interface CredentialRequestManager extends StateEntityManager {
      *
      * @param participantContext The Participant Context ID of the requestor
      * @param issuerDid          The DID of the issuer
-     * @param requestId          The holder-defined request ID.
+     * @param holderPid          The holder-defined request ID.
      * @param typesAndFormats    A map containing credential-type - credential-format entries
-     * @return A ServiceResult containing the issuer-assigned process ID, or a failure otherwise.
+     * @return A ServiceResult containing the database ID of the {@code HolderCredentialRequest}.
      */
-    ServiceResult<String> initiateRequest(String participantContext, String issuerDid, String requestId, Map<String, String> typesAndFormats);
+    ServiceResult<String> initiateRequest(String participantContext, String issuerDid, String holderPid, Map<String, String> typesAndFormats);
 }


### PR DESCRIPTION
## What this PR changes/adds

renames `requestId` -> `holderPid` and `issuanceProcessId` -> `issuerPid` to comply with the spec.

## Why it does that

spec compliance

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
