### PR TITLE
feat: add Participant-aware STS

### DIFF
--- a/core/common-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/common-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -75,7 +75,7 @@ public class DefaultServicesExtension implements ServiceExtension {
     public static final String JWS_2020_JSON = "jws2020.json";
     public static final String CREDENTIALS_V_1_JSON = "credentials.v1.json";
 
-    
+
     public static final String NAME = "IdentityHub Default Services Extension";
     public static final long DEFAULT_REVOCATION_CACHE_VALIDITY_MILLIS = 15 * 60 * 1000L;
     static final String ACCESSTOKEN_JTI_VALIDATION_ACTIVATE = "edc.iam.accesstoken.jti.validation";

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -18,7 +18,6 @@ package org.eclipse.edc.identityhub.core;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
-import org.eclipse.edc.iam.identitytrust.spi.SecureTokenService;
 import org.eclipse.edc.iam.identitytrust.spi.verification.SignatureSuiteRegistry;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.RevocationServiceRegistry;
@@ -33,6 +32,7 @@ import org.eclipse.edc.identityhub.core.services.verifiablepresentation.generato
 import org.eclipse.edc.identityhub.core.services.verifiablepresentation.generators.LdpPresentationGenerator;
 import org.eclipse.edc.identityhub.core.services.verification.SelfIssuedTokenVerifierImpl;
 import org.eclipse.edc.identityhub.publickey.KeyPairResourcePublicKeyResolver;
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.credential.request.store.HolderCredentialRequestStore;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.store.KeyPairResourceStore;
@@ -134,7 +134,7 @@ public class CoreServicesExtension implements ServiceExtension {
     @Inject
     private HolderCredentialRequestStore credentialRequestStore;
     @Inject
-    private SecureTokenService secureTokenService;
+    private ParticipantSecureTokenService secureTokenService;
     @Inject
     private EdcHttpClient httpClient;
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequest;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage;
-import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestStatus.Status;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.credential.request.model.HolderCredentialRequest;
 import org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState;

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -178,6 +178,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
                 .did(manifest.getDid())
                 .apiTokenAlias("%s-%s".formatted(manifest.getParticipantId(), API_KEY_ALIAS_SUFFIX))
                 .state(ParticipantContextState.CREATED)
+                .properties(manifest.getAdditionalProperties())
                 .build();
     }
 }

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/fixtures/IdentityHubEndToEndTestContext.java
@@ -116,7 +116,7 @@ public class IdentityHubEndToEndTestContext {
                 .participantContextId(participantContextId)
                 .holderId("holderId")
                 .issuerId("issuerId")
-                .credential(new VerifiableCredentialContainer("rawVc", CredentialFormat.JWT, credential))
+                .credential(new VerifiableCredentialContainer("rawVc", CredentialFormat.VC1_0_JWT, credential))
                 .build();
         runtime.getService(CredentialStore.class).create(resource).orElseThrow(f -> new EdcException(f.getFailureDetail()));
         return resource.getId();

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-02-21T12:00:00Z",
+    "lastUpdated": "2025-02-21T14:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/BaseSqlDialectStatements.java
@@ -32,6 +32,7 @@ public class BaseSqlDialectStatements implements ParticipantContextStoreStatemen
                 .column(getApiTokenAliasColumn())
                 .column(getDidColumn())
                 .jsonColumn(getRolesRolumn())
+                .jsonColumn(getPropertiesColumn())
                 .insertInto(getParticipantContextTable());
     }
 
@@ -45,6 +46,7 @@ public class BaseSqlDialectStatements implements ParticipantContextStoreStatemen
                 .column(getApiTokenAliasColumn())
                 .column(getDidColumn())
                 .jsonColumn(getRolesRolumn())
+                .jsonColumn(getPropertiesColumn())
                 .update(getParticipantContextTable(), getIdColumn());
     }
 

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/ParticipantContextStoreStatements.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/ParticipantContextStoreStatements.java
@@ -55,6 +55,10 @@ public interface ParticipantContextStoreStatements extends SqlStatements {
         return "roles";
     }
 
+    default String getPropertiesColumn() {
+        return "properties";
+    }
+
     String getInsertTemplate();
 
     String getUpdateTemplate();

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/SqlParticipantContextStore.java
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/participantcontext/SqlParticipantContextStore.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.store.sql.participantcontext;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
@@ -32,6 +31,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.eclipse.edc.spi.result.StoreResult.alreadyExists;
@@ -43,8 +43,6 @@ import static org.eclipse.edc.spi.result.StoreResult.success;
  */
 public class SqlParticipantContextStore extends AbstractSqlStore implements ParticipantContextStore {
 
-    private static final TypeReference<List<String>> LIST_REF = new TypeReference<>() {
-    };
     private final ParticipantContextStoreStatements statements;
 
     public SqlParticipantContextStore(DataSourceRegistry dataSourceRegistry,
@@ -74,7 +72,8 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                         participantContext.getState(),
                         participantContext.getApiTokenAlias(),
                         participantContext.getDid(),
-                        toJson(participantContext.getRoles())
+                        toJson(participantContext.getRoles()),
+                        toJson(participantContext.getProperties())
                 );
                 return success();
 
@@ -114,6 +113,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                             participantContext.getApiTokenAlias(),
                             participantContext.getDid(),
                             toJson(participantContext.getRoles()),
+                            toJson(participantContext.getProperties()),
                             id);
                     return StoreResult.success();
                 }
@@ -156,7 +156,8 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
         var state = resultSet.getInt(statements.getStateColumn());
         var tokenAliase = resultSet.getString(statements.getApiTokenAliasColumn());
         var did = resultSet.getString(statements.getDidColumn());
-        var roles = fromJson(resultSet.getString(statements.getRolesRolumn()), LIST_REF);
+        List<String> roles = fromJson(resultSet.getString(statements.getRolesRolumn()), getTypeRef());
+        Map<String, Object> props = fromJson(resultSet.getString(statements.getPropertiesColumn()), getTypeRef());
 
         return ParticipantContext.Builder.newInstance()
                 .participantContextId(id)
@@ -166,6 +167,7 @@ public class SqlParticipantContextStore extends AbstractSqlStore implements Part
                 .apiTokenAlias(tokenAliase)
                 .did(did)
                 .roles(roles)
+                .properties(props)
                 .build();
     }
 }

--- a/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/resources/participant-schema.sql
+++ b/extensions/store/sql/identity-hub-participantcontext-store-sql/src/main/resources/participant-schema.sql
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS participant_context
     state              INTEGER             NOT NULL, -- 0 = CREATED, 1 = ACTIVE, 2 = DEACTIVATED
     api_token_alias    VARCHAR             NOT NULL, -- alias under which this PC's api token is stored in the vault
     did                VARCHAR,                      -- the DID with which this participant is identified
-    roles              JSON                          -- JSON array containing all the roles a user has. may be empty
+    roles              JSON,                         -- JSON array containing all the roles a user has. may be empty
+    properties         JSON DEFAULT '{}'             -- JSON object containing additional information, such as OAuth2 client secret aliases
 );
 CREATE UNIQUE INDEX IF NOT EXISTS participant_context_participant_context_id_uindex ON participant_context USING btree (participant_context_id);
 

--- a/extensions/sts/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerImpl.java
+++ b/extensions/sts/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerImpl.java
@@ -34,8 +34,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-import static java.util.Optional.ofNullable;
-
 /**
  * AccountProvisioner, that synchronizes the {@link org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext} object
  * to {@link StsAccount} entries. That means, when a participant is created, this provisioner takes care of creating a corresponding
@@ -79,9 +77,7 @@ public class StsAccountProvisionerImpl implements EventSubscriber, StsAccountPro
     @Override
     public ServiceResult<AccountInfo> create(ParticipantManifest manifest) {
 
-        var secretAlias = ofNullable(manifest.getProperty(CLIENT_SECRET_PROPERTY))
-                .map(Object::toString)
-                .orElseGet(() -> manifest.getParticipantId() + "-sts-client-secret");
+        var secretAlias = manifest.clientSecretAlias();
         var createResult = stsAccountService.createAccount(manifest, secretAlias)
                 .map(v -> stsClientSecretGenerator.generateClientSecret(null))
                 .map(secret -> new AccountInfo(manifest.getDid(), secret))

--- a/extensions/sts/sts-account-service-local/build.gradle.kts
+++ b/extensions/sts/sts-account-service-local/build.gradle.kts
@@ -20,8 +20,9 @@ plugins {
 dependencies {
 
     api(project(":spi:participant-context-spi"))
+    api(project(":spi:identity-hub-spi")) // participant STS
+    api(project(":spi:keypair-spi")) // keypair resource store
     implementation(libs.edc.lib.token)
-    implementation(libs.edc.sts)
     implementation(libs.edc.sts.spi)
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.transaction)

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/AccessTokenDecorator.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/AccessTokenDecorator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2025 Cofinity-X
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Cofinity-X - initial API and implementation
  *
  */
 

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/AccessTokenDecorator.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/AccessTokenDecorator.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.eclipse.edc.spi.iam.TokenParameters;
+import org.eclipse.edc.token.spi.TokenDecorator;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.JWT_ID;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.NOT_BEFORE;
+
+/**
+ * Opinionated decorator that adds "jti", "iat", "nbf" and "exp" claims to an existing set of claims, overwriting if the aforementioned
+ * are already contained in the map.
+ */
+class AccessTokenDecorator implements TokenDecorator {
+
+    private final String jti;
+    private final Instant now;
+    private final Instant expiration;
+    private final Map<String, String> claims;
+
+    AccessTokenDecorator(String jti, Instant now, Instant expiration, Map<String, String> claims) {
+        this.jti = jti;
+        this.now = now;
+        this.expiration = expiration;
+        this.claims = claims;
+    }
+
+    @Override
+    public TokenParameters.Builder decorate(TokenParameters.Builder tokenParameters) {
+        this.claims.forEach(tokenParameters::claims);
+        return tokenParameters
+                .claims(ISSUED_AT, Date.from(now))
+                .claims(NOT_BEFORE, Date.from(now))
+                .claims(EXPIRATION_TIME, Date.from(expiration))
+                .claims(JWT_ID, jti);
+    }
+}

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/EmbeddedSecureTokenService.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/EmbeddedSecureTokenService.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
+import org.eclipse.edc.identityhub.spi.participantcontext.StsAccountService;
+import org.eclipse.edc.jwt.validation.jti.JtiValidationEntry;
+import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.token.spi.KeyIdDecorator;
+import org.eclipse.edc.token.spi.TokenGenerationService;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUER;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SCOPE;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.SUBJECT;
+import static org.eclipse.edc.spi.result.Result.failure;
+import static org.eclipse.edc.spi.result.Result.success;
+
+public class EmbeddedSecureTokenService implements ParticipantSecureTokenService {
+    public static final String PRESENTATION_TOKEN_CLAIM = "token";
+    public static final String BEARER_ACCESS_SCOPE = "bearer_access_scope";
+    private static final List<String> ACCESS_TOKEN_INHERITED_CLAIMS = List.of(ISSUER);
+    private final TransactionContext transactionContext;
+    private final long tokenValiditySeconds;
+    private final JtiValidationStore jtiValidationStore;
+    private final TokenGenerationService tokenGenerationService;
+    private final Clock clock;
+    private final StsAccountService stsAccountService;
+
+    public EmbeddedSecureTokenService(TransactionContext transactionContext,
+                                      long tokenValiditySeconds,
+                                      JtiValidationStore jtiValidationStore,
+                                      TokenGenerationService tokenGenerationService,
+                                      Clock clock, StsAccountService stsAccountService) {
+        this.transactionContext = transactionContext;
+        this.tokenValiditySeconds = tokenValiditySeconds;
+        this.jtiValidationStore = jtiValidationStore;
+        this.tokenGenerationService = tokenGenerationService;
+        this.clock = clock;
+        this.stsAccountService = stsAccountService;
+    }
+
+    @Override
+    public Result<TokenRepresentation> createToken(String participantContextId, Map<String, String> claims, @Nullable String bearerAccessScope) {
+
+        return transactionContext.execute(() -> {
+            var result = stsAccountService.findById(participantContextId);
+            if (result.failed()) {
+                return Result.failure(result.getFailureDetail());
+            }
+
+
+            var keypair = result.getContent();
+
+            var keyId = keypair.getPublicKeyReference();
+            var privateKeyAlias = keypair.getPrivateKeyAlias();
+            var selfIssuedClaims = new HashMap<>(claims);
+
+            return ofNullable(bearerAccessScope)
+                    .map(scope -> createAndAcceptAccessToken(claims, scope, selfIssuedClaims::put, keyId, privateKeyAlias))
+                    .orElse(success())
+                    .compose(v -> {
+                        var keyIdDecorator = new KeyIdDecorator(keyId);
+                        return tokenGenerationService.generate(privateKeyAlias, keyIdDecorator, new SelfIssuedTokenDecorator(selfIssuedClaims, clock, tokenValiditySeconds));
+                    });
+        });
+
+    }
+
+    private Result<Void> recordToken(String jti, Long exp) {
+        var storeResult = jtiValidationStore.storeEntry(new JtiValidationEntry(jti, exp));
+        return storeResult.succeeded()
+                ? Result.success()
+                : failure("error storing JTI for later validation: %s".formatted(storeResult.getFailureDetail()));
+    }
+
+    private Result<Void> createAndAcceptAccessToken(Map<String, String> claims, String scope, BiConsumer<String, String> consumer, String keyId, String privateKeyAlias) {
+        return createAccessToken(claims, scope, keyId, privateKeyAlias)
+                .compose(tokenRepresentation -> success(tokenRepresentation.getToken()))
+                .onSuccess(withClaim(PRESENTATION_TOKEN_CLAIM, consumer))
+                .mapEmpty();
+    }
+
+    private Result<TokenRepresentation> createAccessToken(Map<String, String> claims, String bearerAccessScope, String keyId, String privateKeyAlias) {
+        var accessTokenClaims = new HashMap<>(accessTokenInheritedClaims(claims));
+        var now = clock.instant();
+        var exp = now.plusSeconds(tokenValiditySeconds);
+        var jti = "accesstoken-%s".formatted(UUID.randomUUID());
+
+        accessTokenClaims.put(SCOPE, bearerAccessScope);
+
+        return addClaim(claims, ISSUER, withClaim(AUDIENCE, accessTokenClaims::put))
+                .compose(v -> addClaim(claims, AUDIENCE, withClaim(SUBJECT, accessTokenClaims::put)))
+                .compose(v -> {
+                    var keyIdDecorator = new KeyIdDecorator(keyId);
+                    return tokenGenerationService.generate(privateKeyAlias, keyIdDecorator, new AccessTokenDecorator(jti, now, exp, accessTokenClaims));
+                }).compose(tr -> recordToken(jti, exp.toEpochMilli()).map(v -> tr));
+
+    }
+
+    private Result<Void> addClaim(Map<String, String> claims, String claim, Consumer<String> consumer) {
+        var claimValue = claims.get(claim);
+        if (claimValue != null) {
+            consumer.accept(claimValue);
+            return success();
+        } else {
+            return failure(format("Missing %s in the input claims", claim));
+        }
+    }
+
+    private Consumer<String> withClaim(String key, BiConsumer<String, String> consumer) {
+        return (value) -> consumer.accept(key, value);
+    }
+
+    private Map<String, String> accessTokenInheritedClaims(Map<String, String> claims) {
+        return claims.entrySet().stream()
+                .filter(entry -> ACCESS_TOKEN_INHERITED_CLAIMS.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/LocalStsServiceExtension.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/LocalStsServiceExtension.java
@@ -14,8 +14,8 @@
 
 package org.eclipse.edc.identityhub.sts;
 
-import org.eclipse.edc.iam.identitytrust.spi.SecureTokenService;
-import org.eclipse.edc.iam.identitytrust.sts.embedded.EmbeddedSecureTokenService;
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
+import org.eclipse.edc.identityhub.spi.participantcontext.StsAccountService;
 import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
@@ -25,6 +25,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.JwtGenerationService;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
@@ -43,12 +44,12 @@ public class LocalStsServiceExtension implements ServiceExtension {
     @Inject
     private JwsSignerProvider externalSigner;
 
-    @Setting(description = "Alias of private key used for signing tokens, retrieved from private key resolver. Required when using Embedded STS", key = "edc.iam.sts.privatekey.alias", required = true)
-    private String privateKeyAlias;
-    @Setting(description = "Key Identifier used by the counterparty to resolve the public key for token validation, e.g. did:example:123#public-key-1. Required when using Embedded STS", key = "edc.iam.sts.publickey.id", required = true)
-    private String publicKeyId;
     @Setting(description = "Self-issued ID Token expiration in minutes. By default is 5 minutes", defaultValue = "" + DEFAULT_STS_TOKEN_EXPIRATION_MIN, key = "edc.iam.sts.token.expiration")
     private long stsTokenExpirationMin;
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private StsAccountService stsAccountService;
 
     @Override
     public String name() {
@@ -56,15 +57,7 @@ public class LocalStsServiceExtension implements ServiceExtension {
     }
 
     @Provider
-    public SecureTokenService createDefaultTokenService(ServiceExtensionContext context) {
-        context.getMonitor().info("Using the Embedded STS client, as no other implementation was provided.");
-
-        if (context.getSetting("edc.oauth.token.url", null) != null) {
-            context.getMonitor().warning("The property '%s' was configured, but no remote SecureTokenService was found on the classpath. ".formatted("edc.oauth.token.url") +
-                    "This could be an indication of a configuration problem.");
-        }
-
-        //todo: this must be replaced with an Embedded STS, that can resolve the key IDs/aliases dynamically based on the participant context
-        return new EmbeddedSecureTokenService(new JwtGenerationService(externalSigner), () -> privateKeyAlias, () -> publicKeyId, clock, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), jtiValidationStore);
+    public ParticipantSecureTokenService createDefaultTokenService(ServiceExtensionContext context) {
+        return new EmbeddedSecureTokenService(transactionContext, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), jtiValidationStore, new JwtGenerationService(externalSigner), clock, stsAccountService);
     }
 }

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/LocalStsServiceExtension.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/LocalStsServiceExtension.java
@@ -23,7 +23,6 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
@@ -57,7 +56,7 @@ public class LocalStsServiceExtension implements ServiceExtension {
     }
 
     @Provider
-    public ParticipantSecureTokenService createDefaultTokenService(ServiceExtensionContext context) {
+    public ParticipantSecureTokenService createDefaultTokenService() {
         return new EmbeddedSecureTokenService(transactionContext, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), jtiValidationStore, new JwtGenerationService(externalSigner), clock, stsAccountService);
     }
 }

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/SelfIssuedTokenDecorator.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/SelfIssuedTokenDecorator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2025 Cofinity-X
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       Cofinity-X - initial API and implementation
  *
  */
 

--- a/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/SelfIssuedTokenDecorator.java
+++ b/extensions/sts/sts-account-service-local/src/main/java/org/eclipse/edc/identityhub/sts/SelfIssuedTokenDecorator.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.eclipse.edc.spi.iam.TokenParameters;
+import org.eclipse.edc.token.spi.TokenDecorator;
+
+import java.time.Clock;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.JWT_ID;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.NOT_BEFORE;
+
+/**
+ * Decorator for Self-Issued ID token and Access Token. It appends input claims and
+ * generic claims like iat, exp, and jti
+ */
+class SelfIssuedTokenDecorator implements TokenDecorator {
+    private final Map<String, String> claims;
+    private final Clock clock;
+    private final long validity;
+
+    SelfIssuedTokenDecorator(Map<String, String> claims, Clock clock, long validity) {
+        this.claims = claims;
+        this.clock = clock;
+        this.validity = validity;
+    }
+
+    @Override
+    public TokenParameters.Builder decorate(TokenParameters.Builder tokenParameters) {
+        this.claims.forEach(tokenParameters::claims);
+        return tokenParameters.claims(ISSUED_AT, Date.from(clock.instant()))
+                .claims(NOT_BEFORE, Date.from(clock.instant()))
+                .claims(EXPIRATION_TIME, Date.from(clock.instant().plusSeconds(validity)))
+                .claims(JWT_ID, UUID.randomUUID().toString());
+    }
+}

--- a/extensions/sts/sts-account-service-local/src/test/java/org/eclipse/edc/identityhub/sts/EmbeddedSecureTokenServiceTest.java
+++ b/extensions/sts/sts-account-service-local/src/test/java/org/eclipse/edc/identityhub/sts/EmbeddedSecureTokenServiceTest.java
@@ -1,0 +1,173 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.eclipse.edc.iam.identitytrust.sts.spi.model.StsAccount;
+import org.eclipse.edc.identityhub.spi.participantcontext.StsAccountService;
+import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.token.spi.KeyIdDecorator;
+import org.eclipse.edc.token.spi.TokenDecorator;
+import org.eclipse.edc.token.spi.TokenGenerationService;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Clock;
+import java.util.Map;
+
+import static com.nimbusds.jwt.JWTClaimNames.AUDIENCE;
+import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EmbeddedSecureTokenServiceTest {
+    public static final String TEST_PRIVATEKEY_ID = "test-privatekey-id";
+    public static final String TEST_PARTICIPANT = "test-participant";
+    private final TokenGenerationService tokenGenerationService = mock();
+    private final JtiValidationStore jtiValidationStore = mock();
+    private final StsAccountService stsAccountService = mock();
+    private final EmbeddedSecureTokenService sts = new EmbeddedSecureTokenService(new NoopTransactionContext(), 10 * 60, jtiValidationStore, tokenGenerationService, Clock.systemUTC(), stsAccountService);
+
+    @BeforeEach
+    void setup() {
+        when(jtiValidationStore.storeEntry(any())).thenReturn(StoreResult.success());
+        when(stsAccountService.findById(anyString())).thenReturn(
+                ServiceResult.success(StsAccount.Builder.newInstance()
+                        .id("key-pair-id")
+                        .privateKeyAlias(TEST_PRIVATEKEY_ID)
+                        .publicKeyReference("key-id")
+                        .clientId(TEST_PRIVATEKEY_ID)
+                        .secretAlias(TEST_PARTICIPANT + "-alias")
+                        .name(TEST_PARTICIPANT)
+                        .did("did:web:" + TEST_PARTICIPANT)
+                        .build()));
+    }
+
+    @Test
+    void createToken_withoutBearerAccessScope() {
+        var token = TokenRepresentation.Builder.newInstance().token("test").build();
+
+        when(tokenGenerationService.generate(eq(TEST_PRIVATEKEY_ID), any(TokenDecorator[].class))).thenReturn(Result.success(token));
+        var result = sts.createToken(TEST_PARTICIPANT, Map.of(), null);
+
+        assertThat(result.succeeded()).isTrue();
+        var captor = ArgumentCaptor.forClass(TokenDecorator[].class);
+
+        verify(tokenGenerationService).generate(any(), captor.capture());
+
+        assertThat(captor.getAllValues()).hasSize(1)
+                .allSatisfy(decorators -> {
+                    assertThat(decorators).hasSize(2)
+                            .hasOnlyElementsOfTypes(KeyIdDecorator.class, SelfIssuedTokenDecorator.class);
+                });
+
+    }
+
+    @Test
+    void createToken_withBearerAccessScope() {
+
+        var claims = Map.of(ISSUER, "testIssuer", AUDIENCE, "aud");
+        var token = TokenRepresentation.Builder.newInstance().token("test").build();
+
+        when(tokenGenerationService.generate(eq(TEST_PRIVATEKEY_ID), any(TokenDecorator[].class)))
+                .thenReturn(Result.success(token))
+                .thenReturn(Result.success(token));
+
+
+        var result = sts.createToken(TEST_PARTICIPANT, claims, "scope:test");
+
+        assertThat(result.succeeded()).isTrue();
+        var captor = ArgumentCaptor.forClass(TokenDecorator[].class);
+
+        verify(tokenGenerationService, times(2)).generate(any(), captor.capture());
+
+        assertThat(captor.getAllValues()).hasSize(2)
+                .satisfies(decorators -> {
+                    assertThat(decorators.get(0))
+                            .hasSize(2)
+                            .hasOnlyElementsOfTypes(KeyIdDecorator.class, AccessTokenDecorator.class, SelfIssuedTokenDecorator.class);
+
+                    assertThat(decorators.get(1))
+                            .hasSize(2)
+                            .hasOnlyElementsOfTypes(KeyIdDecorator.class, AccessTokenDecorator.class, SelfIssuedTokenDecorator.class);
+                });
+
+    }
+
+    @Test
+    void createToken_error_whenAccessTokenFails() {
+
+        var claims = Map.of(ISSUER, "testIssuer", AUDIENCE, "aud");
+
+        var token = TokenRepresentation.Builder.newInstance().token("test").build();
+
+        when(tokenGenerationService.generate(eq(TEST_PRIVATEKEY_ID), any(TokenDecorator[].class)))
+                .thenReturn(Result.failure("Failed to create access token"))
+                .thenReturn(Result.success(token));
+
+        var result = sts.createToken(TEST_PARTICIPANT, claims, "scope:test");
+
+        assertThat(result.failed()).isTrue();
+        var captor = ArgumentCaptor.forClass(TokenDecorator[].class);
+
+        verify(tokenGenerationService, times(1)).generate(any(), captor.capture());
+
+        assertThat(captor.getValue())
+                .hasSize(2)
+                .hasOnlyElementsOfTypes(SelfIssuedTokenDecorator.class, AccessTokenDecorator.class, KeyIdDecorator.class);
+
+    }
+
+    @Test
+    void createToken_error_whenSelfTokenFails() {
+        var claims = Map.of(ISSUER, "testIssuer", AUDIENCE, "aud");
+
+        var token = TokenRepresentation.Builder.newInstance().token("test").build();
+
+        when(tokenGenerationService.generate(eq(TEST_PRIVATEKEY_ID), any(TokenDecorator[].class)))
+                .thenReturn(Result.success(token))
+                .thenReturn(Result.failure("Failed to create access token"));
+
+
+        var result = sts.createToken(TEST_PARTICIPANT, claims, "scope:test");
+
+        assertThat(result.failed()).isTrue();
+
+        verify(tokenGenerationService, times(2)).generate(eq(TEST_PRIVATEKEY_ID), any(TokenDecorator[].class));
+
+    }
+
+    @Test
+    void createToken_whenStsAccountNotfound_expectFailure() {
+        when(stsAccountService.findById(anyString())).thenReturn(ServiceResult.notFound("foobar"));
+
+        var result = sts.createToken(TEST_PARTICIPANT, Map.of(), null);
+        assertThat(result).isFailed()
+                .detail()
+                .isEqualTo("foobar");
+    }
+}

--- a/extensions/sts/sts-account-service-remote/build.gradle.kts
+++ b/extensions/sts/sts-account-service-remote/build.gradle.kts
@@ -19,6 +19,9 @@ plugins {
 
 dependencies {
     api(project(":spi:participant-context-spi"))
+    api(project(":spi:identity-hub-spi")) // participant STS
+    api(libs.edc.spi.oauth2) // OAuth2 client
+    implementation(libs.edc.spi.transaction)
     implementation(libs.edc.sts.spi)
     implementation(libs.edc.spi.core)
     implementation(libs.edc.spi.http)

--- a/extensions/sts/sts-account-service-remote/src/main/java/org/eclipse/edc/identityhub/sts/RemoteSecureTokenService.java
+++ b/extensions/sts/sts-account-service-remote/src/main/java/org/eclipse/edc/identityhub/sts/RemoteSecureTokenService.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2CredentialsRequest;
+import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
+import org.eclipse.edc.identityhub.spi.participantcontext.StsAccountService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
+
+public class RemoteSecureTokenService implements ParticipantSecureTokenService {
+    public static final String PRESENTATION_TOKEN_CLAIM = "token";
+    public static final String BEARER_ACCESS_SCOPE = "bearer_access_scope";
+    public static final String GRANT_TYPE = "client_credentials";
+    public static final String AUDIENCE_PARAM = "audience";
+
+    private static final Map<String, String> CLAIM_MAPPING = Map.of(
+            AUDIENCE, AUDIENCE_PARAM,
+            PRESENTATION_TOKEN_CLAIM, PRESENTATION_TOKEN_CLAIM);
+
+
+    private final Oauth2Client oauth2Client;
+    private final TransactionContext transactionContext;
+    private final Vault vault;
+    private final String tokenUrl;
+    private final StsAccountService stsAccountService;
+
+    public RemoteSecureTokenService(Oauth2Client oauth2Client, TransactionContext transactionContext, Vault vault, String tokenUrl, StsAccountService stsAccountService) {
+        this.oauth2Client = oauth2Client;
+        this.transactionContext = transactionContext;
+        this.vault = vault;
+        this.tokenUrl = tokenUrl;
+        this.stsAccountService = stsAccountService;
+    }
+
+    @Override
+    public Result<TokenRepresentation> createToken(String participantContextId, Map<String, String> claims, @Nullable String bearerAccessScope) {
+        return transactionContext.execute(() -> {
+            var result = stsAccountService.findById(participantContextId);
+            if (result.failed()) {
+                return Result.failure(result.getFailureDetail());
+            }
+            var stsAccount = result.getContent();
+            return createRequest(stsAccount.getClientId(), stsAccount.getSecretAlias(), claims, bearerAccessScope)
+                    .compose(oauth2Client::requestToken);
+        });
+    }
+
+    @NotNull
+    private Result<Oauth2CredentialsRequest> createRequest(String clientId, String clientSecretAlias, Map<String, String> claims, @Nullable String bearerAccessScope) {
+
+        var secret = vault.resolveSecret(clientSecretAlias);
+        if (secret != null) {
+            var builder = SharedSecretOauth2CredentialsRequest.Builder.newInstance()
+                    .url(tokenUrl)
+                    .clientId(clientId)
+                    .clientSecret(secret)
+                    .grantType(GRANT_TYPE);
+
+            var additionalParams = claims.entrySet().stream()
+                    .filter(entry -> CLAIM_MAPPING.containsKey(entry.getKey()))
+                    .map(entry -> Map.entry(CLAIM_MAPPING.get(entry.getKey()), entry.getValue()))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (bearerAccessScope != null) {
+                additionalParams.put(BEARER_ACCESS_SCOPE, bearerAccessScope);
+            }
+
+            builder.params(additionalParams);
+            return Result.success(builder.build());
+        } else {
+            return Result.failure("Failed to fetch client secret from the vault with alias: %s".formatted(clientSecretAlias));
+        }
+    }
+}

--- a/extensions/sts/sts-account-service-remote/src/main/java/org/eclipse/edc/identityhub/sts/RemoteStsServiceExtension.java
+++ b/extensions/sts/sts-account-service-remote/src/main/java/org/eclipse/edc/identityhub/sts/RemoteStsServiceExtension.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
+import org.eclipse.edc.identityhub.spi.participantcontext.StsAccountService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import static org.eclipse.edc.identityhub.sts.RemoteStsServiceExtension.NAME;
+
+@Extension(value = NAME)
+public class RemoteStsServiceExtension implements ServiceExtension {
+    public static final String NAME = "Remote Secure Token Service extension";
+
+    @Setting(key = "edc.iam.sts.oauth.token.url", description = "STS OAuth2 endpoint for requesting a token")
+    private String tokenUrl;
+
+    @Inject
+    private Oauth2Client oauth2Client;
+
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private Vault vault;
+    @Inject
+    private StsAccountService stsAccountService;
+
+    @Provider
+    public ParticipantSecureTokenService createRemoteSecureTokenService() {
+        return new RemoteSecureTokenService(oauth2Client, transactionContext, vault, tokenUrl, stsAccountService);
+    }
+}

--- a/extensions/sts/sts-account-service-remote/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/sts/sts-account-service-remote/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -13,3 +13,4 @@
 #
 
 org.eclipse.edc.identityhub.sts.accountservice.RemoteStsAccountServiceExtension
+org.eclipse.edc.identityhub.sts.RemoteStsServiceExtension

--- a/extensions/sts/sts-account-service-remote/src/test/java/org/eclipse/edc/identityhub/sts/RemoteSecureTokenServiceTest.java
+++ b/extensions/sts/sts-account-service-remote/src/test/java/org/eclipse/edc/identityhub/sts/RemoteSecureTokenServiceTest.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.sts;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.edc.iam.identitytrust.sts.spi.model.StsAccount;
+import org.eclipse.edc.iam.oauth2.spi.client.Oauth2Client;
+import org.eclipse.edc.iam.oauth2.spi.client.SharedSecretOauth2CredentialsRequest;
+import org.eclipse.edc.identityhub.spi.participantcontext.StsAccountService;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.eclipse.edc.identityhub.sts.RemoteSecureTokenService.AUDIENCE_PARAM;
+import static org.eclipse.edc.identityhub.sts.RemoteSecureTokenService.BEARER_ACCESS_SCOPE;
+import static org.eclipse.edc.identityhub.sts.RemoteSecureTokenService.GRANT_TYPE;
+import static org.eclipse.edc.identityhub.sts.RemoteSecureTokenService.PRESENTATION_TOKEN_CLAIM;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RemoteSecureTokenServiceTest {
+    public static final String TEST_SECRET_ALIAS = "test-secret-alias";
+    public static final String TOKEN_URL = "http://foo.com/auth/token";
+    private static final String PARTICIPANT_ID = "test-participant";
+    private final Oauth2Client oauth2Client = mock();
+    private final Vault vault = mock();
+    private final StsAccountService stsAccountService = mock();
+    private RemoteSecureTokenService secureTokenService;
+
+    @BeforeEach
+    void setup() {
+        secureTokenService = new RemoteSecureTokenService(oauth2Client, new NoopTransactionContext(), vault, TOKEN_URL, stsAccountService);
+        when(stsAccountService.findById(PARTICIPANT_ID)).thenReturn(ServiceResult.success(StsAccount.Builder.newInstance()
+                .id(UUID.randomUUID().toString())
+                .name(PARTICIPANT_ID)
+                .did("did:web:test")
+                .privateKeyAlias("privateKeyAlias")
+                .publicKeyReference("public-key")
+                .clientId(PARTICIPANT_ID)
+                .secretAlias(TEST_SECRET_ALIAS)
+                .build()));
+    }
+
+    @Test
+    void createToken() {
+        var audience = "aud";
+        var secret = "secret";
+        when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(eq(TEST_SECRET_ALIAS))).thenReturn(secret);
+
+        assertThat(secureTokenService.createToken(PARTICIPANT_ID, Map.of(AUDIENCE, audience), null)).isSucceeded();
+
+        var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
+        verify(oauth2Client).requestToken(captor.capture());
+
+        Assertions.assertThat(captor.getValue()).satisfies(request -> {
+            Assertions.assertThat(request.getUrl()).isEqualTo(TOKEN_URL);
+            Assertions.assertThat(request.getClientId()).isEqualTo(PARTICIPANT_ID);
+            Assertions.assertThat(request.getGrantType()).isEqualTo(GRANT_TYPE);
+            Assertions.assertThat(request.getClientSecret()).isEqualTo(secret);
+            Assertions.assertThat(request.getParams())
+                    .containsEntry(AUDIENCE_PARAM, audience);
+        });
+    }
+
+    @Test
+    void createToken_withAccessScope() {
+        var audience = "aud";
+        var bearerAccessScope = "scope";
+        var secret = "secret";
+
+        when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(eq(TEST_SECRET_ALIAS))).thenReturn(secret);
+
+        assertThat(secureTokenService.createToken(PARTICIPANT_ID, Map.of(AUDIENCE, audience), bearerAccessScope)).isSucceeded();
+
+        var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
+        verify(oauth2Client).requestToken(captor.capture());
+
+        Assertions.assertThat(captor.getValue()).satisfies(request -> {
+            Assertions.assertThat(request.getUrl()).isEqualTo(TOKEN_URL);
+            Assertions.assertThat(request.getClientId()).isEqualTo(PARTICIPANT_ID);
+            Assertions.assertThat(request.getGrantType()).isEqualTo(GRANT_TYPE);
+            Assertions.assertThat(request.getClientSecret()).isEqualTo(secret);
+            Assertions.assertThat(request.getParams())
+                    .containsEntry(AUDIENCE_PARAM, audience)
+                    .containsEntry(BEARER_ACCESS_SCOPE, bearerAccessScope);
+        });
+    }
+
+    @Test
+    void createToken_withAccessToken() {
+        var audience = "aud";
+        var accessToken = "accessToken";
+        var secret = "secret";
+
+        when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(eq(TEST_SECRET_ALIAS))).thenReturn(secret);
+
+        assertThat(secureTokenService.createToken(PARTICIPANT_ID, Map.of(AUDIENCE, audience, PRESENTATION_TOKEN_CLAIM, accessToken), null)).isSucceeded();
+
+        var captor = ArgumentCaptor.forClass(SharedSecretOauth2CredentialsRequest.class);
+        verify(oauth2Client).requestToken(captor.capture());
+
+        Assertions.assertThat(captor.getValue()).satisfies(request -> {
+            Assertions.assertThat(request.getUrl()).isEqualTo(TOKEN_URL);
+            Assertions.assertThat(request.getClientId()).isEqualTo(PARTICIPANT_ID);
+            Assertions.assertThat(request.getGrantType()).isEqualTo(GRANT_TYPE);
+            Assertions.assertThat(request.getClientSecret()).isEqualTo(secret);
+            Assertions.assertThat(request.getParams())
+                    .containsEntry(AUDIENCE_PARAM, audience)
+                    .containsEntry(PRESENTATION_TOKEN_CLAIM, accessToken);
+        });
+    }
+
+    @Test
+    void createToken_shouldFail_whenSecretIsNotPresent() {
+        var audience = "aud";
+        var accessToken = "accessToken";
+
+        when(oauth2Client.requestToken(any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().build()));
+        when(vault.resolveSecret(eq(TEST_SECRET_ALIAS))).thenReturn(null);
+
+        assertThat(secureTokenService.createToken(PARTICIPANT_ID, Map.of(AUDIENCE, audience, PRESENTATION_TOKEN_CLAIM, accessToken), null))
+                .isFailed()
+                .detail().isEqualTo(format("Failed to fetch client secret from the vault with alias: %s", TEST_SECRET_ALIAS));
+
+    }
+
+    @Test
+    void createToken_whenNoStsAccount_expectFailure() {
+        when(stsAccountService.findById(PARTICIPANT_ID)).thenReturn(ServiceResult.notFound("foo"));
+
+        assertThat(secureTokenService.createToken(PARTICIPANT_ID, Map.of(AUDIENCE, "audience"), null)).isFailed()
+                .detail()
+                .isEqualTo("foo");
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ edc-spi-web = { module = "org.eclipse.edc:web-spi", version.ref = "edc" }
 edc-spi-token = { module = "org.eclipse.edc:token-spi", version.ref = "edc" }
 edc-spi-dcp = { module = "org.eclipse.edc:identity-trust-spi", version.ref = "edc" }
 edc-spi-vc = { module = "org.eclipse.edc:verifiable-credentials-spi", version.ref = "edc" }
+edc-spi-oauth2 = { module = "org.eclipse.edc:oauth2-spi", version.ref = "edc" }
 edc-core-connector = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
 edc-core-token = { module = "org.eclipse.edc:token-core", version.ref = "edc" }
 edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/build.gradle.kts
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
 }
 
 dependencies {
+    api(project(":spi:identity-hub-spi"))
     api(project(":spi:verifiable-credential-spi"))
     api(project(":spi:issuerservice:issuerservice-participant-spi"))
     api(project(":spi:issuerservice:issuerservice-issuance-spi"))

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerCoreExtension.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerCoreExtension.java
@@ -18,9 +18,9 @@ import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.iam.identitytrust.spi.CredentialServiceUrlResolver;
-import org.eclipse.edc.iam.identitytrust.spi.SecureTokenService;
 import org.eclipse.edc.identityhub.protocols.dcp.issuer.spi.DcpIssuerService;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpHolderTokenVerifier;
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.participantcontext.store.ParticipantContextStore;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationPipeline;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.CredentialDefinitionService;
@@ -91,7 +91,7 @@ public class DcpIssuerCoreExtension implements ServiceExtension {
     private EdcHttpClient httpClient;
 
     @Inject
-    private SecureTokenService secureTokenService;
+    private ParticipantSecureTokenService secureTokenService;
 
     @Inject
     private Monitor monitor;

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authentication/ParticipantSecureTokenService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authentication/ParticipantSecureTokenService.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.authentication;
+
+import org.eclipse.edc.spi.iam.TokenRepresentation;
+import org.eclipse.edc.spi.result.Result;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+/**
+ * Multi-tenant (participant-aware) variant of a SecureTokenService
+ */
+public interface ParticipantSecureTokenService {
+
+
+    /**
+     * Creates a self-issued ID token ("SI token")
+     *
+     * @param participantContextId The ID of the participant context on behalf of whom the token is generated
+     * @param claims               a set of claims, that are to be included in the SI token. MUST include {@code iss}, {@code sub} and {@code aud}.
+     * @param bearerAccessScope    if non-null, must be a space-separated list of scopes as per <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#31-access-scopes">DCP specification</a>
+     *                             if bearerAccessScope != null -> creates a {@code token} claim, which is another JWT containing the scope as claims.
+     *                             if bearerAccessScope == null -> creates a normal JWT using all the claims in the map
+     * @return A result containing the token representation, or a failure
+     */
+    Result<TokenRepresentation> createToken(String participantContextId, Map<String, String> claims, @Nullable String bearerAccessScope);
+}

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantContext.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantContext.java
@@ -22,14 +22,19 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * Representation of a participant in Identity Hub.
  */
 @JsonDeserialize(builder = ParticipantContext.Builder.class)
 public class ParticipantContext extends ParticipantResource {
+    private Map<String, Object> properties = new HashMap<>();
     private List<String> roles = new ArrayList<>();
     private String did;
     private long createdAt;
@@ -37,7 +42,12 @@ public class ParticipantContext extends ParticipantResource {
     private int state; // CREATED, ACTIVATED, DEACTIVATED
     private String apiTokenAlias;
 
+
     private ParticipantContext() {
+    }
+
+    public String clientSecretAlias() {
+        return ofNullable(properties.get("clientSecret")).map(Object::toString).orElseGet(() -> participantContextId + "-sts-client-secret");
     }
 
     /**
@@ -107,6 +117,10 @@ public class ParticipantContext extends ParticipantResource {
         this.roles = roles;
     }
 
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class Builder extends ParticipantResource.Builder<ParticipantContext, Builder> {
 
@@ -164,6 +178,16 @@ public class ParticipantContext extends ParticipantResource {
 
         public Builder apiTokenAlias(String apiToken) {
             this.entity.apiTokenAlias = apiToken;
+            return this;
+        }
+
+        public Builder property(String key, Object value) {
+            entity.properties.put(key, value);
+            return this;
+        }
+
+        public Builder properties(Map<String, Object> properties) {
+            entity.properties = properties;
             return this;
         }
 

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantManifest.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantManifest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Optional.ofNullable;
+
 /**
  * Manifest (=recipe) for creating the {@link ParticipantContext}.
  */
@@ -44,6 +46,10 @@ public class ParticipantManifest {
 
     public Map<String, Object> getAdditionalProperties() {
         return additionalProperties;
+    }
+
+    public String clientSecretAlias() {
+        return ofNullable(additionalProperties.get("clientSecret")).map(Object::toString).orElseGet(() -> participantId + "-sts-client-secret");
     }
 
     /**

--- a/spi/participant-context-spi/src/testFixtures/java/org/eclipse/edc/identityhub/participantcontext/store/ParticipantContextStoreTestBase.java
+++ b/spi/participant-context-spi/src/testFixtures/java/org/eclipse/edc/identityhub/participantcontext/store/ParticipantContextStoreTestBase.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.participantcontext.store;
 
-import org.assertj.core.api.Assertions;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.participantcontext.store.ParticipantContextStore;
@@ -23,8 +22,10 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState.ACTIVATED;
 import static org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState.CREATED;
 import static org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState.DEACTIVATED;
@@ -39,7 +40,7 @@ public abstract class ParticipantContextStoreTestBase {
         assertThat(result).isSucceeded();
         var query = getStore().query(QuerySpec.max());
         assertThat(query).isSucceeded();
-        Assertions.assertThat(query.getContent()).usingRecursiveFieldByFieldElementComparator().containsExactly(participantContext);
+        assertThat(query.getContent()).usingRecursiveFieldByFieldElementComparator().containsExactly(participantContext);
     }
 
     @Test
@@ -62,7 +63,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .build();
 
         assertThat(getStore().query(query)).isSucceeded()
-                .satisfies(str -> Assertions.assertThat(str).hasSize(1));
+                .satisfies(str -> assertThat(str).hasSize(1));
     }
 
     @Test
@@ -75,7 +76,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .build();
 
         assertThat(getStore().query(query)).isSucceeded()
-                .satisfies(str -> Assertions.assertThat(str)
+                .satisfies(str -> assertThat(str)
                         .hasSize(1)
                         .usingRecursiveFieldByFieldElementComparator()
                         .containsExactly(participantContext));
@@ -91,7 +92,7 @@ public abstract class ParticipantContextStoreTestBase {
 
         var res = getStore().query(QuerySpec.none());
         assertThat(res).isSucceeded();
-        Assertions.assertThat(res.getContent())
+        assertThat(res.getContent())
                 .usingRecursiveFieldByFieldElementComparator()
                 .containsExactlyInAnyOrder(resources.toArray(new ParticipantContext[0]));
     }
@@ -110,7 +111,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .build();
         var res = getStore().query(query);
         assertThat(res).isSucceeded();
-        Assertions.assertThat(res.getContent()).isEmpty();
+        assertThat(res.getContent()).isEmpty();
     }
 
     @Test
@@ -128,7 +129,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .build();
         var res = getStore().query(query);
         assertThat(res).isSucceeded();
-        Assertions.assertThat(res.getContent()).isNotNull().isEmpty();
+        assertThat(res.getContent()).isNotNull().isEmpty();
     }
 
     @Test
@@ -180,6 +181,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .roles(List.of("role1", "role2"))
                 .state(CREATED)
                 .apiTokenAlias("test-alias")
+                .properties(Map.of("property1", "value1", "property2", 42))
                 .build();
     }
 
@@ -188,6 +190,7 @@ public abstract class ParticipantContextStoreTestBase {
                 .participantContextId("test-participant")
                 .state(CREATED)
                 .roles(List.of("role1", "role2"))
+                .properties(Map.of("property1", "value1", "property2", 42))
                 .apiTokenAlias("test-alias");
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

Adds another STS interface, that takes its runtime values (client-id, client-secret, private/public key id,...) from the participant context rather than 
configuration.

Both the remote and the embedded STS use the `StsAccountService` to fetch account information.

## Why it does that

in a "multi-tenant" environment such as IdentityHub (and at least conceptually, IssuerService), it is not possible to provide the aforementioned values via configuration.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #595

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
