### PR TITLE
feat: add get-request endpoint for holder requests

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -41,6 +41,7 @@ import org.eclipse.edc.statemachine.StateMachineManager;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -93,6 +94,11 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
             return ServiceResult.badRequest(e.getMessage());
         }
         return ServiceResult.success(holderPid);
+    }
+
+    @Override
+    public @Nullable HolderCredentialRequest findById(String participantContextId, String holderPid) {
+        return transactionContext.execute(() -> store.findById(holderPid));
     }
 
     @Override

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -97,7 +97,7 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
     }
 
     @Override
-    public @Nullable HolderCredentialRequest findById(String participantContextId, String holderPid) {
+    public @Nullable HolderCredentialRequest findById(String holderPid) {
         return transactionContext.execute(() -> store.findById(holderPid));
     }
 

--- a/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-02-21T14:00:00Z",
+    "lastUpdated": "2025-02-24T14:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
@@ -189,7 +189,7 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
         authorizationService.isAuthorized(securityContext, participantId, ParticipantContext.class)
                 .orElseThrow(exceptionMapper(ParticipantContext.class, participantId));
 
-        return ofNullable(credentialRequestService.findById(participantContextId, holderPid))
+        return ofNullable(credentialRequestService.findById(holderPid))
                 .map(req -> new HolderCredentialRequestDto(req.getIssuerDid(), req.getHolderPid(), req.getIssuerPid(), req.stateAsString(), List.of(), req.getTypesAndFormats()))
                 .orElseThrow(() -> new ObjectNotFoundException(HolderCredentialRequest.class, holderPid));
     }

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/model/HolderCredentialRequestDto.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/model/HolderCredentialRequestDto.java
@@ -14,7 +14,8 @@
 
 package org.eclipse.edc.identityhub.api.verifiablecredentials.v1.unstable.model;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * Represents a credential request of the holder.
@@ -24,9 +25,9 @@ import java.util.List;
  * @param issuerPid       the process ID returned from the issuer
  * @param status          REQUESTED, ISSUED, etc.
  * @param credentialIds   after the credentials are issued, their IDs are stored here
- * @param credentialTypes list of credential types/formats that were originally requested
+ * @param typesAndFormats list of credential types/formats that were originally requested
  */
-// todo: this DTO might get removed again later, when we have a HolderCredentialRequest entity, which will likely have the same signature
 public record HolderCredentialRequestDto(String issuerDid, String holderPid, String issuerPid, String status,
-                                         List<String> credentialIds, List<CredentialDescriptor> credentialTypes) {
+                                         Collection<String> credentialIds,
+                                         Map<String, String> typesAndFormats) {
 }

--- a/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
@@ -526,7 +526,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
     class GetCredentialRequest {
         @Test
         void success() {
-            when(credentialRequestService.findById(any(), any()))
+            when(credentialRequestService.findById(any()))
                     .thenReturn(HolderCredentialRequest.Builder.newInstance()
                             .issuerDid("did:web:issuer")
                             .participantContextId("test-participant")

--- a/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.identityhub.api.verifiablecredential.validation.Verifiabl
 import org.eclipse.edc.identityhub.api.verifiablecredentials.v1.unstable.model.CredentialDescriptor;
 import org.eclipse.edc.identityhub.api.verifiablecredentials.v1.unstable.model.CredentialRequestDto;
 import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
+import org.eclipse.edc.identityhub.spi.credential.request.model.HolderCredentialRequest;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.CredentialRequestManager;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialManifest;
@@ -55,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.ServiceResult.unauthorized;
 import static org.eclipse.edc.spi.result.StoreResult.alreadyExists;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -517,6 +519,36 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
                     .statusCode(403)
                     .body(containsString("test-message"));
             verifyNoInteractions(credentialRequestService);
+        }
+    }
+
+    @Nested
+    class GetCredentialRequest {
+        @Test
+        void success() {
+            when(credentialRequestService.findById(any(), any()))
+                    .thenReturn(HolderCredentialRequest.Builder.newInstance()
+                            .issuerDid("did:web:issuer")
+                            .participantContextId("test-participant")
+                            .typesAndFormats(Map.of("TestCredential", CredentialFormat.VC1_0_JWT.toString()))
+                            .build());
+
+            baseRequest()
+                    .get("/request/test-issuer-pid")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(200)
+                    .body("issuerDid", equalTo("did:web:issuer"))
+                    .body("typesAndFormats", aMapWithSize(1));
+        }
+
+        @Test
+        void getRequest_whenNotFound_shouldReturn20xNoBody() {
+            baseRequest()
+                    .get("/request/test-issuer-pid")
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(404);
         }
     }
 }

--- a/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/SqlHolderCredentialRequestStore.java
+++ b/extensions/store/sql/holder-credential-request-store-sql/src/main/java/org/eclipse/edc/identityhub/store/sql/credentialrequest/schema/SqlHolderCredentialRequestStore.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.store.sql.credentialrequest.schema;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.identityhub.spi.credential.request.model.HolderCredentialRequest;
 import org.eclipse.edc.identityhub.spi.credential.request.store.HolderCredentialRequestStore;
@@ -47,8 +46,6 @@ import static java.util.stream.Collectors.toList;
  */
 public class SqlHolderCredentialRequestStore extends AbstractSqlStore implements HolderCredentialRequestStore {
 
-    private static final TypeReference<List<String>> CREDENTIALTYPES_LIST_REF = new TypeReference<>() {
-    };
     private final String leaseHolderName;
     private final SqlLeaseContextBuilder leaseContext;
 

--- a/spi/verifiable-credential-spi/build.gradle.kts
+++ b/spi/verifiable-credential-spi/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 
 dependencies {
 
+    api(project(":spi:holder-credential-request-spi"))
     api(project(":spi:participant-context-spi"))
     api(libs.edc.spi.dcp)
 

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/CredentialRequestManager.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/CredentialRequestManager.java
@@ -46,9 +46,8 @@ public interface CredentialRequestManager extends StateEntityManager {
     /**
      * Finds a {@link HolderCredentialRequest} for the given participant context, with the given ID
      *
-     * @param participantContextId The Participant Context ID of the requestor
-     * @param holderPid            The (holder-side) ID of the request. Not to be confused with issuerPid.
+     * @param holderPid The (holder-side) ID of the request. Not to be confused with issuerPid.
      * @return the holder request, or null if not found
      */
-    @Nullable HolderCredentialRequest findById(String participantContextId, String holderPid);
+    @Nullable HolderCredentialRequest findById(String holderPid);
 }

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/CredentialRequestManager.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/CredentialRequestManager.java
@@ -14,9 +14,11 @@
 
 package org.eclipse.edc.identityhub.spi.verifiablecredentials;
 
+import org.eclipse.edc.identityhub.spi.credential.request.model.HolderCredentialRequest;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.entity.StateEntityManager;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -33,11 +35,20 @@ public interface CredentialRequestManager extends StateEntityManager {
     /**
      * Initiates the holder-side credential request by sending the DCP message to the issuer
      *
-     * @param participantContext The Participant Context ID of the requestor
-     * @param issuerDid          The DID of the issuer
-     * @param holderPid          The holder-defined request ID.
-     * @param typesAndFormats    A map containing credential-type - credential-format entries
+     * @param participantContextId The Participant Context ID of the requestor
+     * @param issuerDid            The DID of the issuer
+     * @param holderPid            The holder-defined request ID.
+     * @param typesAndFormats      A map containing credential-type - credential-format entries
      * @return A ServiceResult containing the database ID of the {@code HolderCredentialRequest}.
      */
-    ServiceResult<String> initiateRequest(String participantContext, String issuerDid, String holderPid, Map<String, String> typesAndFormats);
+    ServiceResult<String> initiateRequest(String participantContextId, String issuerDid, String holderPid, Map<String, String> typesAndFormats);
+
+    /**
+     * Finds a {@link HolderCredentialRequest} for the given participant context, with the given ID
+     *
+     * @param participantContextId The Participant Context ID of the requestor
+     * @param holderPid            The (holder-side) ID of the request. Not to be confused with issuerPid.
+     * @return the holder request, or null if not found
+     */
+    @Nullable HolderCredentialRequest findById(String participantContextId, String holderPid);
 }


### PR DESCRIPTION
## What this PR changes/adds

implement the get-request endpoint to obtain the status of holder credential requests.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #589

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
