### PR TITLE
docs: decision record about STS deployment

### DIFF
--- a/docs/developer/decision-records/2025-02-24-sts-deployment-embedded/README.md
+++ b/docs/developer/decision-records/2025-02-24-sts-deployment-embedded/README.md
@@ -55,7 +55,7 @@ In this case the standalone runtime must implement its own PKI based on DID docu
 aspects would need to be implemented:
 
 - key management: to rotate, revoke, add, ... key pairs
-- DID management: public keys need to be added to the DID document so that verifiers can resolve it
+- DID management: public keys need to be added/updated/removed to/from the DID document so that verifiers can resolve them
 - account mapping: participant contexts (in IdentityHub) must be mapped to STS accounts, so that IdentityHub can act _on
   behalf_ of the correct participant. This is particularly relevant when making credential issuance requests.
 
@@ -66,3 +66,5 @@ for that IdP will most likely become necessary, so that it can create DCP-compli
 extension must be developed in IdentityHub that maps participant contexts onto IdP user principals.
 
 Note that in this scenario the IdP is responsible for key management and a DCP-compliant PKI.
+
+Note also that neither of these deployment scenarios is recommended or supported by the EDC project.

--- a/docs/developer/decision-records/2025-02-24-sts-deployment-embedded/README.md
+++ b/docs/developer/decision-records/2025-02-24-sts-deployment-embedded/README.md
@@ -1,4 +1,4 @@
-# EDC's SecureTokenService must always be embedded in IdentityHub
+# The SecureTokenService must always be embedded in IdentityHub
 
 ## Decision
 
@@ -10,24 +10,24 @@ standalone mode is not supported.
 By definition, the STS and IdentityHub are coupled together, because the shape of the access token must be known to
 either of them.
 
-In addition, IdentityHub is designed to manage all security-related material such as key pairs, which are
-bound to a participant context, and for that it contains facilities to create, rotate, revoke, query,... key material.
+In addition, IdentityHub is designed to manage all security-related material such as key pairs, which is
+bound to a participant context, and for which it contains specific APIs and services.
 
-Were STS to run in standalone mode, it would also have to provide those facilities, which would increase complexity
-significantly without adding much value.
+Our EDC components shall reflect this coupling by directly embedding the SecureTokenService into the IdentityHub
+runtime.
 
 ## Approach
 
 ### Removal of the STS Accounts API
 
 The fact that STS maintains an account (client ID and client secret) for each participant context becomes an
-implementation detail that need not be accessible through a REST API.
+implementation detail that need not be exposed externally through a REST API.
 
-When creating participant contexts, the IdentityHub always provisions the account internally without the need for a
+When creating participant contexts, the IdentityHub always creates the "account" internally without the need for a
 remote call.
 
-This also removes the need for a `RemoteStsAccountService`, because IdentityHub can simply use a local delegate to
-handle that. This will further simplify the `StsAccountProvisioner -> StsAccountService` indirection.
+This also removes the need for a `RemoteStsAccountService`, because IdentityHub can simply create a
+local "account". This will further simplify the `StsAccountProvisioner -> StsAccountService` indirection.
 
 ### Moving code from the Connector to IdentityHub
 

--- a/docs/developer/decision-records/2025-02-24-sts-deployment-embedded/README.md
+++ b/docs/developer/decision-records/2025-02-24-sts-deployment-embedded/README.md
@@ -1,0 +1,68 @@
+# EDC's SecureTokenService must always be embedded in IdentityHub
+
+## Decision
+
+When using EDC modules, the SecureTokenService (STS) must always be embedded in the IdentityHub runtime. Running it in
+standalone mode is not supported.
+
+## Rationale
+
+By definition, the STS and IdentityHub are coupled together, because the shape of the access token must be known to
+either of them.
+
+In addition, IdentityHub is designed to manage all security-related material such as key pairs, which are
+bound to a participant context, and for that it contains facilities to create, rotate, revoke, query,... key material.
+
+Were STS to run in standalone mode, it would also have to provide those facilities, which would increase complexity
+significantly without adding much value.
+
+## Approach
+
+### Removal of the STS Accounts API
+
+The fact that STS maintains an account (client ID and client secret) for each participant context becomes an
+implementation detail that need not be accessible through a REST API.
+
+When creating participant contexts, the IdentityHub always provisions the account internally without the need for a
+remote call.
+
+This also removes the need for a `RemoteStsAccountService`, because IdentityHub can simply use a local delegate to
+handle that. This will further simplify the `StsAccountProvisioner -> StsAccountService` indirection.
+
+### Moving code from the Connector to IdentityHub
+
+Most of the STS modules that are currently located in EDC can be moved to the IdentityHub repository. The connector only
+needs to have an `RemoteSecureTokenService` implementation with which it can communicate with STS/IdentityHub using
+REST.
+
+IdentityHub on the other hand, does not need any remote call code anymore, because it always has STS in the same
+runtime.
+
+_Note that embedding STS/IdentityHub in the connector runtime would still be possible, but is **not** a recommended
+deployment scenario._
+
+### Adapting MinimumViableDataspace
+
+MVD will be modified (and simplified) accordingly.
+
+## Further considerations
+
+### What if
+
+##### ... I absolutely want to run STS standalone?
+
+In this case the standalone runtime must implement its own PKI based on DID documents. Specifically, the following
+aspects would need to be implemented:
+
+- key management: to rotate, revoke, add, ... key pairs
+- DID management: public keys need to be added to the DID document so that verifiers can resolve it
+- account mapping: participant contexts (in IdentityHub) must be mapped to STS accounts, so that IdentityHub can act _on
+  behalf_ of the correct participant. This is particularly relevant when making credential issuance requests.
+
+##### ... I need to use a third-party IdP to create tokens?
+
+In cases where all security tokens must be created by a central (third-party) IdP such as KeyCloak, developing a plugin
+for that IdP will most likely become necessary, so that it can create DCP-compliant SI-tokens. In all likeliness, an
+extension must be developed in IdentityHub that maps participant contexts onto IdP user principals.
+
+Note that in this scenario the IdP is responsible for key management and a DCP-compliant PKI.

--- a/docs/developer/decision-records/README.md
+++ b/docs/developer/decision-records/README.md
@@ -7,3 +7,4 @@
 - [2023-01-20 Credentials Verifier Output Format](2023-01-20-credentials-verifier-output-format/)
 - [2024-08-23 Identity Hub Write Credentials API](2024-08-23-identity_hub_identity_write_credentials_api/)
 - [2024-09-02 Identity Hub Resource Operations](2024-09-02-resource-operations)
+- [2025-02-24 EDC's STS modules must be embedded in IdentityHub](./2025-02-24-sts-deployment-embedded)


### PR DESCRIPTION
## What this PR changes/adds

adds a decision record about STS always being deployed directly embedded in IdentityHub

## Why it does that

simplicity, avoid coupling at database- or HSM-level

## Further notes

- although some connector-related code areas are affected, this is mainly a decision that affects IdentityHub

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
