### PR TITLE
chore: several smaller fixes

### DIFF
--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
@@ -68,6 +68,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -149,7 +150,7 @@ class CredentialRequestManagerImplTest {
         private static final Duration MAX_DURATION = Duration.ofSeconds(5);
 
         @ParameterizedTest(name = "state = {0}")
-        @ValueSource(strings = { "CREATED", "REQUESTING" })
+        @ValueSource(strings = {"CREATED", "REQUESTING"})
         void processInitial_shouldSendRequest(String stateString) {
             var state = HolderRequestState.valueOf(stateString);
             when(resolver.resolve(eq(ISSUER_DID))).thenReturn(success(didDocument()));
@@ -160,8 +161,7 @@ class CredentialRequestManagerImplTest {
                     .state(state.code())
                     .build();
             when(store.nextNotLeased(anyInt(), stateIs(state.code())))
-                    .thenReturn(List.of(rq))
-                    .thenReturn(List.of());
+                    .thenReturn(List.of(rq));
 
             credentialRequestService.start();
 
@@ -176,7 +176,7 @@ class CredentialRequestManagerImplTest {
         }
 
         @ParameterizedTest(name = "state = {0}")
-        @ValueSource(strings = { "CREATED", "REQUESTING" })
+        @ValueSource(strings = {"CREATED", "REQUESTING"})
         void processInitial_whenDidNotResolvable_shouldTransitionToError(String stateString) {
             var state = HolderRequestState.valueOf(stateString);
 
@@ -185,21 +185,20 @@ class CredentialRequestManagerImplTest {
                     .state(state.code())
                     .build();
             when(store.nextNotLeased(anyInt(), stateIs(state.code())))
-                    .thenReturn(List.of(rq))
-                    .thenReturn(List.of());
+                    .thenReturn(List.of(rq));
 
             credentialRequestService.start();
 
             await().atMost(MAX_DURATION).untilAsserted(() -> {
                 var inOrder = inOrder(resolver, store);
                 inOrder.verify(resolver).resolve(eq(ISSUER_DID));
-                inOrder.verify(store).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().equals("foobar")));
+                inOrder.verify(store, times(2)).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().equals("foobar")));
                 verifyNoMoreInteractions(resolver, sts, httpClient);
             });
         }
 
         @ParameterizedTest(name = "state = {0}")
-        @ValueSource(strings = { "CREATED", "REQUESTING" })
+        @ValueSource(strings = {"CREATED", "REQUESTING"})
         void processInitial_whenDidDoesNotContainEndpoint_shouldTransitionToError(String stateString) {
             var state = HolderRequestState.valueOf(stateString);
 
@@ -212,21 +211,20 @@ class CredentialRequestManagerImplTest {
                     .state(state.code())
                     .build();
             when(store.nextNotLeased(anyInt(), stateIs(state.code())))
-                    .thenReturn(List.of(rq))
-                    .thenReturn(List.of());
+                    .thenReturn(List.of(rq));
 
             credentialRequestService.start();
 
             await().atMost(MAX_DURATION).untilAsserted(() -> {
                 var inOrder = inOrder(resolver, store);
                 inOrder.verify(resolver).resolve(eq(ISSUER_DID));
-                inOrder.verify(store).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().contains("DID Document does not contain any 'IssuerService' endpoint")));
+                inOrder.verify(store, times(2)).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().contains("DID Document does not contain any 'IssuerService' endpoint")));
                 verifyNoMoreInteractions(resolver, sts, httpClient);
             });
         }
 
         @ParameterizedTest(name = "state = {0}")
-        @ValueSource(strings = { "CREATED", "REQUESTING" })
+        @ValueSource(strings = {"CREATED", "REQUESTING"})
         void processInitial_whenStsFails_shouldTransitionToError(String stateString) {
             var state = HolderRequestState.valueOf(stateString);
 
@@ -237,22 +235,21 @@ class CredentialRequestManagerImplTest {
                     .state(state.code())
                     .build();
             when(store.nextNotLeased(anyInt(), stateIs(state.code())))
-                    .thenReturn(List.of(rq))
-                    .thenReturn(List.of());
+                    .thenReturn(List.of(rq));
 
             credentialRequestService.start();
 
             await().atMost(MAX_DURATION).untilAsserted(() -> {
                 var inOrder = inOrder(resolver, store, httpClient, sts);
                 inOrder.verify(resolver).resolve(eq(ISSUER_DID));
-                inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTING.code()));
+//                inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTING.code()));
                 inOrder.verify(sts).createToken(anyString(), anyMap(), ArgumentMatchers.isNull());
-                inOrder.verify(store).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().equals("sts-failure")));
+                inOrder.verify(store, times(2)).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().equals("sts-failure")));
             });
         }
 
         @ParameterizedTest(name = "state = {0}")
-        @ValueSource(strings = { "CREATED", "REQUESTING" })
+        @ValueSource(strings = {"CREATED", "REQUESTING"})
         void processInitial_whenIssuerReturnsError_shouldTransitionToError(String stateString) {
             var state = HolderRequestState.valueOf(stateString);
             when(resolver.resolve(eq(ISSUER_DID))).thenReturn(success(didDocument()));
@@ -262,18 +259,17 @@ class CredentialRequestManagerImplTest {
                     .state(state.code())
                     .build();
             when(store.nextNotLeased(anyInt(), stateIs(state.code())))
-                    .thenReturn(List.of(rq))
-                    .thenReturn(List.of());
+                    .thenReturn(List.of(rq));
 
             credentialRequestService.start();
 
             await().atMost(MAX_DURATION).untilAsserted(() -> {
                 var inOrder = inOrder(resolver, store, httpClient, sts);
                 inOrder.verify(resolver).resolve(eq(ISSUER_DID));
-                inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTING.code()));
+//                inOrder.verify(store).save(argThat(r -> r.getState() == REQUESTING.code()));
                 inOrder.verify(sts).createToken(anyString(), anyMap(), ArgumentMatchers.isNull());
                 inOrder.verify(httpClient).execute(any(), (Function<Response, Result<String>>) any());
-                inOrder.verify(store).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().equals("issuer failure bad request")));
+                inOrder.verify(store, times(2)).save(argThat(r -> r.getState() == ERROR.code() && r.getErrorDetail().equals("issuer failure bad request")));
             });
         }
 
@@ -288,7 +284,7 @@ class CredentialRequestManagerImplTest {
 
 
         private Criterion[] stateIs(int state) {
-            return aryEq(new Criterion[]{ hasState(state), isNotPending() });
+            return aryEq(new Criterion[]{hasState(state), isNotPending()});
         }
 
     }

--- a/extensions/api/identity-api/build.gradle.kts
+++ b/extensions/api/identity-api/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":extensions:api:identity-api:api-configuration"))
+    api(project(":extensions:api:identity-api:did-api"))
+    api(project(":extensions:api:identity-api:keypair-api"))
+    api(project(":extensions:api:identity-api:participant-context-api"))
+    api(project(":extensions:api:identity-api:validators"))
+    api(project(":extensions:api:identity-api:verifiable-credentials-api"))
+}

--- a/extensions/api/identity-api/did-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/unstable/DidManagementApiController.java
+++ b/extensions/api/identity-api/did-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/v1/unstable/DidManagementApiController.java
@@ -33,11 +33,13 @@ import org.eclipse.edc.identityhub.spi.did.model.DidResource;
 import org.eclipse.edc.identityhub.spi.did.model.DidState;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 
 import java.util.Collection;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.edc.identityhub.spi.authorization.AuthorizationResultHandler.exceptionMapper;
+import static org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextId.onEncoded;
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
@@ -96,10 +98,11 @@ public class DidManagementApiController implements DidManagementApi {
     @Path("/{did}/endpoints")
     public void addDidEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish,
                                @Context SecurityContext securityContext) {
-        authorizationService.isAuthorized(securityContext, did, DidResource.class)
-                .compose(u -> documentService.addService(did, service))
-                .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
-                .orElseThrow(exceptionMapper(Service.class, did));
+        var decodedDid = onEncoded(did).orElseThrow(InvalidRequestException::new);
+        authorizationService.isAuthorized(securityContext, decodedDid, DidResource.class)
+                .compose(u -> documentService.addService(decodedDid, service))
+                .compose(v -> autoPublish ? documentService.publish(decodedDid) : ServiceResult.success())
+                .orElseThrow(exceptionMapper(Service.class, decodedDid));
     }
 
     @Override
@@ -107,10 +110,12 @@ public class DidManagementApiController implements DidManagementApi {
     @Path("/{did}/endpoints")
     public void replaceDidEndpoint(@PathParam("did") String did, Service service, @QueryParam("autoPublish") boolean autoPublish,
                                    @Context SecurityContext securityContext) {
-        authorizationService.isAuthorized(securityContext, did, DidResource.class)
-                .compose(u -> documentService.replaceService(did, service))
-                .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
-                .orElseThrow(exceptionMapper(Service.class, did));
+        var decodedDid = onEncoded(did).orElseThrow(InvalidRequestException::new);
+
+        authorizationService.isAuthorized(securityContext, decodedDid, DidResource.class)
+                .compose(u -> documentService.replaceService(decodedDid, service))
+                .compose(v -> autoPublish ? documentService.publish(decodedDid) : ServiceResult.success())
+                .orElseThrow(exceptionMapper(Service.class, decodedDid));
     }
 
     @Override
@@ -118,10 +123,12 @@ public class DidManagementApiController implements DidManagementApi {
     @Path("/{did}/endpoints")
     public void deleteDidEndpoint(@PathParam("did") String did, @QueryParam("serviceId") String serviceId, @QueryParam("autoPublish") boolean autoPublish,
                                   @Context SecurityContext securityContext) {
-        authorizationService.isAuthorized(securityContext, did, DidResource.class)
-                .compose(u -> documentService.removeService(did, serviceId))
-                .compose(v -> autoPublish ? documentService.publish(did) : ServiceResult.success())
-                .orElseThrow(exceptionMapper(Service.class, did));
+        var decodedDid = onEncoded(did).orElseThrow(InvalidRequestException::new);
+
+        authorizationService.isAuthorized(securityContext, decodedDid, DidResource.class)
+                .compose(u -> documentService.removeService(decodedDid, serviceId))
+                .compose(v -> autoPublish ? documentService.publish(decodedDid) : ServiceResult.success())
+                .orElseThrow(exceptionMapper(Service.class, decodedDid));
     }
 
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -89,6 +89,7 @@ include(":protocols:dcp:dcp-identityhub:dcp-identityhub-transform-lib")
 include(":protocols:dcp:dcp-identityhub:dcp-identityhub-core")
 
 // Identity APIs
+include(":extensions:api:identity-api")
 include(":extensions:api:identity-api:api-configuration")
 include(":extensions:api:identityhub-api-authentication")
 include(":extensions:api:identityhub-api-authorization")

--- a/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderCredentialRequest.java
+++ b/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderCredentialRequest.java
@@ -21,6 +21,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.CREATED;
+import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.ERROR;
+import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.ISSUED;
+import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.REQUESTED;
+import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.REQUESTING;
 import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.from;
 
 /**
@@ -38,7 +43,34 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
     private String issuerPid;
 
     private HolderCredentialRequest() {
-        this.state = HolderRequestState.CREATED.code();
+        this.state = CREATED.code();
+    }
+
+    public void transitionCreated() {
+        state = CREATED.code();
+        updateStateTimestamp();
+    }
+
+    public void transitionRequesting() {
+        state = REQUESTING.code();
+        updateStateTimestamp();
+    }
+
+    public void transitionRequested(String issuerPid) {
+        state = REQUESTED.code();
+        this.issuerPid = issuerPid;
+        updateStateTimestamp();
+    }
+
+    public void transitionIssued() {
+        state = ISSUED.code();
+        updateStateTimestamp();
+    }
+
+    public void transitionError(String detail) {
+        state = ERROR.code();
+        errorDetail = detail;
+        updateStateTimestamp();
     }
 
     public String getParticipantContextId() {
@@ -100,10 +132,6 @@ public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequ
         }
         var that = (Entity) o;
         return id.equals(that.getId());
-    }
-
-    public Builder toBuilder() {
-        return new Builder(this);
     }
 
     /**

--- a/spi/holder-credential-request-spi/src/testFixtures/java/org/eclipse/edc/identityhub/credential/request/test/HolderCredentialRequestStoreTestBase.java
+++ b/spi/holder-credential-request-spi/src/testFixtures/java/org/eclipse/edc/identityhub/credential/request/test/HolderCredentialRequestStoreTestBase.java
@@ -316,7 +316,7 @@ public abstract class HolderCredentialRequestStoreTestBase {
             var request = createHolderRequest();
             getStore().save(request);
 
-            request = request.toBuilder().state(CREATED.code()).build();
+            request.transitionCreated();
 
             getStore().save(request);
 
@@ -335,7 +335,7 @@ public abstract class HolderCredentialRequestStoreTestBase {
             // acquire lease
             leaseEntity(request.getId(), RUNTIME_ID);
 
-            request = request.toBuilder().state(CREATED.code()).build();
+            request.transitionCreated();
             getStore().save(request);
 
             // lease should be broken
@@ -351,10 +351,10 @@ public abstract class HolderCredentialRequestStoreTestBase {
             getStore().save(request);
             leaseEntity(id, "someone");
 
-            var updatedRequest = request.toBuilder().state(CREATED.code()).build();
+            request.transitionCreated();
 
             // leased by someone else -> throw exception
-            assertThatThrownBy(() -> getStore().save(updatedRequest)).isInstanceOf(IllegalStateException.class);
+            assertThatThrownBy(() -> getStore().save(request)).isInstanceOf(IllegalStateException.class);
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Several smaller fixes: 
- add `transition*` methods to the HolderCredentialRequest
- DID strings are always encoded in API calls
- create meta module for the Identity API

## Why it does that



## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
