### PR TITLE
feat: expose StorageAPI and PresentationAPI on same web context

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ two ways of running IdentityHub:
 Once the jar file is built, IdentityHub can be launched using this shell command:
 
 ```bash
-java -Dweb.http.presentation.port=10001 \
-     -Dweb.http.presentation.path="/api/presentation" \
+java -Dweb.http.credentials.port=10001 \
+     -Dweb.http.credentials.path="/api/credentials" \
      -Dweb.http.port=8181 \
      -Dweb.http.path="/api" \
      -Dweb.http.identity.port=8182 \

--- a/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -62,10 +62,8 @@ public class BomSmokeTests {
                                 put("web.http.port", DEFAULT_PORT);
                                 put("web.http.path", DEFAULT_PATH);
                                 put("edc.ih.iam.publickey.path", "/some/path/to/key.pem");
-                                put("web.http.presentation.port", valueOf(getFreePort()));
-                                put("web.http.presentation.path", "/api/resolution");
-                                put("web.http.storage.port", valueOf(getFreePort()));
-                                put("web.http.storage.path", "/api/storage");
+                                put("web.http.credentials.port", valueOf(getFreePort()));
+                                put("web.http.credentials.path", "/api/credentials");
                                 put("web.http.identity.port", valueOf(getFreePort()));
                                 put("web.http.identity.path", "/api/identity");
                                 put("web.http.accounts.port", valueOf(getFreePort()));

--- a/e2e-tests/fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/credentialservice/IdentityHubEndToEndTestContext.java
+++ b/e2e-tests/fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/credentialservice/IdentityHubEndToEndTestContext.java
@@ -106,7 +106,7 @@ public class IdentityHubEndToEndTestContext extends AbstractTestContext {
     }
 
     public Service createServiceEndpoint(String participantContextId) {
-        var credentialServiceEndpoint = format("%s/%s", configuration.getStorageEndpoint().getUrl(), storageApiBasePath(participantContextId));
+        var credentialServiceEndpoint = format("%s/%s", configuration.getCredentialsEndpoint().getUrl(), storageApiBasePath(participantContextId));
         return new Service("credential-service-id", "CredentialService", credentialServiceEndpoint);
     }
 
@@ -125,11 +125,11 @@ public class IdentityHubEndToEndTestContext extends AbstractTestContext {
     }
 
     public Endpoint getPresentationEndpoint() {
-        return configuration.getPresentationEndpoint();
+        return configuration.getCredentialsEndpoint();
     }
 
     public Endpoint getStorageEndpoint() {
-        return configuration.getStorageEndpoint();
+        return configuration.getCredentialsEndpoint();
     }
 
     public Collection<DidDocument> getDidForParticipant(String participantContextId) {
@@ -207,7 +207,7 @@ public class IdentityHubEndToEndTestContext extends AbstractTestContext {
     }
 
     private @NotNull String storageApiBasePath(String participantContextId) {
-        return "v1alpha/participants/%s".formatted(base64Encode(participantContextId));
+        return "v1/participants/%s".formatted(base64Encode(participantContextId));
     }
 
 }

--- a/e2e-tests/fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/credentialservice/IdentityHubRuntimeConfiguration.java
+++ b/e2e-tests/fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/credentialservice/IdentityHubRuntimeConfiguration.java
@@ -31,13 +31,9 @@ import static org.eclipse.edc.util.io.Ports.getFreePort;
  */
 public class IdentityHubRuntimeConfiguration extends AbstractRuntimeConfiguration {
 
-    private Endpoint presentationEndpoint;
     private Endpoint identityEndpoint;
-    private Endpoint storageEndpoint;
+    private Endpoint credentialsEndpoint;
 
-    public Endpoint getPresentationEndpoint() {
-        return presentationEndpoint;
-    }
 
     public Config config() {
         return ConfigFactory.fromMap(new HashMap<>() {
@@ -45,10 +41,8 @@ public class IdentityHubRuntimeConfiguration extends AbstractRuntimeConfiguratio
                 put(PARTICIPANT_ID, id);
                 put("web.http.port", String.valueOf(getFreePort()));
                 put("web.http.path", "/api/v1");
-                put("web.http.presentation.port", String.valueOf(presentationEndpoint.getUrl().getPort()));
-                put("web.http.presentation.path", presentationEndpoint.getUrl().getPath());
-                put("web.http.storage.port", String.valueOf(storageEndpoint.getUrl().getPort()));
-                put("web.http.storage.path", String.valueOf(storageEndpoint.getUrl().getPath()));
+                put("web.http.credentials.port", String.valueOf(credentialsEndpoint.getUrl().getPort()));
+                put("web.http.credentials.path", String.valueOf(credentialsEndpoint.getUrl().getPath()));
                 put("web.http.identity.port", String.valueOf(identityEndpoint.getUrl().getPort()));
                 put("web.http.identity.path", identityEndpoint.getUrl().getPath());
                 put("web.http.sts.port", String.valueOf(getFreePort()));
@@ -73,8 +67,8 @@ public class IdentityHubRuntimeConfiguration extends AbstractRuntimeConfiguratio
         return identityEndpoint;
     }
 
-    public Endpoint getStorageEndpoint() {
-        return storageEndpoint;
+    public Endpoint getCredentialsEndpoint() {
+        return credentialsEndpoint;
     }
 
     public static final class Builder extends AbstractRuntimeConfiguration.Builder<IdentityHubRuntimeConfiguration, Builder> {
@@ -89,9 +83,8 @@ public class IdentityHubRuntimeConfiguration extends AbstractRuntimeConfiguratio
 
         public IdentityHubRuntimeConfiguration build() {
             super.build();
-            participant.presentationEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/presentation"), Map.of());
             participant.identityEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/identity"), Map.of());
-            participant.storageEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/storage"), Map.of());
+            participant.credentialsEndpoint = new Endpoint(URI.create("http://localhost:" + getFreePort() + "/api/credentials"), Map.of());
             return participant;
         }
     }

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
@@ -305,7 +305,7 @@ public class PresentationApiEndToEndTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { DCP_CONTEXT_URL, DSPACE_DCP_V_1_0_CONTEXT })
+        @ValueSource(strings = {DCP_CONTEXT_URL, DSPACE_DCP_V_1_0_CONTEXT})
         void query_success_noCredentials(String dcpContext, IdentityHubEndToEndTestContext context) throws JOSEException {
 
             var token = generateSiToken();
@@ -333,7 +333,7 @@ public class PresentationApiEndToEndTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { DCP_CONTEXT_URL, DSPACE_DCP_V_1_0_CONTEXT })
+        @ValueSource(strings = {DCP_CONTEXT_URL, DSPACE_DCP_V_1_0_CONTEXT})
         void query_success_containsCredential(String dcpContext, IdentityHubEndToEndTestContext context, CredentialStore store) throws JOSEException, JsonProcessingException {
 
             var cred = OBJECT_MAPPER.readValue(TestData.VC_EXAMPLE, VerifiableCredential.class);
@@ -377,7 +377,7 @@ public class PresentationApiEndToEndTest {
         }
 
         @ParameterizedTest
-        @ValueSource(strings = { DCP_CONTEXT_URL, DSPACE_DCP_V_1_0_CONTEXT })
+        @ValueSource(strings = {DCP_CONTEXT_URL, DSPACE_DCP_V_1_0_CONTEXT})
         void query_success_containsMultiplePresentations(String dcpContext, IdentityHubEndToEndTestContext context, CredentialStore store) throws JOSEException, JsonProcessingException {
 
             var cred = OBJECT_MAPPER.readValue(TestData.VC_EXAMPLE, VerifiableCredential.class);
@@ -466,7 +466,7 @@ public class PresentationApiEndToEndTest {
         }
 
         @ParameterizedTest(name = "VcState code: {0}")
-        @ValueSource(ints = { 600, 700, 800, 900 })
+        @ValueSource(ints = {600, 700, 800, 900})
         void query_shouldFilterOutInvalidCreds(int vcStateCode, IdentityHubEndToEndTestContext context, CredentialStore store) throws JOSEException, JsonProcessingException {
 
             // modify VC content, so that it becomes either not-yet-valid or expired

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/StorageApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/StorageApiEndToEndTest.java
@@ -118,7 +118,7 @@ public class StorageApiEndToEndTest {
                     .contentType(ContentType.JSON)
                     .header("Authorization", "Bearer " + generateSiToken())
                     .body(credentialMessage)
-                    .post("/v1alpha/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
+                    .post("/v1/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
                     .then()
                     .statusCode(200);
 
@@ -135,7 +135,7 @@ public class StorageApiEndToEndTest {
                     .contentType(ContentType.JSON)
                     .header("Authorization", "Bearer " + generateSiToken())
                     .body(credentialMessage)
-                    .post("/v1alpha/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
+                    .post("/v1/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
                     .then()
                     .statusCode(401)
                     .body(Matchers.containsString("not found"));
@@ -152,7 +152,7 @@ public class StorageApiEndToEndTest {
                     .contentType(ContentType.JSON)
                     .header("Authorization", "Bearer " + generateSiToken(CONSUMER_DID, PROVIDER_DID))
                     .body(credentialMessage)
-                    .post("/v1alpha/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
+                    .post("/v1/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
                     .then()
                     .statusCode(401)
                     .body(Matchers.containsString("Token verification failed"));
@@ -173,7 +173,7 @@ public class StorageApiEndToEndTest {
                     .contentType(ContentType.JSON)
                     .header("Authorization", "Bearer " + generateSiToken())
                     .body(credentialMessage)
-                    .post("/v1alpha/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
+                    .post("/v1/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
                     .then()
                     .statusCode(400)
                     .body(Matchers.containsString("Invalid format"));
@@ -194,7 +194,7 @@ public class StorageApiEndToEndTest {
                     .contentType(ContentType.JSON)
                     .header("Authorization", "Bearer " + generateSiToken())
                     .body(credentialMessage)
-                    .post("/v1alpha/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
+                    .post("/v1/participants/" + TEST_PARTICIPANT_CONTEXT_ID_ENCODED + "/credentials")
                     .then()
                     .statusCode(200);
 

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
@@ -130,7 +130,7 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
         var query = QuerySpec.Builder.newInstance();
 
         if (!StringUtils.isNullOrEmpty(type)) {
-            query.filter(new Criterion("verifiableCredential.credential.types", "contains", type));
+            query.filter(new Criterion("verifiableCredential.credential.type", "contains", type));
         }
 
         return credentialStore.query(query.build())

--- a/protocols/dcp/dcp-identityhub/credentials-api-configuration/build.gradle.kts
+++ b/protocols/dcp/dcp-identityhub/credentials-api-configuration/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     api(libs.edc.spi.core)
     api(libs.edc.spi.identity.did)
 
-    implementation(project(":protocols:dcp:dcp-identityhub:credentials-api-configuration"))
     implementation(project(":protocols:dcp:dcp-transform-lib"))
     implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)

--- a/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/CredentialsApiConfigurationExtension.java
+++ b/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/CredentialsApiConfigurationExtension.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.system.apiversion.ApiVersionService;
+import org.eclipse.edc.spi.system.apiversion.VersionRecord;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
+import static org.eclipse.edc.identityhub.api.CredentialsApiConfigurationExtension.NAME;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_1_0;
+import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.CREDENTIALS;
+
+@Extension(value = NAME)
+public class CredentialsApiConfigurationExtension implements ServiceExtension {
+
+    public static final String NAME = "Storage API Extension";
+    private static final String API_VERSION_JSON_FILE = "credentials-api-version.json";
+
+    @Configuration
+    private CredentialsApiConfiguration apiConfiguration;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private ApiVersionService apiVersionService;
+    @Inject
+    private PortMappingRegistry portMappingRegistry;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+
+        portMappingRegistry.register(new PortMapping(CREDENTIALS, apiConfiguration.port(), apiConfiguration.path()));
+        jsonLd.registerContext(DSPACE_DCP_V_1_0_CONTEXT, DCP_SCOPE_V_1_0);
+        registerVersionInfo(getClass().getClassLoader());
+    }
+
+    private void registerVersionInfo(ClassLoader resourceClassLoader) {
+        try (var versionContent = resourceClassLoader.getResourceAsStream(API_VERSION_JSON_FILE)) {
+            if (versionContent == null) {
+                throw new EdcException("Version file not found or not readable.");
+            }
+            Stream.of(typeManager.getMapper()
+                            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+                            .readValue(versionContent, VersionRecord[].class))
+                    .forEach(vr -> apiVersionService.addRecord("credentials", vr));
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    @Settings
+    record CredentialsApiConfiguration(
+            @Setting(key = "web.http." + CREDENTIALS + ".port", description = "Port for " + CREDENTIALS + " api context", defaultValue = 13131 + "")
+            int port,
+            @Setting(key = "web.http." + CREDENTIALS + ".path", description = "Path for " + CREDENTIALS + " api context", defaultValue = "/api/credentials")
+            String path
+    ) {
+
+    }
+
+}

--- a/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Cofinity-X - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.api.CredentialsApiConfigurationExtension

--- a/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/credentials-api-version.json
+++ b/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/credentials-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1",
-    "lastUpdated": "2025-02-05T12:00:00Z",
+    "lastUpdated": "2025-02-26T12:00:00Z",
     "maturity": "stable"
   }
 ]

--- a/protocols/dcp/dcp-identityhub/presentation-api/build.gradle.kts
+++ b/protocols/dcp/dcp-identityhub/presentation-api/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     api(libs.edc.spi.jsonld)
     api(libs.edc.spi.jwt)
     api(libs.edc.spi.core)
+    implementation(project(":protocols:dcp:dcp-identityhub:credentials-api-configuration"))
     implementation(libs.edc.spi.validator)
     implementation(libs.edc.spi.web)
     implementation(libs.edc.spi.dcp)
@@ -41,6 +42,6 @@ dependencies {
 
 edcBuild {
     swagger {
-        apiGroup.set("presentation-api")
+        apiGroup.set("credentials-api")
     }
 }

--- a/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.api;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.eclipse.edc.iam.identitytrust.transform.from.JsonObjectFromPresentationResponseMessageTransformer;
 import org.eclipse.edc.iam.identitytrust.transform.to.JsonObjectToPresentationQueryTransformer;
 import org.eclipse.edc.identityhub.api.validation.PresentationQueryValidator;
@@ -25,48 +24,31 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.resolution.Credenti
 import org.eclipse.edc.identityhub.spi.verification.SelfIssuedTokenVerifier;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
-import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.Settings;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.apiversion.ApiVersionService;
-import org.eclipse.edc.spi.system.apiversion.VersionRecord;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.PortMapping;
-import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
-
-import java.io.IOException;
-import java.util.stream.Stream;
 
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DCP_CONTEXT_URL;
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_0_8;
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
-import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
 import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_TERM;
 import static org.eclipse.edc.identityhub.api.PresentationApiExtension.NAME;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_0_8;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_1_0;
-import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.PRESENTATION;
-import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.RESOLUTION;
+import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.CREDENTIALS;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = NAME)
 public class PresentationApiExtension implements ServiceExtension {
 
     public static final String NAME = "Presentation API Extension";
-    private static final String API_VERSION_JSON_FILE = "presentation-api-version.json";
-
-    @Configuration
-    private PresentationApiConfiguration apiConfiguration;
 
     @Inject
     private TypeTransformerRegistry typeTransformer;
@@ -86,10 +68,6 @@ public class PresentationApiExtension implements ServiceExtension {
     private TypeManager typeManager;
     @Inject
     private ParticipantContextService participantContextService;
-    @Inject
-    private ApiVersionService apiVersionService;
-    @Inject
-    private PortMappingRegistry portMappingRegistry;
 
     @Override
     public String name() {
@@ -98,25 +76,20 @@ public class PresentationApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var contextString = determineApiContext(context);
-
-        portMappingRegistry.register(new PortMapping(contextString, apiConfiguration.port(), apiConfiguration.path()));
+        var contextString = CREDENTIALS;
 
         registerValidator(DSPACE_DCP_NAMESPACE_V_0_8);
         registerValidator(DSPACE_DCP_NAMESPACE_V_1_0);
 
 
-        var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, selfIssuedTokenVerifier, verifiablePresentationService, context.getMonitor(), participantContextService, jsonLd);
+        var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, selfIssuedTokenVerifier, verifiablePresentationService, context.getMonitor().withPrefix("PresentationAPI"), participantContextService, jsonLd);
         webService.registerResource(contextString, new ObjectMapperProvider(typeManager, JSON_LD));
         webService.registerResource(contextString, controller);
 
         jsonLd.registerContext(DCP_CONTEXT_URL, DCP_SCOPE_V_0_8);
-        jsonLd.registerContext(DSPACE_DCP_V_1_0_CONTEXT, DCP_SCOPE_V_1_0);
 
         registerTransformers(DCP_SCOPE_V_0_8, DSPACE_DCP_NAMESPACE_V_0_8);
         registerTransformers(DCP_SCOPE_V_1_0, DSPACE_DCP_NAMESPACE_V_1_0);
-
-        registerVersionInfo(getClass().getClassLoader());
     }
 
     void registerTransformers(String scope, JsonLdNamespace namespace) {
@@ -129,38 +102,4 @@ public class PresentationApiExtension implements ServiceExtension {
     private void registerValidator(JsonLdNamespace namespace) {
         validatorRegistry.register(namespace.toIri(PRESENTATION_QUERY_MESSAGE_TERM), new PresentationQueryValidator(namespace));
     }
-
-    private String determineApiContext(ServiceExtensionContext context) {
-
-        if (context.getConfig("web.http").getRelativeEntries(PRESENTATION).isEmpty() && !context.getConfig("web.http").getRelativeEntries(RESOLUTION).isEmpty()) {
-            context.getMonitor().warning("Deprecated config: 'web.http.%s.* was replaced by 'web.http.%s.*', please update at your earliest convenience.".formatted(RESOLUTION, PRESENTATION));
-            return RESOLUTION;
-        }
-        return PRESENTATION;
-    }
-
-    private void registerVersionInfo(ClassLoader resourceClassLoader) {
-        try (var versionContent = resourceClassLoader.getResourceAsStream(API_VERSION_JSON_FILE)) {
-            if (versionContent == null) {
-                throw new EdcException("Version file not found or not readable.");
-            }
-            Stream.of(typeManager.getMapper()
-                            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-                            .readValue(versionContent, VersionRecord[].class))
-                    .forEach(vr -> apiVersionService.addRecord("presentation", vr));
-        } catch (IOException e) {
-            throw new EdcException(e);
-        }
-    }
-
-    @Settings
-    record PresentationApiConfiguration(
-            @Setting(key = "web.http." + PRESENTATION + ".port", description = "Port for " + PRESENTATION + " api context", defaultValue = 13131 + "")
-            int port,
-            @Setting(key = "web.http." + PRESENTATION + ".path", description = "Path for " + PRESENTATION + " api context", defaultValue = "/api/presentation")
-            String path
-    ) {
-
-    }
-
 }

--- a/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -82,7 +82,8 @@ public class PresentationApiExtension implements ServiceExtension {
         registerValidator(DSPACE_DCP_NAMESPACE_V_1_0);
 
 
-        var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, selfIssuedTokenVerifier, verifiablePresentationService, context.getMonitor().withPrefix("PresentationAPI"), participantContextService, jsonLd);
+        var controller = new PresentationApiController(validatorRegistry, typeTransformer, credentialResolver, selfIssuedTokenVerifier,
+                verifiablePresentationService, context.getMonitor().withPrefix("PresentationAPI"), participantContextService, jsonLd);
         webService.registerResource(contextString, new ObjectMapperProvider(typeManager, JSON_LD));
         webService.registerResource(contextString, controller);
 

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.identityhub.api;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import jakarta.json.Json;
 import org.eclipse.edc.iam.identitytrust.transform.to.JwtToVerifiableCredentialTransformer;
 import org.eclipse.edc.identityhub.api.storage.StorageApiController;
@@ -27,46 +26,32 @@ import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextServ
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriter;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
-import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.runtime.metamodel.annotation.Setting;
-import org.eclipse.edc.runtime.metamodel.annotation.Settings;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
-import org.eclipse.edc.spi.system.apiversion.ApiVersionService;
-import org.eclipse.edc.spi.system.apiversion.VersionRecord;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.transform.transformer.edc.to.JsonValueToGenericTypeTransformer;
 import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
 import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
 import org.eclipse.edc.web.spi.WebService;
-import org.eclipse.edc.web.spi.configuration.PortMapping;
-import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 
-import java.io.IOException;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
-import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_V_1_0_CONTEXT;
 import static org.eclipse.edc.identityhub.api.StorageApiExtension.NAME;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_1_0;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIAL_MESSAGE_TERM;
-import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.STORAGE;
+import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.CREDENTIALS;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 @Extension(value = NAME)
 public class StorageApiExtension implements ServiceExtension {
 
     public static final String NAME = "Storage API Extension";
-    private static final String API_VERSION_JSON_FILE = "storage-api-version.json";
 
-    @Configuration
-    private StorageApiConfiguration apiConfiguration;
     @Inject
     private TypeTransformerRegistry typeTransformer;
     @Inject
@@ -77,10 +62,6 @@ public class StorageApiExtension implements ServiceExtension {
     private JsonLd jsonLd;
     @Inject
     private TypeManager typeManager;
-    @Inject
-    private ApiVersionService apiVersionService;
-    @Inject
-    private PortMappingRegistry portMappingRegistry;
     @Inject
     private CredentialWriter writer;
     @Inject
@@ -98,22 +79,15 @@ public class StorageApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var contextString = STORAGE;
-
-        portMappingRegistry.register(new PortMapping(contextString, apiConfiguration.port(), apiConfiguration.path()));
+        var contextString = CREDENTIALS;
 
         validatorRegistry.register(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_MESSAGE_TERM), new CredentialMessageValidator());
 
-
-        var controller = new StorageApiController(validatorRegistry, typeTransformer, jsonLd, writer, context.getMonitor(), issuerTokenVerifier, participantContextService);
+        var controller = new StorageApiController(validatorRegistry, typeTransformer, jsonLd, writer, context.getMonitor().withPrefix("StorageAPI"), issuerTokenVerifier, participantContextService);
         webService.registerResource(contextString, new ObjectMapperProvider(typeManager, JSON_LD));
         webService.registerResource(contextString, controller);
 
-        jsonLd.registerContext(DSPACE_DCP_V_1_0_CONTEXT, DCP_SCOPE_V_1_0);
-
         registerTransformers(DCP_SCOPE_V_1_0, DSPACE_DCP_NAMESPACE_V_1_0);
-
-        registerVersionInfo(getClass().getClassLoader());
     }
 
     void registerTransformers(String scope, JsonLdNamespace namespace) {
@@ -130,29 +104,4 @@ public class StorageApiExtension implements ServiceExtension {
         // no need to register a JsonObject -> VerifiableCredential transformer here, because LD-Credentials
         // in the CredentialContainer would be JSON-literals, so they can be converted using an ObjectMapper
     }
-
-    private void registerVersionInfo(ClassLoader resourceClassLoader) {
-        try (var versionContent = resourceClassLoader.getResourceAsStream(API_VERSION_JSON_FILE)) {
-            if (versionContent == null) {
-                throw new EdcException("Version file not found or not readable.");
-            }
-            Stream.of(typeManager.getMapper()
-                            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-                            .readValue(versionContent, VersionRecord[].class))
-                    .forEach(vr -> apiVersionService.addRecord("storage", vr));
-        } catch (IOException e) {
-            throw new EdcException(e);
-        }
-    }
-
-    @Settings
-    record StorageApiConfiguration(
-            @Setting(key = "web.http." + STORAGE + ".port", description = "Port for " + STORAGE + " api context", defaultValue = 14141 + "")
-            int port,
-            @Setting(key = "web.http." + STORAGE + ".path", description = "Path for " + STORAGE + " api context", defaultValue = "/api/storage")
-            String path
-    ) {
-
-    }
-
 }

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/storage/StorageApiController.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/storage/StorageApiController.java
@@ -45,7 +45,7 @@ import static org.eclipse.edc.web.spi.exception.ServiceResultHandler.exceptionMa
 
 @Consumes(APPLICATION_JSON)
 @Produces(APPLICATION_JSON)
-@Path("/v1alpha/participants/{participantContextId}/credentials")
+@Path("/v1/participants/{participantContextId}/credentials")
 public class StorageApiController implements StorageApi {
 
     private final JsonObjectValidatorRegistry validatorRegistry;

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/resources/storage-api-version.json
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/resources/storage-api-version.json
@@ -1,8 +1,0 @@
-[
-  {
-    "version": "0.0.1",
-    "urlPath": "/v1alpha",
-    "lastUpdated": "2025-02-14T12:00:00Z",
-    "maturity": null
-  }
-]

--- a/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/storage/StorageApiControllerTest.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/storage/StorageApiControllerTest.java
@@ -237,7 +237,7 @@ class StorageApiControllerTest extends RestControllerTestBase {
 
         return given()
                 .contentType("application/json")
-                .baseUri("http://localhost:" + port + "/v1alpha/participants/" + s + "/credentials")
+                .baseUri("http://localhost:" + port + "/v1/participants/" + s + "/credentials")
                 .when();
     }
 

--- a/resources/openapi/credentials-api.version
+++ b/resources/openapi/credentials-api.version
@@ -1,0 +1,1 @@
+protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/credentials-api-version.json

--- a/resources/openapi/presentation-api.version
+++ b/resources/openapi/presentation-api.version
@@ -1,1 +1,0 @@
-protocols/dcp/dcp-identityhub/presentation-api/src/main/resources/presentation-api-version.json

--- a/resources/openapi/storage-api.version
+++ b/resources/openapi/storage-api.version
@@ -1,1 +1,0 @@
-protocols/dcp/dcp-identityhub/storage-api/src/main/resources/storage-api-version.json

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,6 +83,7 @@ include(":protocols:dcp:dcp-validation-lib")
 include(":protocols:dcp:dcp-issuer:dcp-issuer-api")
 include(":protocols:dcp:dcp-issuer:dcp-issuer-core")
 
+include(":protocols:dcp:dcp-identityhub:credentials-api-configuration")
 include(":protocols:dcp:dcp-identityhub:presentation-api")
 include(":protocols:dcp:dcp-identityhub:storage-api")
 include(":protocols:dcp:dcp-identityhub:dcp-identityhub-transform-lib")

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/webcontext/IdentityHubApiContext.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/webcontext/IdentityHubApiContext.java
@@ -17,10 +17,7 @@ package org.eclipse.edc.identityhub.spi.webcontext;
 public interface IdentityHubApiContext {
     String IDENTITY = "identity";
     String IH_DID = "did";
-    String PRESENTATION = "presentation";
-    String STORAGE = "storage";
     String ISSUANCE_API = "issuance";
-    @Deprecated(since = "0.9.0")
-    String RESOLUTION = "resolution";
+    String CREDENTIALS = "credentials";
     String ISSUERADMIN = "issueradmin";
 }


### PR DESCRIPTION
## What this PR changes/adds

this PR exposes the Storage API and the Credentials API on the same web context called `credentials`.

to that end, the configurations were merged into `web.http.credentials.port/path`, and a dedicated `credentials-api-configuration` was introduced.

Important note: the Storage API is now available under `/v1/.../credentials` instead of `/v1alpha/.../credentials`, because the base URL paths for it and the PResentationAPI _must_ be identical.

## Why it does that

the holder DID document only contains one service entry `CredentialService` at which both APIs must be available.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #626 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
