### PR TITLE
feat: validate incoming CredentialMessage types and formats

### DIFF
--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/storage/StorageApiController.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/storage/StorageApiController.java
@@ -97,13 +97,9 @@ public class StorageApiController implements StorageApi {
         issuerTokenVerifier.verify(participantContext, authToken)
                 .orElseThrow(f -> new AuthenticationFailedException("ID token verification failed: %s".formatted(f.getFailureDetail())));
 
-
-        // todo: implement response validation by fetching the original CredentialRequest from the DB (using the holderPid )
-        // and comparing the credential types therein
-        monitor.warning("Validation of requested credential types against received credential types is not yet implemented.");
-
         var holderPid = credentialMessage.getHolderPid();
         var issuerPid = credentialMessage.getIssuerPid();
+
         var writeRequests = credentialMessage.getCredentials().stream().map(c -> new CredentialWriteRequest(c.payload(), c.format())).toList();
         return credentialWriter.write(holderPid, issuerPid, writeRequests, participantContextId)
                 .onSuccess(v -> monitor.debug("HolderCredentialRequest %s is now in state %s".formatted(holderPid, HolderRequestState.ISSUED)))

--- a/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/storage/StorageApiControllerTest.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/storage/StorageApiControllerTest.java
@@ -189,6 +189,21 @@ class StorageApiControllerTest extends RestControllerTestBase {
                 .body(containsString("foo"));
     }
 
+    @Test
+    void storeCredential_writerReturnsNotAuthorized_shouldReturn403() {
+        when(validatorRegistry.validate(any(), any())).thenReturn(ValidationResult.success());
+        when(credentialWriter.write(anyString(), anyString(), anyCollection(), anyString())).thenReturn(ServiceResult.unauthorized("foo"));
+
+        baseRequest()
+                .header("Authorization", "Bearer: " + generateJwt())
+                .body(credentialMessageJson())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(403)
+                .body(containsString("foo"));
+    }
+
     @Override
     protected Object controller() {
         return new StorageApiController(validatorRegistry,


### PR DESCRIPTION
## What this PR changes/adds

this PR adds validation for the credential types and serialization formats of an incoming `CredentialMessage`.

Sending credentials, where the type(s) or serialization formats do not correspond to a previously made `HolderCredentialRequest` is not allowed and will result in a HTTP 403 Unauthorized.

## Why it does that

prevent malicious issuers

## Further notes

- this is another thing that the `CredentialWriter` is doing. at some point we might consider splitting it up (which would require another aggregate service), or at least renaming it.
- added some `@DisplayName`s to the Storage API e2e test

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #581

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
