### PR TITLE
refactor: removes attestation linkage to holders

### DIFF
--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/IssuanceServicesExtension.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/IssuanceServicesExtension.java
@@ -28,7 +28,6 @@ import org.eclipse.edc.issuerservice.issuance.rule.CredentialRuleDefinitionEvalu
 import org.eclipse.edc.issuerservice.issuance.rule.CredentialRuleDefinitionValidatorRegistryImpl;
 import org.eclipse.edc.issuerservice.issuance.rule.CredentialRuleFactoryRegistryImpl;
 import org.eclipse.edc.issuerservice.spi.holder.HolderService;
-import org.eclipse.edc.issuerservice.spi.holder.store.HolderStore;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionService;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionStore;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionValidatorRegistry;
@@ -64,8 +63,6 @@ public class IssuanceServicesExtension implements ServiceExtension {
     private CredentialDefinitionStore store;
     @Inject
     private AttestationDefinitionStore attestationDefinitionStore;
-    @Inject
-    private HolderStore holderStore;
 
     @Inject
     private KeyPairService keyPairService;
@@ -99,7 +96,7 @@ public class IssuanceServicesExtension implements ServiceExtension {
 
     @Provider
     public AttestationDefinitionService createAttestationService() {
-        return new AttestationDefinitionServiceImpl(transactionContext, attestationDefinitionStore, holderStore, createAttestationDefinitionValidatorRegistry());
+        return new AttestationDefinitionServiceImpl(transactionContext, attestationDefinitionStore, createAttestationDefinitionValidatorRegistry());
     }
 
     @Provider

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/CredentialGeneratorRegistryImplTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/CredentialGeneratorRegistryImplTest.java
@@ -181,18 +181,13 @@ public class CredentialGeneratorRegistryImplTest {
 
         assertThat(result).isFailed().detail().contains("failed");
     }
-
+    
     private Holder createHolder(String id, String did, String name) {
-        return createHolder(id, did, name, List.of());
-    }
-
-    private Holder createHolder(String id, String did, String name, List<String> attestations) {
         return Holder.Builder.newInstance()
                 .participantContextId(UUID.randomUUID().toString())
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .build();
     }
 

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestApiEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestApiEndToEndTest.java
@@ -422,18 +422,13 @@ public class DcpCredentialRequestApiEndToEndTest {
         private String generateSiToken(String audience) {
             return generateJwt(audience, PARTICIPANT_DID, PARTICIPANT_DID, Map.of(), PARTICIPANT_KEY);
         }
-
+        
         private Holder createHolder(String id, String did, String name) {
-            return createHolder(id, did, name, List.of());
-        }
-
-        private Holder createHolder(String id, String did, String name, List<String> attestations) {
             return Holder.Builder.newInstance()
                     .participantContextId(UUID.randomUUID().toString())
                     .holderId(id)
                     .did(did)
                     .holderName(name)
-                    .attestations(attestations)
                     .build();
         }
     }

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestStatusApiEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestStatusApiEndToEndTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Base64;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -258,16 +257,11 @@ public class DcpCredentialRequestStatusApiEndToEndTest {
         }
 
         private Holder createHolder(String id, String did, String name) {
-            return createHolder(id, did, name, List.of());
-        }
-
-        private Holder createHolder(String id, String did, String name, List<String> attestations) {
             return Holder.Builder.newInstance()
                     .participantContextId(UUID.randomUUID().toString())
                     .holderId(id)
                     .did(did)
                     .holderName(name)
-                    .attestations(attestations)
                     .build();
         }
 

--- a/extensions/api/issuer-admin-api/attestation-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApi.java
+++ b/extensions/api/issuer-admin-api/attestation-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApi.java
@@ -58,46 +58,6 @@ public interface IssuerAttestationAdminApi {
     )
     Response createAttestationDefinition(String participantContextId, AttestationDefinitionRequest attestationRequest, SecurityContext securityContext);
 
-    @Operation(description = "Links an attestation definition to a holder. This enables a certain attestation definition for a holder.",
-            operationId = "linkAttestation",
-            parameters = {
-                    @Parameter(name = "holderId", description = "ID of the holder", required = true, in = ParameterIn.PATH),
-                    @Parameter(name = "attestationId", description = "ID of the attestation", required = true, in = ParameterIn.PATH)
-            },
-            responses = {
-                    @ApiResponse(responseCode = "204", description = "The attestation was linked successfully."),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "The holder was not found.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "409", description = "Can't add the holder, because a object with the same ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
-            }
-    )
-    Response linkAttestation(String attestationDefinitionId, String holderId);
-
-    @Operation(description = "Un-Links an attestation definition to a holder. This disables a certain attestation definition for a holder.",
-            operationId = "unlinkAttestation",
-            parameters = {
-                    @Parameter(name = "holderId", description = "ID of the holder", required = true, in = ParameterIn.PATH),
-                    @Parameter(name = "attestationId", description = "ID of the attestation", required = true, in = ParameterIn.PATH)
-            },
-            responses = {
-                    @ApiResponse(responseCode = "204", description = "The attestation was unlinked successfully."),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "404", description = "The holder was not found.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "409", description = "Can't add the holder, because a object with the same ID already exists",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
-            }
-    )
-    Response unlinkAttestation(String attestationDefinitionId, String holderId);
-
     @Operation(description = "Deletes an attestation definition.",
             operationId = "deleteAttestation",
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
@@ -116,24 +76,7 @@ public interface IssuerAttestationAdminApi {
             }
     )
     void deleteAttestationDefinition(String attestationDefinitionId, SecurityContext securityContext);
-
-    @Operation(description = "Get all attestations for a given participant.",
-            operationId = "getAttestations",
-            parameters = {
-                    @Parameter(name = "participantId", description = "ID of the participant", required = true, in = ParameterIn.PATH)
-            },
-            requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "A list of attestation metadata.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = AttestationDefinition.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
-                    @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
-            }
-    )
-    Collection<AttestationDefinition> getAttestationDefinitionsForHolder(String holderId);
-
+    
     @Operation(description = "Query attestation definitions",
             operationId = "queryAttestations",
             parameters = {

--- a/extensions/api/issuer-admin-api/attestation-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiController.java
+++ b/extensions/api/issuer-admin-api/attestation-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiController.java
@@ -16,12 +16,10 @@ package org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
@@ -57,45 +55,6 @@ public class IssuerAttestationAdminApiController implements IssuerAttestationAdm
     }
 
     @POST
-    @Path("/{attestationDefinitionId}/link")
-    @Override
-    public Response linkAttestation(@PathParam("attestationDefinitionId") String attestationDefinitionId,
-                                    @QueryParam("holderId") String holderId) {
-
-        if (holderId == null) {
-            throw new InvalidRequestException("holderId is null");
-        }
-
-        var wasCreated = attestationDefinitionService.linkAttestation(attestationDefinitionId, holderId)
-                .orElseThrow(InvalidRequestException::new);
-
-        return wasCreated
-                ? Response.created(URI.create("/attestations/" + attestationDefinitionId)).build()
-                : Response.noContent().build();
-
-
-    }
-
-    @POST
-    @Path("/{attestationDefinitionId}/unlink")
-    @Override
-    public Response unlinkAttestation(@PathParam("attestationDefinitionId") String attestationDefinitionId,
-                                      @QueryParam("holderId") String holderId) {
-
-        if (holderId == null) {
-            throw new InvalidRequestException("holderId is null");
-        }
-
-
-        var wasCreated = attestationDefinitionService.unlinkAttestation(holderId, attestationDefinitionId)
-                .orElseThrow(InvalidRequestException::new);
-
-        return wasCreated
-                ? Response.ok().build()
-                : Response.noContent().build();
-    }
-
-    @POST
     @Override
     public Response createAttestationDefinition(@PathParam("participantContextId") String participantContextId, AttestationDefinitionRequest attestationRequest, @Context SecurityContext securityContext) {
 
@@ -114,16 +73,6 @@ public class IssuerAttestationAdminApiController implements IssuerAttestationAdm
         authorizationService.isAuthorized(context, attestationDefinitionId, AttestationDefinition.class)
                 .compose(u -> attestationDefinitionService.deleteAttestation(attestationDefinitionId))
                 .orElseThrow(exceptionMapper(AttestationDefinition.class, attestationDefinitionId));
-    }
-
-    @GET
-    @Override
-    public Collection<AttestationDefinition> getAttestationDefinitionsForHolder(@QueryParam("holderId") String holderId) {
-        if (holderId == null) {
-            throw new InvalidRequestException("holderId is null");
-        }
-        return attestationDefinitionService.getAttestationsForHolder(holderId)
-                .orElseThrow(InvalidRequestException::new);
     }
 
     @POST

--- a/extensions/api/issuer-admin-api/attestation-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/attestation-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiControllerTest.java
@@ -36,7 +36,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class IssuerAttestationAdminApiControllerTest extends RestControllerTestBase {
@@ -49,95 +48,6 @@ class IssuerAttestationAdminApiControllerTest extends RestControllerTestBase {
     @BeforeEach
     void setUp() {
         when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
-    }
-
-    @Test
-    void linkAttestation() {
-        when(attestationDefinitionService.linkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.success(true));
-
-        baseRequest()
-                .post("/test-attestation/link?holderId=test-participant")
-                .then()
-                .log().ifError()
-                .statusCode(201);
-    }
-
-    @Test
-    void linkAttestation_noHolderId_expect400() {
-        when(attestationDefinitionService.linkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.success(true));
-
-        baseRequest()
-                .post("/test-attestation/link")
-                .then()
-                .log().ifError()
-                .statusCode(400);
-    }
-
-    @Test
-    void linkAttestation_whenNotFound_expect400() {
-        when(attestationDefinitionService.linkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.notFound("foo"));
-        baseRequest()
-                .post("/test-attestation/link?holderId=test-participant")
-                .then()
-                .statusCode(400);
-    }
-
-
-    @Test
-    void linkAttestation_alreadyLinked_expect204() {
-        when(attestationDefinitionService.linkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.success(false));
-        baseRequest()
-                .post("/test-attestation/link?holderId=test-participant")
-                .then()
-                .statusCode(204);
-    }
-
-    @Test
-    void unlinkAttestation_expect200() {
-        when(attestationDefinitionService.unlinkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.success(true));
-
-        baseRequest()
-                .post("/test-attestation/unlink?holderId=test-participant")
-                .then()
-                .statusCode(200);
-    }
-
-    @Test
-    void unlinkAttestation_noHolderId_expect400() {
-        when(attestationDefinitionService.unlinkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.success(true));
-
-        baseRequest()
-                .post("/test-attestation/unlink")
-                .then()
-                .log().ifError()
-                .statusCode(400);
-    }
-
-    @Test
-    void unlinkAttestation_holderNotFound_expect400() {
-        when(attestationDefinitionService.unlinkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.notFound("foo"));
-        baseRequest()
-                .post("/test-attestation/unlink?participantId=test-participant")
-                .then()
-                .statusCode(400);
-    }
-
-
-    @Test
-    void unlinkAttestation_notLinked_expect204() {
-        when(attestationDefinitionService.unlinkAttestation(anyString(), anyString()))
-                .thenReturn(ServiceResult.success(false));
-        baseRequest()
-                .post("/test-attestation/unlink?holderId=test-participant")
-                .then()
-                .statusCode(204);
     }
 
     @Test
@@ -189,58 +99,7 @@ class IssuerAttestationAdminApiControllerTest extends RestControllerTestBase {
                 .then()
                 .statusCode(404);
     }
-
-    @Test
-    void getAttestationDefinitionsForHolder() {
-        when(attestationDefinitionService.getAttestationsForHolder(anyString()))
-                .thenReturn(ServiceResult.success(List.of(
-                        createAttestationDefinition("test-id", "test-type", Map.of()),
-                        createAttestationDefinition("test-id2", "test-type", Map.of())))
-                );
-
-        var attestations = baseRequest()
-                .get("?holderId=test-participant")
-                .then()
-                .statusCode(200)
-                .extract().body().as(AttestationDefinition[].class);
-
-        assertThat(attestations).hasSize(2);
-    }
-
-    @Test
-    void getAttestationDefinitionsForParticipant_whenHolderIdMissing_expect400() {
-
-        baseRequest()
-                .get()
-                .then()
-                .statusCode(400);
-
-        verifyNoInteractions(attestationDefinitionService);
-    }
-
-
-    @Test
-    void getAttestationDefinitionsForHolder_noResult_expect200() {
-        when(attestationDefinitionService.getAttestationsForHolder(anyString()))
-                .thenReturn(ServiceResult.success(List.of()));
-
-        var attestations = baseRequest()
-                .get("?holderId=test-participant")
-                .then()
-                .statusCode(200)
-                .extract().body().as(AttestationDefinition[].class);
-
-        assertThat(attestations).isEmpty();
-    }
-
-    @Test
-    void getAttestationDefinitionsForParticipant_holderNotFound_expect400() {
-        baseRequest()
-                .get("?holder=test-participant")
-                .then()
-                .statusCode(400);
-    }
-
+    
     @Test
     void queryAttestationDefinitions() {
         var definitions = List.of(
@@ -309,5 +168,5 @@ class IssuerAttestationAdminApiControllerTest extends RestControllerTestBase {
                 .participantContextId(PARTICIPANT_ID)
                 .build();
     }
-    
+
 }

--- a/extensions/api/issuer-admin-api/holder-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/holder/v1/unstable/IssuerHolderAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/holder-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/holder/v1/unstable/IssuerHolderAdminApiControllerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
-import java.util.List;
 import java.util.Set;
 
 import static io.restassured.RestAssured.given;
@@ -167,16 +166,11 @@ class IssuerHolderAdminApiControllerTest extends RestControllerTestBase {
     }
 
     private Holder createHolder(String id, String did, String name) {
-        return createHolder(id, did, name, List.of());
-    }
-
-    private Holder createHolder(String id, String did, String name, List<String> attestations) {
         return Holder.Builder.newInstance()
                 .participantContextId(PARTICIPANT_ID)
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .build();
     }
 

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-03-04T15:00:00Z",
+    "lastUpdated": "2025-03-05T15:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/BaseSqlDialectStatements.java
@@ -31,7 +31,6 @@ public class BaseSqlDialectStatements implements HolderStoreStatements {
                 .column(getHolderNameColumn())
                 .column(getCreateTimestampColumn())
                 .column(getLastModifiedTimestampColumn())
-                .jsonColumn(getAttestationsColumn())
                 .insertInto(getHoldersTable());
     }
 
@@ -43,7 +42,6 @@ public class BaseSqlDialectStatements implements HolderStoreStatements {
                 .column(getHolderNameColumn())
                 .column(getCreateTimestampColumn())
                 .column(getLastModifiedTimestampColumn())
-                .jsonColumn(getAttestationsColumn())
                 .update(getHoldersTable(), getIdColumn());
     }
 

--- a/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/HolderStoreStatements.java
+++ b/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/HolderStoreStatements.java
@@ -50,11 +50,7 @@ public interface HolderStoreStatements extends SqlStatements {
     default String getDidColumn() {
         return "did";
     }
-
-    default String getAttestationsColumn() {
-        return "attestations";
-    }
-
+    
 
     String getInsertTemplate();
 

--- a/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/SqlHolderStore.java
+++ b/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/SqlHolderStore.java
@@ -87,8 +87,7 @@ public class SqlHolderStore extends AbstractSqlStore implements HolderStore {
                         holder.getDid(),
                         holder.getHolderName(),
                         0, //participant.createdAt(),
-                        0, //participant.lastModifiedAt());
-                        toJson(holder.getAttestations())
+                        0  //participant.lastModifiedAt());
                 );
                 return success();
 
@@ -126,7 +125,6 @@ public class SqlHolderStore extends AbstractSqlStore implements HolderStore {
                             holder.getHolderName(),
                             0, //participant.createdAt(),
                             0, //participant.lastModifiedAt());
-                            toJson(holder.getAttestations()),
                             holder.getHolderId()
                     );
                     return StoreResult.success();
@@ -170,12 +168,10 @@ public class SqlHolderStore extends AbstractSqlStore implements HolderStore {
         var participantContextId = resultSet.getString(statements.getParticipantContextIdColumn());
         var created = resultSet.getLong(statements.getCreateTimestampColumn());
         var lastmodified = resultSet.getLong(statements.getLastModifiedTimestampColumn());
-        var attestations = fromJson(resultSet.getString(statements.getAttestationsColumn()), LIST_REF);
         return Holder.Builder.newInstance()
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .participantContextId(participantContextId)
                 .build();
     }

--- a/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/schema/postgres/HolderMapping.java
+++ b/extensions/store/sql/issuerservice-holder-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/holder/schema/postgres/HolderMapping.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.issuerservice.store.sql.holder.schema.postgres;
 
 import org.eclipse.edc.issuerservice.store.sql.holder.HolderStoreStatements;
-import org.eclipse.edc.sql.translation.JsonArrayTranslator;
 import org.eclipse.edc.sql.translation.TranslationMapping;
 
 
@@ -30,7 +29,6 @@ public class HolderMapping extends TranslationMapping {
     public static final String FIELD_LASTMODIFIED_TIMESTAMP = "lastModified";
     public static final String FIELD_DID = "did";
     public static final String FIELD_NAME = "holderName";
-    public static final String FIELD_ATTESTATIONS = "attestations";
 
     public HolderMapping(HolderStoreStatements statements) {
         add(FIELD_ID, statements.getIdColumn());
@@ -39,6 +37,5 @@ public class HolderMapping extends TranslationMapping {
         add(FIELD_LASTMODIFIED_TIMESTAMP, statements.getLastModifiedTimestampColumn());
         add(FIELD_NAME, statements.getHolderNameColumn());
         add(FIELD_DID, statements.getDidColumn());
-        add(FIELD_ATTESTATIONS, new JsonArrayTranslator(statements.getAttestationsColumn()));
     }
 }

--- a/extensions/store/sql/issuerservice-holder-store-sql/src/main/resources/holder-schema.sql
+++ b/extensions/store/sql/issuerservice-holder-store-sql/src/main/resources/holder-schema.sql
@@ -20,8 +20,7 @@ CREATE TABLE IF NOT EXISTS holders
     did                          VARCHAR NOT NULL,             -- the DID with which this holder is identified
     holder_name                  VARCHAR,                      -- the display name of the holder
     created_date       BIGINT    NOT NULL,                     -- POSIX timestamp of the creation of the PC
-    last_modified_date BIGINT,                                 -- POSIX timestamp of the last modified date
-    attestations       JSON      DEFAULT '[]'                  -- enabled attestations for this holder
+    last_modified_date BIGINT                                  -- POSIX timestamp of the last modified date
 );
 CREATE UNIQUE INDEX IF NOT EXISTS holders_holder_id_uindex ON holders USING btree (holder_id);
 

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1alpha/credentialrequest/CredentialRequestApiControllerTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1alpha/credentialrequest/CredentialRequestApiControllerTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
 import java.sql.Date;
 import java.time.Instant;
 import java.util.Base64;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -209,16 +208,11 @@ class CredentialRequestApiControllerTest extends RestControllerTestBase {
     }
 
     private Holder createHolder(String id, String did, String name) {
-        return createHolder(id, did, name, List.of());
-    }
-
-    private Holder createHolder(String id, String did, String name, List<String> attestations) {
         return Holder.Builder.newInstance()
                 .participantContextId(UUID.randomUUID().toString())
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .build();
     }
 

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1alpha/credentialrequest/CredentialRequestStatusApiControllerTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1alpha/credentialrequest/CredentialRequestStatusApiControllerTest.java
@@ -160,18 +160,13 @@ class CredentialRequestStatusApiControllerTest extends RestControllerTestBase {
                 .state(IssuanceProcessStates.DELIVERED.code())
                 .build();
     }
-
+    
     private Holder createHolder(String id, String did, String name) {
-        return createHolder(id, did, name, List.of());
-    }
-
-    private Holder createHolder(String id, String did, String name, List<String> attestations) {
         return Holder.Builder.newInstance()
                 .participantContextId(UUID.randomUUID().toString())
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .build();
     }
 

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpHolderTokenVerifierImplTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpHolderTokenVerifierImplTest.java
@@ -116,16 +116,11 @@ public class DcpHolderTokenVerifierImplTest {
     }
 
     private Holder createHolder(String id, String did, String name) {
-        return createHolder(id, did, name, List.of());
-    }
-
-    private Holder createHolder(String id, String did, String name, List<String> attestations) {
         return Holder.Builder.newInstance()
                 .participantContextId(UUID.randomUUID().toString())
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .build();
     }
 

--- a/spi/issuerservice/issuerservice-holder-spi/src/main/java/org/eclipse/edc/issuerservice/spi/holder/model/Holder.java
+++ b/spi/issuerservice/issuerservice-holder-spi/src/main/java/org/eclipse/edc/issuerservice/spi/holder/model/Holder.java
@@ -18,9 +18,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.AbstractParticipantResource;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -32,8 +29,6 @@ public class Holder extends AbstractParticipantResource {
     private String holderId;
     private String did;
     private String holderName;
-    private List<String> attestations = new ArrayList<>();
-
 
     private Holder() {
     }
@@ -48,18 +43,6 @@ public class Holder extends AbstractParticipantResource {
 
     public String getHolderName() {
         return holderName;
-    }
-
-    public List<String> getAttestations() {
-        return Collections.unmodifiableList(attestations); // force mutation through method
-    }
-
-    public void addAttestation(String attestationId) {
-        attestations.add(attestationId);
-    }
-
-    public boolean removeAttestation(String attestationId) {
-        return attestations.remove(attestationId);
     }
 
 
@@ -87,11 +70,6 @@ public class Holder extends AbstractParticipantResource {
 
         public Builder holderName(String holderName) {
             entity.holderName = holderName;
-            return this;
-        }
-
-        public Builder attestations(List<String> attestations) {
-            entity.attestations = new ArrayList<>(attestations); //ensure mutability
             return this;
         }
 

--- a/spi/issuerservice/issuerservice-holder-spi/src/testFixtures/java/org/eclipse/edc/issuerservice/spi/holder/store/HolderStoreTestBase.java
+++ b/spi/issuerservice/issuerservice-holder-spi/src/testFixtures/java/org/eclipse/edc/issuerservice/spi/holder/store/HolderStoreTestBase.java
@@ -19,7 +19,6 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.UUID;
 
 import static java.util.stream.IntStream.range;
@@ -190,20 +189,15 @@ public abstract class HolderStoreTestBase {
     protected abstract HolderStore getStore();
 
     private Holder createHolder() {
-        return createHolder("p-id", "did:web:participant", "participant display name", List.of("att1", "att2"));
+        return createHolder("p-id", "did:web:participant", "participant display name");
     }
 
     private Holder createHolder(String id, String did, String name) {
-        return createHolder(id, did, name, List.of());
-    }
-
-    private Holder createHolder(String id, String did, String name, List<String> attestations) {
         return Holder.Builder.newInstance()
                 .participantContextId(UUID.randomUUID().toString())
                 .holderId(id)
                 .did(did)
                 .holderName(name)
-                .attestations(attestations)
                 .build();
     }
 }

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/attestation/AttestationDefinitionService.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/attestation/AttestationDefinitionService.java
@@ -37,35 +37,6 @@ public interface AttestationDefinitionService {
     ServiceResult<Void> deleteAttestation(String attestationId);
 
     /**
-     * "Links" (=enables) an {@link AttestationDefinition} for a given {@code Holder}. When a holder makes an issuance request,
-     * they can only request claims (attestation data) from AttestationDefinitions that are enabled for them.
-     *
-     * @param attestationId The ID of the {@link AttestationDefinition}
-     * @param holderId      The ID of the {@code Holder}
-     * @return success with {@link Boolean#TRUE} if the link was created successfully, or {@link Boolean#FALSE} if the link already existed, a failure otherwise.
-     */
-    ServiceResult<Boolean> linkAttestation(String attestationId, String holderId);
-
-    /**
-     * "Unlinks" (=disables) an {@link AttestationDefinition} for a given {@code Holder}. When a holder makes an issuance request,
-     * they can only request claims (attestation data) from AttestationDefinitions that are enabled for them. Removing the link
-     * disables a certain {@link AttestationDefinition}
-     *
-     * @param attestationId The ID of the {@link AttestationDefinition}
-     * @param holderId      The ID of the {@code Holder}
-     * @return success with {@link Boolean#TRUE} if the link was deleted successfully, {@link Boolean#FALSE} if no link existed, a failure otherwise.
-     */
-    ServiceResult<Boolean> unlinkAttestation(String attestationId, String holderId);
-
-    /**
-     * Gets all attestations for a given holder.
-     *
-     * @param holderId the ID of the holder
-     * @return A (potentially empty) list of {@link AttestationDefinition} objects, or an error if the holder was not found.
-     */
-    ServiceResult<Collection<AttestationDefinition>> getAttestationsForHolder(String holderId);
-
-    /**
      * Gets an {@link AttestationDefinition} by id.
      *
      * @param attestationId the ID of the attestation


### PR DESCRIPTION
## What this PR changes/adds

 removes attestation linkage to holders

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #652 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
