### PR TITLE
feat: add signing capability to credential generator

### DIFF
--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/CredentialGeneratorRegistryImpl.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/CredentialGeneratorRegistryImpl.java
@@ -75,6 +75,7 @@ public class CredentialGeneratorRegistryImpl implements CredentialGeneratorRegis
                 .compose(mappedClaims -> generateCredentialInternal(participantContextId, participantId, credentialGenerationRequest, mappedClaims));
     }
 
+    @Override
     public Result<VerifiableCredentialContainer> signCredential(String participantContextId, VerifiableCredential credential, CredentialFormat format) {
         return ofNullable(generators.get(format))
                 .map(generator -> fetchActiveKeyPair(participantContextId)

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGenerator.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGenerator.java
@@ -141,11 +141,17 @@ public class JwtCredentialGenerator implements CredentialGenerator {
     }
 
     private Map<String, Object> createVcClaim(VerifiableCredential verifiableCredential, String... type) {
-        return Map.of(
-                JsonLdKeywords.CONTEXT, List.of(VcConstants.W3C_CREDENTIALS_URL),
-                TYPE_PROPERTY, Arrays.asList(type),
-                CREDENTIAL_SUBJECT, credentialSubjectClaims(verifiableCredential),
-                CREDENTIAL_STATUS, credentialStatusClaims(verifiableCredential));
+        var claims = new HashMap<>(
+                Map.of(JsonLdKeywords.CONTEXT, List.of(VcConstants.W3C_CREDENTIALS_URL),
+                        TYPE_PROPERTY, Arrays.asList(type),
+                        CREDENTIAL_SUBJECT, credentialSubjectClaims(verifiableCredential)
+                ));
+
+        var status = credentialStatusClaims(verifiableCredential);
+        if (!status.isEmpty()) {
+            claims.put(CREDENTIAL_STATUS, credentialStatusClaims(verifiableCredential));
+        }
+        return claims;
     }
 
     private Map<String, Object> credentialStatusClaims(VerifiableCredential verifiableCredential) {

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGenerator.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGenerator.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.issuerservice.issuance.generator;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.DataModelVersion;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
@@ -25,6 +26,7 @@ import org.eclipse.edc.issuerservice.spi.issuance.generator.CredentialGenerator;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames;
+import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.spi.KeyIdDecorator;
 import org.eclipse.edc.token.spi.TokenDecorator;
@@ -32,7 +34,9 @@ import org.eclipse.edc.token.spi.TokenGenerationService;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -41,9 +45,9 @@ public class JwtCredentialGenerator implements CredentialGenerator {
 
     public static final String VERIFIABLE_CREDENTIAL_CLAIM = "vc";
     public static final String CREDENTIAL_SUBJECT = "credentialSubject";
+    public static final String CREDENTIAL_STATUS = "credentialStatus";
     public static final String VERIFIABLE_CREDENTIAL = "VerifiableCredential";
     public static final String TYPE_PROPERTY = "type";
-
     private final TokenGenerationService tokenGenerationService;
     private final Clock clock;
 
@@ -53,27 +57,46 @@ public class JwtCredentialGenerator implements CredentialGenerator {
     }
 
     @Override
-    public Result<VerifiableCredentialContainer> generateCredential(CredentialDefinition definition, String privateKeyAlias, String publicKeyId, String issuerId, String participantId, Map<String, Object> claims) {
+    public Result<VerifiableCredentialContainer> generateCredential(CredentialDefinition definition, String privateKeyAlias, String publicKeyId, String issuerId, String holderDid, Map<String, Object> claims) {
 
         var subjectResult = getCredentialSubject(claims);
-
         if (subjectResult.failed()) {
             return subjectResult.mapFailure();
         }
 
-        var credential = generateVerifiableCredential(definition.getCredentialType(), definition.getValidity(), issuerId, participantId, subjectResult.getContent());
+        var statusResult = createCredentialStatus(claims);
 
+        var credentialBuilder = generateVerifiableCredential(definition.getCredentialType(), definition.getValidity(), issuerId, holderDid, subjectResult.getContent());
+
+        statusResult.onSuccess(credentialBuilder::credentialStatus);
+
+        var credential = credentialBuilder.build();
+        return signCredentialInternal(credential, privateKeyAlias, publicKeyId, issuerId, holderDid, VERIFIABLE_CREDENTIAL, definition.getCredentialType())
+                .map(token -> new VerifiableCredentialContainer(token, CredentialFormat.VC1_0_JWT, credential));
+    }
+
+    @Override
+    public Result<String> signCredential(VerifiableCredential credential, String privateKeyAlias, String publicKeyId) {
+        var issuerId = credential.getIssuer().id();
+        var type = credential.getType().toArray(new String[0]);
+        var holderDid = credential.getCredentialSubject().iterator().next().getId();
+
+        return signCredentialInternal(credential, privateKeyAlias, publicKeyId, issuerId, holderDid, type);
+    }
+
+
+    private Result<String> signCredentialInternal(VerifiableCredential credential, String privateKeyAlias, String publicKeyId, String issuerId, String holderDid, String... types) {
         var composedKeyId = publicKeyId;
         if (!publicKeyId.startsWith(issuerId)) {
             composedKeyId = issuerId + "#" + publicKeyId;
         }
 
-        return tokenGenerationService.generate(privateKeyAlias, vcDecorator(definition.getCredentialType(), participantId, credential), new KeyIdDecorator(composedKeyId))
-                .map(token -> new VerifiableCredentialContainer(token.getToken(), CredentialFormat.VC1_0_JWT, credential));
+        return tokenGenerationService.generate(privateKeyAlias, vcDecorator(holderDid, credential, types), new KeyIdDecorator(composedKeyId))
+                .map(TokenRepresentation::getToken);
     }
 
-    @SuppressWarnings("unchecked")
-    private VerifiableCredential generateVerifiableCredential(String type, long validity, String issuer, String participantId, Map<String, Object> credentialSubject) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private VerifiableCredential.Builder generateVerifiableCredential(String type, long validity, String issuer, String holderId, Map<String, Object> credentialSubject) {
         return VerifiableCredential.Builder.newInstance()
                 .issuer(new Issuer(issuer))
                 .dataModelVersion(DataModelVersion.V_1_1)
@@ -81,10 +104,9 @@ public class JwtCredentialGenerator implements CredentialGenerator {
                 .expirationDate(Instant.now(clock).plusSeconds(validity))
                 .types(List.of(VERIFIABLE_CREDENTIAL, type))
                 .credentialSubject(CredentialSubject.Builder.newInstance()
-                        .id(participantId)
+                        .id(holderId)
                         .claims(credentialSubject)
-                        .build())
-                .build();
+                        .build());
     }
 
     @SuppressWarnings("unchecked")
@@ -95,22 +117,46 @@ public class JwtCredentialGenerator implements CredentialGenerator {
         return Result.success((Map<String, Object>) claims.get(CREDENTIAL_SUBJECT));
     }
 
-    private TokenDecorator vcDecorator(String type, String participantId, VerifiableCredential credential) {
+    @SuppressWarnings("unchecked")
+    private Result<CredentialStatus> createCredentialStatus(Map<String, Object> claims) {
+        if (!claims.containsKey(CREDENTIAL_STATUS)) {
+            return Result.failure("no credentialStatus in claims");
+        }
+        var statusClaims = (Map<String, Object>) claims.get(CREDENTIAL_STATUS);
+
+        return Result.success(new CredentialStatus((String) statusClaims.get("id"),
+                (String) statusClaims.get("type"),
+                statusClaims));
+    }
+
+    private TokenDecorator vcDecorator(String participantId, VerifiableCredential credential, String... type) {
         var now = Date.from(clock.instant());
         return tp -> tp.claims(JwtRegisteredClaimNames.ISSUER, credential.getIssuer().id())
                 .claims(JwtRegisteredClaimNames.ISSUED_AT, now)
                 .claims(JwtRegisteredClaimNames.NOT_BEFORE, Date.from(credential.getIssuanceDate()))
                 .claims(JwtRegisteredClaimNames.JWT_ID, UUID.randomUUID().toString())
                 .claims(JwtRegisteredClaimNames.SUBJECT, participantId)
-                .claims(VERIFIABLE_CREDENTIAL_CLAIM, createVcClaim(type, credential))
-                .claims(JwtRegisteredClaimNames.EXPIRATION_TIME, Date.from(credential.getExpirationDate()));
+                .claims(VERIFIABLE_CREDENTIAL_CLAIM, createVcClaim(credential, type))
+                .claims(JwtRegisteredClaimNames.EXPIRATION_TIME, Date.from(credential.getExpirationDate())); //todo: this will fail for credentials that don't have an expiration date
     }
 
-    private Map<String, Object> createVcClaim(String type, VerifiableCredential verifiableCredential) {
+    private Map<String, Object> createVcClaim(VerifiableCredential verifiableCredential, String... type) {
         return Map.of(
                 JsonLdKeywords.CONTEXT, List.of(VcConstants.W3C_CREDENTIALS_URL),
-                TYPE_PROPERTY, List.of(VERIFIABLE_CREDENTIAL, type),
-                CREDENTIAL_SUBJECT, credentialSubjectClaims(verifiableCredential));
+                TYPE_PROPERTY, Arrays.asList(type),
+                CREDENTIAL_SUBJECT, credentialSubjectClaims(verifiableCredential),
+                CREDENTIAL_STATUS, credentialStatusClaims(verifiableCredential));
+    }
+
+    private Map<String, Object> credentialStatusClaims(VerifiableCredential verifiableCredential) {
+        if (verifiableCredential.getCredentialStatus().isEmpty()) {
+            return Map.of();
+        }
+        var status = verifiableCredential.getCredentialStatus().get(0);
+        var statusMap = new HashMap<String, Object>(Map.of("id", status.id(),
+                "type", status.type()));
+        statusMap.putAll(status.additionalProperties());
+        return statusMap;
     }
 
     private Map<String, Object> credentialSubjectClaims(VerifiableCredential verifiableCredential) {

--- a/e2e-tests/fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/issuerservice/IssuerServiceRuntimeConfiguration.java
+++ b/e2e-tests/fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/issuerservice/IssuerServiceRuntimeConfiguration.java
@@ -56,6 +56,8 @@ public class IssuerServiceRuntimeConfiguration extends AbstractRuntimeConfigurat
                 put("web.http.issuance.port", String.valueOf(issuerApiEndpoint.getUrl().getPort()));
                 put("web.http.issuance.path", issuerApiEndpoint.getUrl().getPath());
                 put("web.http.version.port", String.valueOf(getFreePort()));
+                put("web.http.identity.port", String.valueOf(getFreePort()));
+                put("web.http.identity.path", "/api/identity");
                 put("web.http.version.path", "/.well-known/api");
                 put("web.http.did.port", String.valueOf(didEndpoint.getUrl().getPort()));
                 put("web.http.did.path", didEndpoint.getUrl().getPath());

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/generator/CredentialGenerator.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/generator/CredentialGenerator.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.issuerservice.spi.issuance.generator;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
@@ -29,9 +30,8 @@ import java.util.Map;
  */
 @ExtensionPoint
 public interface CredentialGenerator {
-
     /**
-     * Generates a credential based on the given definition and claims
+     * Generates (and signs) a credential based on the given definition and claims
      *
      * @param definition      the definition of the credential
      * @param privateKeyAlias the alias of the private key to use for signing
@@ -39,8 +39,19 @@ public interface CredentialGenerator {
      * @param issuerId        the ID of the issuer
      * @param participantId   the ID of the participant
      * @param claims          the claims to include in the credential
-     * @return the generated {@link VerifiableCredentialContainer}
+     * @return the generated {@link VerifiableCredentialContainer} including the original credential, its serialized and signed form and the format
      */
     Result<VerifiableCredentialContainer> generateCredential(CredentialDefinition definition, String privateKeyAlias, String publicKeyId, String issuerId, String participantId, Map<String, Object> claims);
+
+
+    /**
+     * Signs an input {@link VerifiableCredential} with the given private key.
+     *
+     * @param credential      the input credential
+     * @param privateKeyAlias The alias of the private they that is expected to be found in the {@link org.eclipse.edc.spi.security.Vault}
+     * @param publicKeyId     the ID of the public key. Relevant for adding verification material to the signed representation.
+     * @return a String representing the serialized and signed credential, for example a JWT token, a Json-LD structure, etc.
+     */
+    Result<String> signCredential(VerifiableCredential credential, String privateKeyAlias, String publicKeyId);
 
 }

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/generator/CredentialGeneratorRegistry.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/generator/CredentialGeneratorRegistry.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.issuerservice.spi.issuance.generator;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
@@ -28,7 +29,6 @@ import java.util.Map;
  */
 @ExtensionPoint
 public interface CredentialGeneratorRegistry {
-
     /**
      * Adds a generator for the given {@link CredentialFormat}.
      *
@@ -69,4 +69,15 @@ public interface CredentialGeneratorRegistry {
      * @return The {@link VerifiableCredentialContainer} if successful, or the failure information if unsuccessful
      */
     Result<VerifiableCredentialContainer> generateCredential(String participantContextId, String participantId, CredentialGenerationRequest credentialGenerationRequest, Map<String, Object> claims);
+
+    /**
+     * Signs an input credential, i.e. creates its serialized representation (JWT, LD,...) including a proof.
+     *
+     * @param participantContextId The participant context ID (= issuer tenant). Relevant for selecting keypairs and issuer DIDs.
+     * @param verifiableCredential The verifiable credential that is to be signed
+     * @param format               The CredentialFormat, how the signed credential is to be represented
+     * @return A {@link VerifiableCredentialContainer} that contains the credential as object plus the raw representation (=signed form)
+     */
+    Result<VerifiableCredentialContainer> signCredential(String participantContextId, VerifiableCredential verifiableCredential, CredentialFormat format);
+
 }


### PR DESCRIPTION
## What this PR changes/adds

in addition to generate new credentials, the `CredentialGeneratorRegistry` (and by extension: the `CredentialGenerator`) are now capable of signing existing `VerifiableCredential` objects.

## Why it does that

this will be necessary when updating holder credentials, for example after a `credentialStatus` object was added. This happens at a later time, after the credential was generated.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
