### PR TITLE
fix: adds IssuerKeyIdValidationRule to SI token validation

### DIFF
--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verification/SelfIssuedTokenVerifierImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verification/SelfIssuedTokenVerifierImplTest.java
@@ -17,14 +17,17 @@ package org.eclipse.edc.identityhub.core.services.verification;
 import org.assertj.core.api.Assertions;
 import org.eclipse.edc.identityhub.publickey.KeyPairResourcePublicKeyResolver;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.JwtCreationUtil;
 import org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.VerifiableCredentialTestUtil;
 import org.eclipse.edc.junit.assertions.AbstractResultAssert;
 import org.eclipse.edc.keys.spi.PublicKeyResolver;
 import org.eclipse.edc.spi.iam.ClaimToken;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.token.spi.TokenValidationRulesRegistry;
 import org.eclipse.edc.token.spi.TokenValidationService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -51,6 +54,11 @@ class SelfIssuedTokenVerifierImplTest {
     private final KeyPairResourcePublicKeyResolver localPublicKeyResolver = mock();
     private final ParticipantContextService participantContextService = mock();
     private final SelfIssuedTokenVerifierImpl verifier = new SelfIssuedTokenVerifierImpl(tokenValidationSerivce, localPublicKeyResolver, tokenValidationRulesRegistry, pkResolver, participantContextService);
+
+    @BeforeEach
+    void beforeEach() {
+        when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.success(createParticipantContext()));
+    }
 
     @Test
     void verify_validSiToken_validAccessToken() {
@@ -106,4 +114,15 @@ class SelfIssuedTokenVerifierImplTest {
     }
 
 
+    private ParticipantContext createParticipantContext(String did) {
+        return ParticipantContext.Builder.newInstance()
+                .apiTokenAlias("token-alias")
+                .participantContextId(did)
+                .did(did)
+                .build();
+    }
+
+    private ParticipantContext createParticipantContext() {
+        return createParticipantContext(PARTICIPANT_CONTEXT_ID);
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

adds IssuerKeyIdValidationRule to SI token validation

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #656 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
