### PR TITLE
feat: add StatusList credential endpoint

### DIFF
--- a/core/issuerservice/issuerservice-core/build.gradle.kts
+++ b/core/issuerservice/issuerservice-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":core:lib:common-lib"))
     api(project(":core:lib:common-lib"))
 
+    implementation(project(":extensions:issuance:local-statuslist-publisher"))
     implementation(libs.edc.lib.store)
     testImplementation(libs.edc.junit)
     testImplementation(libs.edc.lib.query)

--- a/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/CredentialServiceExtension.java
+++ b/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/CredentialServiceExtension.java
@@ -25,6 +25,7 @@ import org.eclipse.edc.issuerservice.credentials.statuslist.bitstring.BitstringS
 import org.eclipse.edc.issuerservice.credentials.statuslist.bitstring.BitstringStatusListManager;
 import org.eclipse.edc.issuerservice.spi.credentials.CredentialStatusService;
 import org.eclipse.edc.issuerservice.spi.credentials.IssuerCredentialOfferService;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialPublisher;
 import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListInfoFactoryRegistry;
 import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListManager;
 import org.eclipse.edc.issuerservice.spi.holder.store.HolderStore;
@@ -79,6 +80,8 @@ public class CredentialServiceExtension implements ServiceExtension {
     private StatusListInfoFactoryRegistry factory;
     @Inject
     private ParticipantContextService particpantContextService;
+    @Inject
+    private StatusListCredentialPublisher credentialPublisher;
 
     @Provider
     public CredentialStatusService getStatusListService(ServiceExtensionContext context) {
@@ -87,7 +90,7 @@ public class CredentialServiceExtension implements ServiceExtension {
         // Bitstring StatusList is provided by default. others can be added via extensions
         fact.register(BITSTRING_STATUS_LIST_ENTRY, new BitstringStatusListFactory(store));
 
-        var manager = ofNullable(externalTracker).orElseGet(() -> new BitstringStatusListManager(store, transactionContext, registry, particpantContextService));
+        var manager = ofNullable(externalTracker).orElseGet(() -> new BitstringStatusListManager(store, transactionContext, registry, particpantContextService, credentialPublisher));
 
         var tokenGenerationService = new JwtGenerationService(jwsSignerProvider);
         return new CredentialStatusServiceImpl(store, transactionContext, typeManager.getMapper(JSON_LD), context.getMonitor(), tokenGenerationService,

--- a/e2e-tests/identityhub-test-fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/issuerservice/IssuerExtension.java
+++ b/e2e-tests/identityhub-test-fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/issuerservice/IssuerExtension.java
@@ -90,6 +90,7 @@ public class IssuerExtension extends AbstractIdentityHubExtension {
                 put("web.http.version.path", "/.well-known/api");
                 put("web.http.did.port", String.valueOf(didEndpoint.get().getUrl().getPort()));
                 put("web.http.did.path", didEndpoint.get().getUrl().getPath());
+                put("web.http.statuslist.port", String.valueOf(getFreePort()));
                 put("edc.sql.schema.autocreate", "true");
                 put("edc.iam.accesstoken.jti.validation", String.valueOf(false));
                 put("edc.issuer.statuslist.signing.key.alias", "signing-key");

--- a/extensions/issuance/local-statuslist-publisher/build.gradle.kts
+++ b/extensions/issuance/local-statuslist-publisher/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `java-test-fixtures`
+    `maven-publish`
+}
+
+dependencies {
+
+    api(project(":spi:issuerservice:issuerservice-credential-spi"))
+
+    implementation(libs.edc.spi.transaction)
+    implementation(libs.jakarta.rsApi)
+    implementation(libs.edc.spi.web)
+
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.restAssured)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+}

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalCredentialPublisher.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalCredentialPublisher.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.publisher;
+
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialPublisher;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+import java.util.HashMap;
+
+public class LocalCredentialPublisher implements StatusListCredentialPublisher {
+    private final CredentialStore credentialStore;
+    private final String baseUrl;
+    private final TransactionContext transactionContext;
+
+    public LocalCredentialPublisher(CredentialStore credentialStore, String baseUrl, TransactionContext transactionContext) {
+        this.credentialStore = credentialStore;
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+        this.transactionContext = transactionContext;
+    }
+
+    @Override
+    public Result<String> publish(String participantContextId, String statusListCredentialResourceId) {
+        return transactionContext.execute(() -> {
+            var res = credentialStore.findById(statusListCredentialResourceId);
+            if (res.failed()) {
+                return Result.failure(res.getFailureDetail());
+            }
+
+            var resource = res.getContent();
+
+            // update resource with URL
+            var url = baseUrl + resource.getVerifiableCredential().credential().getId();
+
+            resource = setPublished(resource);
+            var updateResult = credentialStore.update(resource);
+            if (updateResult.succeeded()) {
+                return Result.success(url);
+            }
+            return Result.failure(updateResult.getFailureDetail());
+        });
+    }
+
+    @Override
+    public boolean canHandle(String participantContextId, String statusListCredentialId) {
+        return credentialStore.findById(statusListCredentialId)
+                .map(res -> !res.getMetadata().isEmpty())
+                .orElse(f -> false); // only status list credentials have metadata
+    }
+
+    @Override
+    public Result<Void> unpublish(String participantContextId, String statusListCredentialId) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    private VerifiableCredentialResource setPublished(VerifiableCredentialResource resource) {
+        var meta = new HashMap<>(resource.getMetadata());
+        meta.put("published", Boolean.TRUE);
+        return resource.toBuilder().metadata(meta).build();
+    }
+}

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalStatusListCredentialPublisherExtension.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalStatusListCredentialPublisherExtension.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.issuerservice.publisher.api.StatusListCredentialController;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialPublisher;
+import org.eclipse.edc.runtime.metamodel.annotation.Configuration;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.system.Hostname;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.web.spi.WebService;
+import org.eclipse.edc.web.spi.configuration.PortMapping;
+import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
+import org.jetbrains.annotations.NotNull;
+
+
+@Extension(value = LocalStatusListCredentialPublisherExtension.NAME)
+public class LocalStatusListCredentialPublisherExtension implements ServiceExtension {
+    public static final String NAME = "IssuerService Default Services Extension";
+    private static final String STATUS_LIST = "statuslist";
+    @Inject
+    private CredentialStore store;
+
+    @Inject
+    private PortMappingRegistry portMappingRegistry;
+    @Inject
+    private Hostname hostname;
+
+    @Inject
+    private WebService webServer;
+
+    @Configuration
+    private StatusListCredentialEndpointConfig config;
+    @Inject
+    private TransactionContext transactionContext;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+        portMappingRegistry.register(new PortMapping(STATUS_LIST, config.port(), config.path()));
+
+        webServer.registerResource(STATUS_LIST, new StatusListCredentialController(store, context.getMonitor(), new ObjectMapper()));
+    }
+
+    @Provider(isDefault = true)
+    public StatusListCredentialPublisher createInMemoryStatusListCredentialPublisher() {
+        return new LocalCredentialPublisher(store, baseUrl(), transactionContext);
+    }
+
+    private @NotNull String baseUrl() {
+        return "http://%s:%s%s".formatted(hostname.get(), config.port(), config.path());
+    }
+
+    @Settings
+    record StatusListCredentialEndpointConfig(
+            @Setting(key = "web.http.statuslist.port", defaultValue = "9999", description = "Port of the status list credential web endpoint")
+            int port,
+            @Setting(key = "web.http.statuslist.path", defaultValue = "/statuslist", description = "Port of the status list credential web endpoint")
+            String path
+    ) {
+    }
+}

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialController.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialController.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.publisher.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.spi.EdcException;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.ObjectConflictException;
+
+import java.util.List;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("{any:.*}")
+public class StatusListCredentialController {
+    private static final List<String> SUPPORTED_TYPES = List.of(APPLICATION_JSON, "application/vc+jwt", MediaType.WILDCARD);
+    private final CredentialStore store;
+    private final Monitor monitor;
+    private final ObjectMapper mapper;
+
+    public StatusListCredentialController(CredentialStore store, Monitor monitor, ObjectMapper mapper) {
+        this.store = store;
+        this.monitor = monitor;
+        this.mapper = mapper;
+    }
+
+    @GET
+    public Response resolveStatusListCredential(@HeaderParam("Accept") @DefaultValue(MediaType.WILDCARD) String acceptHeader,
+                                                @Context ContainerRequestContext context) {
+
+        var httpUrl = context.getUriInfo().getAbsolutePath();
+        if (!SUPPORTED_TYPES.contains(acceptHeader)) {
+            return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
+                    .entity("Supported media types are: %s".formatted(SUPPORTED_TYPES))
+                    .build();
+        }
+
+        var split = httpUrl.getPath().split("/");
+        var credentialId = split[split.length - 1];
+
+        var query = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("verifiableCredential.credential.id", "=", credentialId))
+                .filter(new Criterion("metadata.published", "=", true))
+                .build();
+        var statusListCredential = store.query(query)
+                .orElseThrow(InvalidRequestException::new);
+
+        if (statusListCredential.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        if (statusListCredential.size() > 1) {
+            throw new ObjectConflictException("Multiple active status list credentials found for the same ID");
+        }
+
+        var selectedCredential = statusListCredential.iterator().next();
+
+        var publicUrl = selectedCredential.getMetadata().get("publicUrl");
+        if (!httpUrl.toString().equals(publicUrl)) {
+            monitor.warning("The status list credential's public URL property is not equal to the request URL: '%s' <> '%s'"
+                    .formatted(publicUrl, httpUrl));
+        }
+        var body = selectedCredential.getVerifiableCredential().rawVc();
+
+        var contentType = "application/vc+jwt";
+        if (acceptHeader.equals(APPLICATION_JSON)) {
+            try {
+                body = mapper.writeValueAsString(selectedCredential.getVerifiableCredential().credential());
+                contentType = APPLICATION_JSON;
+            } catch (JsonProcessingException e) {
+                throw new EdcException(e);
+            }
+        }
+
+        return Response.ok()
+                .header("Content-Type", contentType)
+                .entity(body).build();
+    }
+}

--- a/extensions/issuance/local-statuslist-publisher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/issuance/local-statuslist-publisher/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2023 Metaform Systems, Inc.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Metaform Systems, Inc. - initial API and implementation
+#
+#
+
+org.eclipse.edc.issuerservice.publisher.LocalStatusListCredentialPublisherExtension

--- a/extensions/issuance/local-statuslist-publisher/src/test/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialControllerTest.java
+++ b/extensions/issuance/local-statuslist-publisher/src/test/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialControllerTest.java
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.publisher.api;
+
+import io.restassured.specification.RequestSpecification;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class StatusListCredentialControllerTest extends RestControllerTestBase {
+
+
+    private static final String CREDENTIAL_ID = "test-credential-id";
+    private static final String RAW_CREDENTIAL = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    private final CredentialStore store = mock();
+    private final Monitor monitor = mock();
+    private final VerifiableCredential credential = VerifiableCredential.Builder.newInstance()
+            .type("TestCredential")
+            .credentialSubject(new CredentialSubject())
+            .issuer(new Issuer("did:web:issuer"))
+            .issuanceDate(Instant.now())
+            .build();
+    private final VerifiableCredentialResource credentialResource = VerifiableCredentialResource.Builder.newInstance()
+            .issuerId("did:web:issuer")
+            .holderId("did:web:issuer")
+            .metadata("publicUrl", "http://localhost:%s/statuslist/foobar/%s".formatted(port, CREDENTIAL_ID))
+            .credential(new VerifiableCredentialContainer(RAW_CREDENTIAL, CredentialFormat.VC1_0_JWT, credential))
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        when(store.query(any())).thenReturn(StoreResult.success(List.of(credentialResource)));
+    }
+
+    @Test
+    void resolveStatusListCredential_noAcceptHeader_expectDefaultFormat() {
+        baseRequest()
+                .get("/foobar/" + CREDENTIAL_ID)
+                .then()
+                .statusCode(200)
+                .header("Content-Type", "application/vc+jwt")
+                .body(equalTo(RAW_CREDENTIAL));
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void resolveStatusListCredential_whenUrlNotEqual() {
+        baseRequest()
+                .get("/foobar/barbaz/" + CREDENTIAL_ID)
+                .then()
+                .statusCode(200)
+                .body(equalTo(RAW_CREDENTIAL));
+        verify(monitor).warning(contains("not equal to the request URL"));
+    }
+
+
+    @Test
+    void resolveStatusListCredential_acceptJson() {
+        var body = baseRequest()
+                .header("Accept", "application/json")
+                .get("/foobar/" + CREDENTIAL_ID)
+                .then()
+                .statusCode(200)
+                .header("Content-Type", APPLICATION_JSON)
+                // this implicitly verifies that it is JSON
+                .extract().body().as(VerifiableCredential.class);
+
+        assertThat(body).usingRecursiveComparison().isEqualTo(credential);
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void resolveStatusListCredential_acceptJwt() {
+        baseRequest()
+                .header("Accept", "application/vc+jwt")
+                .get("/foobar/" + CREDENTIAL_ID)
+                .then()
+                .statusCode(200)
+                .header("Content-Type", "application/vc+jwt")
+                .body(equalTo(RAW_CREDENTIAL));
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void resolveStatusListCredential_invalidAcceptHeader_expect415() {
+        baseRequest()
+                .header("Accept", "application/vc+cose")
+                .get("/foobar/" + CREDENTIAL_ID)
+                .then()
+                .statusCode(415);
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void resolveStatusListCredential_credentialNotFound_expect404() {
+        when(store.query(any())).thenReturn(StoreResult.success(List.of()));
+        baseRequest()
+                .get("/foobar/nonexist-credential")
+                .then()
+                .statusCode(404);
+        verifyNoInteractions(monitor);
+    }
+
+    @Test
+    void resolveStatusListCredential_moreThanOneCredential_expect409() {
+        when(store.query(any())).thenReturn(StoreResult.success(List.of(credentialResource, credentialResource)));
+        baseRequest()
+                .get("/foobar/" + CREDENTIAL_ID)
+                .then()
+                .statusCode(409);
+        verifyNoInteractions(monitor);
+    }
+
+
+    @Override
+    protected Object controller() {
+        return new StatusListCredentialController(store, monitor, objectMapper);
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .baseUri("http://localhost:%s/statuslist".formatted(port));
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -118,6 +118,7 @@ include(":extensions:api:identity-api:validators:verifiable-credential-validator
 include(":extensions:issuance:issuerservice-presentation-attestations")
 include(":extensions:issuance:issuerservice-database-attestations")
 include(":extensions:issuance:issuerservice-issuance-rules")
+include(":extensions:issuance:local-statuslist-publisher")
 
 // other modules
 include(":launcher:identityhub")

--- a/spi/did-spi/src/main/java/org/eclipse/edc/identityhub/spi/did/DidDocumentPublisher.java
+++ b/spi/did-spi/src/main/java/org/eclipse/edc/identityhub/spi/did/DidDocumentPublisher.java
@@ -19,8 +19,9 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 import org.eclipse.edc.spi.result.Result;
 
 /**
- * The DidDocumentPublisher is responsible for taking a {@link DidDocument} and making it available at a VDR (verifiable data registry).
- * For example, an implementation may choose to publish the DID to a CDN.
+ * The DidDocumentPublisher is responsible for taking a {@link DidDocument} and making it available at a public location.
+ * This could be as simple as putting the DID document on a CDN, or more complex implementations could choose to publish
+ * the document on a VDR (verifiable data registry),
  */
 @ExtensionPoint
 public interface DidDocumentPublisher {

--- a/spi/issuerservice/issuerservice-credential-spi/src/main/java/org/eclipse/edc/issuerservice/spi/credentials/statuslist/StatusListCredentialPublisher.java
+++ b/spi/issuerservice/issuerservice-credential-spi/src/main/java/org/eclipse/edc/issuerservice/spi/credentials/statuslist/StatusListCredentialPublisher.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.spi.credentials.statuslist;
+
+import org.eclipse.edc.spi.result.Result;
+
+/**
+ * Publishes a status list credential (Bitstring Statuslist, StatusList2021,...) to a publicly available location.
+ * In many cases this will be a simple static web resource
+ */
+public interface StatusListCredentialPublisher {
+
+    /**
+     * Publishes the given status list credential.
+     *
+     * @param participantContextId   The ID of the participant context that represents the issuer
+     * @param statusListCredentialId The ID of the {@link org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource} that contains the status list credential.
+     * @return success, if the publishing was successful, a failure otherwise, for example, because the given resource is not a status list credential. Returns a URL to the published resource.
+     */
+    Result<String> publish(String participantContextId, String statusListCredentialId);
+
+
+    /**
+     * Determines, whether the given {@link org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource} can
+     * be handled by this publisher. Reasons why this might not be the case include:
+     * <ul>
+     *     <li>invalid format: the credential is in a format that the publisher can't handle (e.g. binary data)</li>
+     *     <li>invalid type: the credential is not a status list credential</li>
+     * </ul>
+     *
+     * @param participantContextId   The ID of the participant context that represents the issuer
+     * @param statusListCredentialId The ID of the {@link org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource} that contains the status list credential.
+     * @return true if can be handled, false otherwise. This does not necessarily mean, that the credential can be <em>published</em> as well.
+     */
+    boolean canHandle(String participantContextId, String statusListCredentialId);
+
+
+    /**
+     * Un-Publishes the given status list credential, i.e. removes it from the public location.
+     *
+     * @param participantContextId   The ID of the participant context that represents the issuer
+     * @param statusListCredentialId The ID of the {@link org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource} that contains the status list credential.
+     * @return success, if the un-publishing was successful, a failure otherwise, for example, because the given resource was not published.
+     */
+    Result<Void> unpublish(String participantContextId, String statusListCredentialId);
+}

--- a/spi/issuerservice/issuerservice-credential-spi/src/main/java/org/eclipse/edc/issuerservice/spi/credentials/statuslist/StatusListManager.java
+++ b/spi/issuerservice/issuerservice-credential-spi/src/main/java/org/eclipse/edc/issuerservice/spi/credentials/statuslist/StatusListManager.java
@@ -29,6 +29,19 @@ import org.eclipse.edc.spi.result.ServiceResult;
  */
 public interface StatusListManager {
     /**
+     * the current status list index. needed to detect overflow or "fullness"s
+     */
+    String CURRENT_INDEX = "currentIndex";
+    /**
+     * the public URL where the status list credential can be obtained
+     */
+    String PUBLIC_URL = "publicUrl";
+    /**
+     * marks the "active" credential, i.e. the ones where new holder credentials get added
+     */
+    String IS_ACTIVE = "isActive";
+
+    /**
      * Obtains the currently active status list credential for a particular participant context id (=tenant). If the current
      * status list credential is saturated, a new one is created and published transparently and then returned
      *


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a web endpoint that exposes status list credentials. It maps to an arbitrary URL path and interprets the last path segment as credential ID.

for example a status list credential with credential ID of `https://foo.com/bar/statuslist/credential-1` would be resolvable under that exact URL.

The endpoint accepts the `Accept` header and attempts to convert. Currently only `application/json` and `application/vc+jwt` are supported, with the latter being the default.

## Why it does that

make StatusList credentials publicly available, without authn/authz.

## Further notes

- fixed tests that were failing due to the change in the JTI validation


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #550

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
