### PR TITLE
fix: use `id` insted of `clientId` when generating the token

### DIFF
--- a/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/service/StsClientTokenGeneratorServiceImpl.java
+++ b/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/identitytrust/sts/service/StsClientTokenGeneratorServiceImpl.java
@@ -60,7 +60,7 @@ public class StsClientTokenGeneratorServiceImpl implements StsClientTokenGenerat
                                 .map(enrichClaimsWith(accumulator, entity.getKey()))
                                 .orElse(accumulator), (a, b) -> b);
 
-        var tokenResult = tokenGenerator.createToken(client.getClientId(), claims, additionalParams.getBearerAccessScope())
+        var tokenResult = tokenGenerator.createToken(client.getId(), claims, additionalParams.getBearerAccessScope())
                 .map(this::enrichWithExpiration);
 
         if (tokenResult.failed()) {

--- a/extensions/sts/sts-core/src/test/java/org/eclipse/edc/iam/identitytrust/sts/defaults/StsAccountTokenIssuanceIntegrationTest.java
+++ b/extensions/sts/sts-core/src/test/java/org/eclipse/edc/iam/identitytrust/sts/defaults/StsAccountTokenIssuanceIntegrationTest.java
@@ -26,6 +26,7 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManif
 import org.eclipse.edc.identityhub.sts.accountservice.RandomStringGenerator;
 import org.eclipse.edc.identityhub.sts.accountservice.StsAccountServiceImpl;
 import org.eclipse.edc.junit.annotations.ComponentTest;
+import org.eclipse.edc.junit.assertions.AbstractResultAssert;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
 import org.eclipse.edc.keys.VaultPrivateKeyResolver;
@@ -86,12 +87,13 @@ public class StsAccountTokenIssuanceIntegrationTest {
 
     @Test
     void authenticateAndGenerateToken() throws Exception {
+        var participantId = "participant_id";
         var clientId = "client_id";
         var secretAlias = "client_secret_alias";
         var privateKeyAlias = "client_id";
         var audience = "aud";
         var did = "did:example:subject";
-        var client = createClientBuilder(clientId)
+        var client = createClientBuilder(participantId)
                 .clientId(clientId)
                 .privateKeyAlias(privateKeyAlias)
                 .secretAlias(secretAlias)
@@ -104,7 +106,7 @@ public class StsAccountTokenIssuanceIntegrationTest {
         vault.storeSecret(privateKeyAlias, loadResourceFile("ec-privatekey.pem"));
 
         var createResult = clientService.createAccount(ParticipantManifest.Builder.newInstance()
-                .participantId(clientId)
+                .participantId(participantId)
                 .did(did)
                 .key(KeyDescriptor.Builder.newInstance()
                         .keyId("public-key")
@@ -114,6 +116,9 @@ public class StsAccountTokenIssuanceIntegrationTest {
         assertThat(createResult.succeeded()).isTrue();
 
         var tokenResult = tokenGeneratorService.tokenFor(client, additional);
+
+        AbstractResultAssert.assertThat(tokenResult).isSucceeded();
+
         var jwt = SignedJWT.parse(tokenResult.getContent().getToken());
 
         assertThat(jwt.getJWTClaimsSet().getClaims())
@@ -127,13 +132,14 @@ public class StsAccountTokenIssuanceIntegrationTest {
 
     @Test
     void authenticateAndGenerateToken_withBearerAccessScope() throws Exception {
+        var participantId = "participant_id";
         var clientId = "client_id";
         var secretAlias = "client_secret_alias";
         var privateKeyAlias = "client_id";
         var did = "did:example:subject";
         var audience = "aud";
         var scope = "scope:test";
-        var client = createClientBuilder(clientId)
+        var client = createClientBuilder(participantId)
                 .clientId(clientId)
                 .privateKeyAlias(privateKeyAlias)
                 .secretAlias(secretAlias)
@@ -146,7 +152,7 @@ public class StsAccountTokenIssuanceIntegrationTest {
         vault.storeSecret(privateKeyAlias, loadResourceFile("ec-privatekey.pem"));
 
         var createResult = clientService.createAccount(ParticipantManifest.Builder.newInstance()
-                .participantId(clientId)
+                .participantId(participantId)
                 .did(did)
                 .key(KeyDescriptor.Builder.newInstance()
                         .keyId("public-key")
@@ -169,6 +175,7 @@ public class StsAccountTokenIssuanceIntegrationTest {
 
     @Test
     void authenticateAndGenerateToken_withAccessToken() throws Exception {
+        var participantId = "participant_id";
         var clientId = "client_id";
         var secretAlias = "client_secret_alias";
         var privateKeyAlias = "client_id";
@@ -176,7 +183,7 @@ public class StsAccountTokenIssuanceIntegrationTest {
         var accessToken = "tokenTest";
         var did = "did:example:subject";
 
-        var client = createClientBuilder(clientId)
+        var client = createClientBuilder(participantId)
                 .clientId(clientId)
                 .privateKeyAlias(privateKeyAlias)
                 .secretAlias(secretAlias)
@@ -189,7 +196,7 @@ public class StsAccountTokenIssuanceIntegrationTest {
         vault.storeSecret(privateKeyAlias, loadResourceFile("ec-privatekey.pem"));
 
         var createResult = clientService.createAccount(ParticipantManifest.Builder.newInstance()
-                .participantId(clientId)
+                .participantId(participantId)
                 .did(did)
                 .key(KeyDescriptor.Builder.newInstance()
                         .keyId("public-key")


### PR DESCRIPTION
## What this PR changes/adds

Currently when generating a token for an `StsAccount` with the `StsClientTokenGeneratorServiceImpl` the `client#clientId` property is used as `participantContextId` passed to the `ParticipantSecureTokenService`. But when creating an `StsAccount` in the `StsAccountServiceImpl` the `clientId` is sourced by the `ParticipantManifest#did`, which means that
The `StsClientTokenGeneratorServiceImpl` works only if the `participantContextId` is equals to the `did` of the participant.

This fixes it by using the `id` instead of  `clientId` of the `StsAccount` 

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
