### PR TITLE
feat: implement CredentialOfferMessage + transformers

### DIFF
--- a/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/PresentationApiExtension.java
@@ -95,8 +95,11 @@ public class PresentationApiExtension implements ServiceExtension {
 
     void registerTransformers(String scope, JsonLdNamespace namespace) {
         var scopedTransformerRegistry = typeTransformer.forContext(scope);
+        // inbound
         scopedTransformerRegistry.register(new JsonObjectToPresentationQueryTransformer(typeManager, JSON_LD, namespace));
         scopedTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
+
+        // outbound
         scopedTransformerRegistry.register(new JsonObjectFromPresentationResponseMessageTransformer(namespace));
     }
 

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
@@ -94,8 +94,12 @@ public class StorageApiExtension implements ServiceExtension {
 
         var factory = Json.createBuilderFactory(Map.of());
         var scopedTransformerRegistry = typeTransformer.forContext(scope);
+
+        // inbound
         scopedTransformerRegistry.register(new JsonObjectToCredentialMessageTransformer(typeManager, JSON_LD, namespace));
         scopedTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
+
+        //outbound
         scopedTransformerRegistry.register(new JsonObjectFromCredentialMessageTransformer(factory, typeManager, JSON_LD, namespace));
         scopedTransformerRegistry.register(new JsonObjectFromCredentialRequestMessageTransformer(factory, typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
 

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/IssuerApiExtension.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/IssuerApiExtension.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.identityhub.protocols.dcp.issuer.api.v1alpha.issuermetada
 import org.eclipse.edc.identityhub.protocols.dcp.issuer.spi.DcpIssuerService;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpHolderTokenVerifier;
 import org.eclipse.edc.identityhub.protocols.dcp.transform.from.JsonObjectFromCredentialObjectTransformer;
+import org.eclipse.edc.identityhub.protocols.dcp.transform.from.JsonObjectFromCredentialOfferMessageTransformer;
 import org.eclipse.edc.identityhub.protocols.dcp.transform.from.JsonObjectFromCredentialRequestStatusTransformer;
 import org.eclipse.edc.identityhub.protocols.dcp.transform.from.JsonObjectFromIssuerMetadataTransformer;
 import org.eclipse.edc.identityhub.protocols.dcp.transform.to.JsonObjectToCredentialRequestMessageTransformer;
@@ -128,6 +129,7 @@ public class IssuerApiExtension implements ServiceExtension {
         dcpRegistry.register(new JsonObjectFromCredentialRequestStatusTransformer(namespace, builderFactory));
         dcpRegistry.register(new JsonObjectFromIssuerMetadataTransformer(namespace));
         dcpRegistry.register(new JsonObjectFromCredentialObjectTransformer(typeManager, JSON_LD, namespace));
+        dcpRegistry.register(new JsonObjectFromCredentialOfferMessageTransformer(namespace));
 
         // to
         dcpRegistry.register(new JsonObjectToCredentialRequestMessageTransformer(typeManager, JSON_LD, namespace));

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialOfferMessage.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialOfferMessage.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.spi.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CredentialOfferMessage {
+    public static final String TYPE = "CredentialOfferMessage";
+    public static final String CREDENTIAL_ISSUER_TERM = "credentialIssuer";
+    public static final String CREDENTIALS_TERM = "credentials";
+    private List<CredentialObject> credentials = new ArrayList<>();
+    private String issuer;
+
+    private CredentialOfferMessage() {
+
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public List<CredentialObject> getCredentials() {
+        return credentials;
+    }
+
+
+    public static final class Builder {
+        private final CredentialOfferMessage instance;
+
+        private Builder(CredentialOfferMessage instance) {
+            this.instance = instance;
+        }
+
+        public static Builder newInstance() {
+            return new Builder(new CredentialOfferMessage());
+        }
+
+        public Builder issuer(String issuer) {
+            this.instance.issuer = issuer;
+            return this;
+        }
+
+        public Builder credentials(List<CredentialObject> credentials) {
+            this.instance.credentials = credentials;
+            return this;
+        }
+
+        public Builder credential(CredentialObject credential) {
+            this.instance.credentials.add(credential);
+            return this;
+        }
+
+        public CredentialOfferMessage build() {
+            return instance;
+        }
+
+    }
+}

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialOfferMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialOfferMessageTransformer.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.transform.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static jakarta.json.stream.JsonCollectors.toJsonArray;
+import static org.eclipse.edc.jsonld.spi.JsonLdKeywords.TYPE;
+
+public class JsonObjectFromCredentialOfferMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<CredentialOfferMessage, JsonObject> {
+    public JsonObjectFromCredentialOfferMessageTransformer(JsonLdNamespace namespace) {
+        super(CredentialOfferMessage.class, JsonObject.class, namespace);
+    }
+
+    @Override
+    public @Nullable JsonObject transform(@NotNull CredentialOfferMessage credentialOfferMessage, @NotNull TransformerContext transformerContext) {
+        var credentials = credentialOfferMessage.getCredentials().stream()
+                .map(credentialObject -> transformerContext.transform(credentialObject, JsonObject.class))
+                .collect(toJsonArray());
+
+        return Json.createObjectBuilder()
+                .add(TYPE, forNamespace(CredentialOfferMessage.TYPE))
+                .add(forNamespace(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), credentialOfferMessage.getIssuer())
+                .add(forNamespace(CredentialOfferMessage.CREDENTIALS_TERM), credentials)
+                .build();
+    }
+}

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformer.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.transform.to;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.jsonld.spi.transformer.AbstractNamespaceAwareJsonLdTransformer;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class JsonObjectToCredentialOfferMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, CredentialOfferMessage> {
+    protected JsonObjectToCredentialOfferMessageTransformer(JsonLdNamespace namespace) {
+        super(JsonObject.class, CredentialOfferMessage.class, namespace);
+    }
+
+    @Override
+    public @Nullable CredentialOfferMessage transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext transformerContext) {
+        var builder = CredentialOfferMessage.Builder.newInstance();
+
+        builder.issuer(transformString(jsonObject.get(forNamespace(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM)), transformerContext));
+
+        var credentialsArray = jsonObject.getJsonArray(forNamespace(CredentialOfferMessage.CREDENTIALS_TERM));
+
+        if (credentialsArray != null) {
+            var credentialObjects = transformArray(credentialsArray, CredentialObject.class, transformerContext);
+            builder.credentials(credentialObjects);
+        }
+        return builder.build();
+    }
+}

--- a/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialOfferMessageTransformerTest.java
+++ b/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialOfferMessageTransformerTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.transform.from;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class JsonObjectFromCredentialOfferMessageTransformerTest {
+
+    private final JsonObjectFromCredentialOfferMessageTransformer transformer = new JsonObjectFromCredentialOfferMessageTransformer(DSPACE_DCP_NAMESPACE_V_1_0);
+    private final TransformerContext transformerContext = mock();
+
+    @Test
+    void transform() {
+
+        var msg = CredentialOfferMessage.Builder.newInstance()
+                .issuer("test-issuer")
+                .credentials(List.of(
+                        CredentialObject.Builder.newInstance()
+                                .credentialType("TestCredential")
+                                .profile("test-profile")
+                                .offerReason("reissuance")
+                                .bindingMethod("did:web")
+                                .issuancePolicy(null)
+                                .build()
+                )).build();
+        when(transformerContext.transform(isA(CredentialObject.class), eq(JsonObject.class)))
+                .thenReturn(Json.createObjectBuilder().build());
+        var result = transformer.transform(msg, transformerContext);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(toIri("credentialIssuer"))).isEqualTo("test-issuer");
+        assertThat(result.getJsonArray(toIri("credentials"))).hasSize(1);
+
+        verify(transformerContext).transform(isA(CredentialObject.class), eq(JsonObject.class));
+        verifyNoMoreInteractions(transformerContext);
+    }
+
+    @Test
+    void transform_noCredentials() {
+
+        var msg = CredentialOfferMessage.Builder.newInstance()
+                .issuer("test-issuer")
+                .build();
+        var result = transformer.transform(msg, transformerContext);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getString(toIri("credentialIssuer"))).isEqualTo("test-issuer");
+        assertThat(result.getJsonArray(toIri("credentials"))).isEmpty();
+
+        verifyNoMoreInteractions(transformerContext);
+    }
+
+    private String toIri(String term) {
+        return DSPACE_DCP_NAMESPACE_V_1_0.toIri(term);
+    }
+}

--- a/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformerTest.java
+++ b/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformerTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.transform.to;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject;
+import org.eclipse.edc.transform.spi.TransformerContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_BINDING_METHODS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_OFFER_REASON_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_PROFILES_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIAL_ISSUER_TERM;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JsonObjectToCredentialOfferMessageTransformerTest {
+
+    private final JsonObjectToCredentialOfferMessageTransformer transformer = new JsonObjectToCredentialOfferMessageTransformer(DSPACE_DCP_NAMESPACE_V_1_0);
+    private final TransformerContext transformerContext = mock();
+
+    @Test
+    void transform() {
+
+        var credentialsObj = CredentialObject.Builder.newInstance()
+                .credentialType("TestCredential")
+                .profile("test-profile")
+                .build();
+        when(transformerContext.transform(isA(JsonObject.class), eq(CredentialObject.class)))
+                .thenReturn(credentialsObj);
+
+        var credentialsArray = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add(toIri(CREDENTIAL_OBJECT_PROFILES_TERM), Json.createArrayBuilder(List.of("profile")))
+                        .add(toIri(CREDENTIAL_OBJECT_OFFER_REASON_TERM), "offerReason")
+                        .add(toIri(CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM), "MembershipCredential")
+                        .add(toIri(CREDENTIAL_OBJECT_BINDING_METHODS_TERM), Json.createArrayBuilder(List.of("binding")))
+                        .build());
+        var msg = Json.createObjectBuilder()
+                .add(toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(toIri(CREDENTIALS_TERM), credentialsArray)
+                .build();
+        var result = transformer.transform(msg, transformerContext);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getIssuer()).isEqualTo("test-issuer");
+        assertThat(result.getCredentials()).usingRecursiveFieldByFieldElementComparator().containsExactly(credentialsObj);
+    }
+
+    @Test
+    void transform_noCredentials() {
+
+        var msg = Json.createObjectBuilder()
+                .add(toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .build();
+        var result = transformer.transform(msg, transformerContext);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getIssuer()).isEqualTo("test-issuer");
+        assertThat(result.getCredentials()).isEmpty();
+    }
+
+    private String toIri(String term) {
+        return DSPACE_DCP_NAMESPACE_V_1_0.toIri(term);
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

implements the `CredentialOfferMessage` object plus transformers

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #671

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
