### PR TITLE
feat: Issuer sends CredentialOffers

### DIFF
--- a/core/issuerservice/issuerservice-credentials/build.gradle.kts
+++ b/core/issuerservice/issuerservice-credentials/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api(project(":spi:issuerservice:issuerservice-holder-spi"))
     api(project(":spi:issuerservice:issuerservice-issuance-spi"))
     api(project(":spi:identity-hub-spi"))
+    api(project(":protocols:dcp:dcp-spi")) // CredentialOfferMessage
     api(libs.edc.spi.http) // for the Request
     implementation(libs.edc.lib.token)
     implementation(libs.nimbus.jwt)

--- a/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/CredentialServiceExtension.java
+++ b/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/CredentialServiceExtension.java
@@ -40,8 +40,10 @@ import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.transaction.spi.TransactionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 
 import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_1_0;
 import static org.eclipse.edc.issuerservice.credentials.CredentialServiceExtension.NAME;
 import static org.eclipse.edc.issuerservice.credentials.statuslist.bitstring.BitstringConstants.BITSTRING_STATUS_LIST_ENTRY;
 import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
@@ -82,6 +84,8 @@ public class CredentialServiceExtension implements ServiceExtension {
     private ParticipantContextService particpantContextService;
     @Inject
     private StatusListCredentialPublisher credentialPublisher;
+    @Inject
+    private TypeTransformerRegistry transformerRegistry;
 
     @Provider
     public CredentialStatusService getStatusListService(ServiceExtensionContext context) {
@@ -99,7 +103,7 @@ public class CredentialServiceExtension implements ServiceExtension {
 
     @Provider
     public IssuerCredentialOfferService credentialOfferService(ServiceExtensionContext context) {
-        return new IssuerCredentialOfferServiceImpl(transactionContext, holderStore, credentialServiceUrlResolver, sts, participantContextService, httpClient, context.getMonitor());
+        return new IssuerCredentialOfferServiceImpl(transactionContext, holderStore, credentialServiceUrlResolver, sts, participantContextService, httpClient, context.getMonitor(), transformerRegistry.forContext(DCP_SCOPE_V_1_0));
     }
 
     @Provider

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialApiEndToEndTest.java
@@ -82,6 +82,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.StringBody.subString;
+import static org.mockserver.verify.VerificationTimes.exactly;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
 public class CredentialApiEndToEndTest {
@@ -414,9 +416,9 @@ public class CredentialApiEndToEndTest {
             var token = runtime.createParticipant(USER).apiKey();
 
             var port = getFreePort();
-            try (var mockedHolderDidServer = ClientAndServer.startClientAndServer(port)) {
+            try (var mockedHolderEndpoint = ClientAndServer.startClientAndServer(port)) {
 
-                mockedHolderDidServer.when(request()
+                mockedHolderEndpoint.when(request()
                                 .withPath("/api/holder/offers")
                                 .withMethod("POST"))
                         .respond(response()
@@ -445,6 +447,13 @@ public class CredentialApiEndToEndTest {
                         .then()
                         .log().ifValidationFails()
                         .statusCode(200);
+
+                mockedHolderEndpoint.verify(request()
+                        .withMethod("POST")
+                        .withPath("/api/holder/offers")
+                        .withBody(subString("credentialIssuer"))
+                        .withBody(subString("credentials"))
+                        .withBody(subString("TestCredential")), exactly(1));
             }
         }
 

--- a/extensions/api/issuer-admin-api/credentials-api/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/credentials-api/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(project(":spi:issuerservice:issuerservice-credential-spi"))
     api(project(":spi:issuerservice:issuerservice-holder-spi"))
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-configuration"))
+    implementation(project(":protocols:dcp:dcp-transform-lib"))
     implementation(libs.edc.spi.web)
     implementation(libs.jakarta.rsApi)
 

--- a/extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/IssuerCredentialsAdminApiExtension.java
+++ b/extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/IssuerCredentialsAdminApiExtension.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.issuerservice.api.admin.credentials;
 
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants;
+import org.eclipse.edc.identityhub.protocols.dcp.transform.from.JsonObjectFromCredentialOfferMessageTransformer;
 import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext;
@@ -24,8 +26,10 @@ import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.web.spi.WebService;
 
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
 import static org.eclipse.edc.issuerservice.api.admin.credentials.IssuerCredentialsAdminApiExtension.NAME;
 
 @Extension(value = NAME)
@@ -40,6 +44,8 @@ public class IssuerCredentialsAdminApiExtension implements ServiceExtension {
     private AuthorizationService authorizationService;
     @Inject
     private IssuerCredentialOfferService credentialOfferService;
+    @Inject
+    private TypeTransformerRegistry typeTransformerRegistry;
 
     @Override
     public String name() {
@@ -52,6 +58,9 @@ public class IssuerCredentialsAdminApiExtension implements ServiceExtension {
         authorizationService.addLookupFunction(VerifiableCredentialResource.class, this::findById);
         var controller = new IssuerCredentialsAdminApiController(authorizationService, credentialService, credentialOfferService);
         webService.registerResource(IdentityHubApiContext.ISSUERADMIN, controller);
+
+        // required for sending CredentialOffer messages to the holder
+        typeTransformerRegistry.forContext(DcpConstants.DCP_SCOPE_V_1_0).register(new JsonObjectFromCredentialOfferMessageTransformer(DSPACE_DCP_NAMESPACE_V_1_0));
     }
 
 


### PR DESCRIPTION
## What this PR changes/adds

this PR amends a previous development, where Admin API clients can trigger a `CredentialOfferMessage` being sent to the holder.

Previously, that was just an empty JSON object, and now a `CredentialOfferMessage` gets sent.

## Why it does that

have API clients send credential offers to holder

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #674


_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
