### PR TITLE
refactor: removes dataModel in CredentialDefinition

### DIFF
--- a/core/issuerservice/issuerservice-core/build.gradle.kts
+++ b/core/issuerservice/issuerservice-core/build.gradle.kts
@@ -9,9 +9,9 @@ dependencies {
     api(project(":core:lib:common-lib"))
 
     implementation(project(":extensions:issuance:local-statuslist-publisher"))
+    implementation(libs.edc.lib.query)
     implementation(libs.edc.lib.store)
     testImplementation(libs.edc.junit)
-    testImplementation(libs.edc.lib.query)
     testImplementation(testFixtures(project(":spi:issuerservice:issuerservice-holder-spi")))
     testImplementation(testFixtures(project(":spi:issuerservice:issuerservice-issuance-spi")))
 

--- a/core/issuerservice/issuerservice-core/src/main/java/org/eclipse/edc/issuerservice/defaults/store/CredentialDefinitionLookup.java
+++ b/core/issuerservice/issuerservice-core/src/main/java/org/eclipse/edc/issuerservice/defaults/store/CredentialDefinitionLookup.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.defaults.store;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
+import org.eclipse.edc.query.ReflectionPropertyLookup;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+
+/**
+ * This class performs the lookup of properties in a {@link CredentialDefinition}.
+ */
+public class CredentialDefinitionLookup extends ReflectionPropertyLookup {
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object getProperty(String key, Object object) {
+        var fieldValue = super.getProperty(key, object);
+        if (key.equals("formats")) {
+            Collection<CredentialFormat> formats = (Collection<CredentialFormat>) fieldValue;
+            return formats.stream().map(CredentialFormat::name).collect(Collectors.toList());
+        }
+        return fieldValue;
+    }
+
+}

--- a/core/issuerservice/issuerservice-core/src/main/java/org/eclipse/edc/issuerservice/defaults/store/InMemoryCredentialDefinitionStore.java
+++ b/core/issuerservice/issuerservice-core/src/main/java/org/eclipse/edc/issuerservice/defaults/store/InMemoryCredentialDefinitionStore.java
@@ -97,6 +97,8 @@ public class InMemoryCredentialDefinitionStore extends InMemoryEntityStore<Crede
 
     @Override
     protected QueryResolver<CredentialDefinition> createQueryResolver() {
+        criterionOperatorRegistry.registerPropertyLookup(new CredentialDefinitionLookup());
+
         return new ReflectionBasedQueryResolver<>(CredentialDefinition.class, criterionOperatorRegistry);
     }
 }

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/CredentialGeneratorRegistryImplTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/CredentialGeneratorRegistryImplTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -62,7 +63,7 @@ public class CredentialGeneratorRegistryImplTest {
     void generate() {
 
         var generator = mock(CredentialGenerator.class);
-        credentialGeneratorRegistry.addGenerator(CredentialFormat.VC1_0_JWT, generator);
+        credentialGeneratorRegistry.addGenerator(VC1_0_JWT, generator);
         var definition = createCredentialDefinition();
 
         var participantContext = ParticipantContext.Builder.newInstance().participantContextId("participantContextId").apiTokenAlias("apiTokenAlias")
@@ -78,7 +79,7 @@ public class CredentialGeneratorRegistryImplTest {
         when(holderService.findById("holderId")).thenReturn(ServiceResult.success(participant));
         when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(key)));
         when(generator.generateCredential(eq(definition), eq(key.getPrivateKeyAlias()), eq(key.getKeyId()), eq("issuerDid"), eq("participantDid"), any())).thenReturn(Result.success(mock()));
-        var request = new CredentialGenerationRequest(definition, CredentialFormat.VC1_0_JWT);
+        var request = new CredentialGenerationRequest(definition, VC1_0_JWT);
         var result = credentialGeneratorRegistry.generateCredential("participantContextId", "holderId", request, Map.of());
 
         assertThat(result).isSucceeded();
@@ -92,7 +93,7 @@ public class CredentialGeneratorRegistryImplTest {
 
         when(claimsMapper.apply(anyList(), any())).thenReturn(Result.success(Map.of()));
 
-        var request = new CredentialGenerationRequest(definition, CredentialFormat.VC1_0_JWT);
+        var request = new CredentialGenerationRequest(definition, VC1_0_JWT);
         var result = credentialGeneratorRegistry.generateCredential("participantContextId", "holderId", request, Map.of());
 
         assertThat(result).isFailed().detail().contains("No generator found for format VC1_0_JWT");
@@ -102,14 +103,14 @@ public class CredentialGeneratorRegistryImplTest {
     void generate_shouldFail_ParticipantContextNotFound() {
 
         var generator = mock(CredentialGenerator.class);
-        credentialGeneratorRegistry.addGenerator(CredentialFormat.VC1_0_JWT, generator);
+        credentialGeneratorRegistry.addGenerator(VC1_0_JWT, generator);
 
         var definition = createCredentialDefinition();
 
         when(claimsMapper.apply(anyList(), any())).thenReturn(Result.success(Map.of()));
         when(participantContextService.getParticipantContext("participantContextId")).thenReturn(ServiceResult.notFound("not found"));
 
-        var request = new CredentialGenerationRequest(definition, CredentialFormat.VC1_0_JWT);
+        var request = new CredentialGenerationRequest(definition, VC1_0_JWT);
         var result = credentialGeneratorRegistry.generateCredential("participantContextId", "holderId", request, Map.of());
 
         assertThat(result).isFailed().detail().contains("not found");
@@ -119,7 +120,7 @@ public class CredentialGeneratorRegistryImplTest {
     void generate_shouldFail_whenParticipantNotFound() {
 
         var generator = mock(CredentialGenerator.class);
-        credentialGeneratorRegistry.addGenerator(CredentialFormat.VC1_0_JWT, generator);
+        credentialGeneratorRegistry.addGenerator(VC1_0_JWT, generator);
 
         var definition = createCredentialDefinition();
 
@@ -131,7 +132,7 @@ public class CredentialGeneratorRegistryImplTest {
         when(participantContextService.getParticipantContext("participantContextId")).thenReturn(ServiceResult.success(participantContext));
         when(holderService.findById("holderId")).thenReturn(ServiceResult.notFound("not found"));
 
-        var request = new CredentialGenerationRequest(definition, CredentialFormat.VC1_0_JWT);
+        var request = new CredentialGenerationRequest(definition, VC1_0_JWT);
         var result = credentialGeneratorRegistry.generateCredential("participantContextId", "holderId", request, Map.of());
 
         assertThat(result).isFailed().detail().contains("not found");
@@ -141,7 +142,7 @@ public class CredentialGeneratorRegistryImplTest {
     void generate_shouldFail_whenNoKeysFound() {
 
         var generator = mock(CredentialGenerator.class);
-        credentialGeneratorRegistry.addGenerator(CredentialFormat.VC1_0_JWT, generator);
+        credentialGeneratorRegistry.addGenerator(VC1_0_JWT, generator);
 
         var definition = createCredentialDefinition();
 
@@ -157,7 +158,7 @@ public class CredentialGeneratorRegistryImplTest {
         when(holderService.findById("holderId")).thenReturn(ServiceResult.success(participant));
         when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of()));
 
-        var request = new CredentialGenerationRequest(definition, CredentialFormat.VC1_0_JWT);
+        var request = new CredentialGenerationRequest(definition, VC1_0_JWT);
         var result = credentialGeneratorRegistry.generateCredential("participantContextId", "holderId", request, Map.of());
 
         assertThat(result).isFailed().detail().contains("No active key pair found");
@@ -167,7 +168,7 @@ public class CredentialGeneratorRegistryImplTest {
     void generate_shouldFail_GenerationFails() {
 
         var generator = mock(CredentialGenerator.class);
-        credentialGeneratorRegistry.addGenerator(CredentialFormat.VC1_0_JWT, generator);
+        credentialGeneratorRegistry.addGenerator(VC1_0_JWT, generator);
         var definition = createCredentialDefinition();
 
         var participantContext = ParticipantContext.Builder.newInstance().participantContextId("participantContextId").apiTokenAlias("apiTokenAlias")
@@ -183,7 +184,7 @@ public class CredentialGeneratorRegistryImplTest {
         when(holderService.findById("holderId")).thenReturn(ServiceResult.success(participant));
         when(keyPairService.query(any())).thenReturn(ServiceResult.success(List.of(key)));
         when(generator.generateCredential(eq(definition), eq(key.getPrivateKeyAlias()), eq(key.getKeyId()), eq("issuerDid"), eq("participantDid"), any())).thenReturn(Result.failure("failed"));
-        var request = new CredentialGenerationRequest(definition, CredentialFormat.VC1_0_JWT);
+        var request = new CredentialGenerationRequest(definition, VC1_0_JWT);
         var result = credentialGeneratorRegistry.generateCredential("participantContextId", "holderId", request, Map.of());
 
         assertThat(result).isFailed().detail().contains("failed");
@@ -267,6 +268,7 @@ public class CredentialGeneratorRegistryImplTest {
                 .mapping(new MappingDefinition("input", "outut", true))
                 .participantContextId("participantContextId")
                 .jsonSchema("{}")
+                .format(VC1_0_JWT)
                 .build();
     }
 }

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGeneratorTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGeneratorTest.java
@@ -22,7 +22,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
@@ -46,6 +45,7 @@ import java.util.UUID;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.issuerservice.issuance.generator.JwtCredentialGenerator.VERIFIABLE_CREDENTIAL_CLAIM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -89,7 +89,7 @@ public class JwtCredentialGeneratorTest {
 
         var container = result.getContent();
         assertThat(container.rawVc()).isNotNull();
-        assertThat(container.format()).isEqualTo(CredentialFormat.VC1_0_JWT);
+        assertThat(container.format()).isEqualTo(VC1_0_JWT);
         assertThat(container.credential()).satisfies(verifiableCredential -> {
             assertThat(verifiableCredential.getType()).contains("MembershipCredential");
             assertThat(verifiableCredential.getIssuer().id()).isEqualTo("did:example:issuer");
@@ -127,7 +127,7 @@ public class JwtCredentialGeneratorTest {
 
         var container = result.getContent();
         assertThat(container.rawVc()).isNotNull();
-        assertThat(container.format()).isEqualTo(CredentialFormat.VC1_0_JWT);
+        assertThat(container.format()).isEqualTo(VC1_0_JWT);
         assertThat(container.credential()).satisfies(verifiableCredential -> {
             assertThat(verifiableCredential.getType()).contains("MembershipCredential");
             assertThat(verifiableCredential.getIssuer().id()).isEqualTo("did:example:issuer");
@@ -260,6 +260,7 @@ public class JwtCredentialGeneratorTest {
                 .mapping(new MappingDefinition("input", "outut", true))
                 .jsonSchema("{}")
                 .participantContextId(UUID.randomUUID().toString())
+                .format(VC1_0_JWT)
                 .build();
     }
 

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/issuance/credentialdefinition/CredentialDefinitionServiceImplTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/issuance/credentialdefinition/CredentialDefinitionServiceImplTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -253,6 +254,8 @@ public class CredentialDefinitionServiceImplTest {
                 .attestation("test-attestation")
                 .participantContextId(UUID.randomUUID().toString())
                 .rule(new CredentialRuleDefinition("test-rule", Map.of()))
-                .credentialType(type).build();
+                .credentialType(type)
+                .format(VC1_0_JWT)
+                .build();
     }
 }

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/process/IssuanceProcessManagerImplTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/process/IssuanceProcessManagerImplTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.issuerservice.issuance.process;
 
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
@@ -50,6 +49,7 @@ import java.util.Map;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.issuerservice.spi.issuance.model.IssuanceProcessStates.APPROVED;
 import static org.eclipse.edc.issuerservice.spi.issuance.model.IssuanceProcessStates.DELIVERED;
 import static org.eclipse.edc.issuerservice.spi.issuance.model.IssuanceProcessStates.ERRORED;
@@ -100,11 +100,12 @@ public class IssuanceProcessManagerImplTest {
                 .jsonSchemaUrl("http://example.org/schema")
                 .jsonSchema("{}")
                 .participantContextId("participantContextId")
+                .format(VC1_0_JWT)
                 .build();
 
-        var generationRequests = new CredentialGenerationRequest(credentialDefinition, CredentialFormat.VC1_0_JWT);
+        var generationRequests = new CredentialGenerationRequest(credentialDefinition, VC1_0_JWT);
 
-        var credential = new VerifiableCredentialContainer("", CredentialFormat.VC1_0_JWT, VerifiableCredential.Builder.newInstance()
+        var credential = new VerifiableCredentialContainer("", VC1_0_JWT, VerifiableCredential.Builder.newInstance()
                 .type("MembershipCredential")
                 .issuer(new Issuer("did:example:issuer"))
                 .issuanceDate(Instant.now())
@@ -118,7 +119,7 @@ public class IssuanceProcessManagerImplTest {
                 .holderId("holderId")
                 .participantContextId("participantContextId")
                 .holderPid("holderPid")
-                .credentialFormats(Map.of(credentialDefinition.getCredentialType(), CredentialFormat.VC1_0_JWT))
+                .credentialFormats(Map.of(credentialDefinition.getCredentialType(), VC1_0_JWT))
                 .build();
 
         when(issuanceProcessStore.nextNotLeased(anyInt(), stateIs(APPROVED.code()))).thenReturn(List.of(process)).thenReturn(emptyList());
@@ -156,15 +157,16 @@ public class IssuanceProcessManagerImplTest {
                 .jsonSchemaUrl("http://example.org/schema")
                 .jsonSchema("{}")
                 .participantContextId("participantContextId")
+                .format(VC1_0_JWT)
                 .build();
 
-        var generationRequests = new CredentialGenerationRequest(credentialDefinition, CredentialFormat.VC1_0_JWT);
+        var generationRequests = new CredentialGenerationRequest(credentialDefinition, VC1_0_JWT);
 
         var process = IssuanceProcess.Builder.newInstance().state(APPROVED.code())
                 .holderId("holderId")
                 .participantContextId("participantContextId")
                 .holderPid("holderPid")
-                .credentialFormats(Map.of(credentialDefinition.getCredentialType(), CredentialFormat.VC1_0_JWT))
+                .credentialFormats(Map.of(credentialDefinition.getCredentialType(), VC1_0_JWT))
                 .stateCount(2)
                 .build();
 

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialDefinitionApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialDefinitionApiEndToEndTest.java
@@ -42,6 +42,7 @@ import java.util.Base64;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.identityhub.tests.TestData.ISSUER_RUNTIME_ID;
 import static org.eclipse.edc.identityhub.tests.TestData.ISSUER_RUNTIME_MEM_MODULES;
 import static org.eclipse.edc.identityhub.tests.TestData.ISSUER_RUNTIME_NAME;
@@ -85,6 +86,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .rule(new CredentialRuleDefinition("expression", credentialRuleConfiguration))
                     .attestation("test-attestation")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             runtime.getAdminEndpoint().baseRequest()
@@ -118,6 +120,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .rule(new CredentialRuleDefinition("notFound", Map.of()))
                     .attestation("test-attestation")
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             runtime.getAdminEndpoint().baseRequest()
@@ -140,6 +143,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("https://example.org/membership-credential-schema.json")
                     .credentialType("MyType")
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -152,7 +156,8 @@ public class CredentialDefinitionApiEndToEndTest {
                               "id": "test-definition-id",
                               "credentialType": "MembershipCredential",
                               "jsonSchema": "{}",
-                              "jsonSchemaUrl": "https://example.org/membership-credential-schema.json"
+                              "jsonSchemaUrl": "https://example.org/membership-credential-schema.json",
+                              "formats": ["VC1_0_JWT"]
                             }
                             """)
                     .post("/v1alpha/participants/%s/credentialdefinitions".formatted(toBase64(USER)))
@@ -171,6 +176,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("https://example.org/membership-credential-schema.json")
                     .credentialType("MembershipCredential")
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -183,7 +189,8 @@ public class CredentialDefinitionApiEndToEndTest {
                               "id": "test-definition-id",
                               "credentialType": "MembershipCredential",
                               "jsonSchema": "{}",
-                              "jsonSchemaUrl": "https://example.org/membership-credential-schema.json"
+                              "jsonSchemaUrl": "https://example.org/membership-credential-schema.json",
+                              "formats": ["VC1_0_JWT"]
                             }
                             """)
                     .post("/v1alpha/participants/%s/credentialdefinitions".formatted(toBase64(USER)))
@@ -222,7 +229,8 @@ public class CredentialDefinitionApiEndToEndTest {
                               "credentialType": "MembershipCredential",
                               "jsonSchema": "{}",
                               "jsonSchemaUrl": "https://example.org/membership-credential-schema.json",
-                              "attestations": ["notfound"]
+                              "attestations": ["notfound"],
+                              "formats": ["VC1_0_JWT"]
                             }
                             """)
                     .post("/v1alpha/participants/%s/credentialdefinitions".formatted(toBase64(USER)))
@@ -242,6 +250,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -269,6 +278,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId("anotherUser")
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -313,6 +323,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -338,6 +349,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId("anotherUser")
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -374,6 +386,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -384,6 +397,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             runtime.getAdminEndpoint().baseRequest()
@@ -409,6 +423,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
 
@@ -432,6 +447,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -442,6 +458,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             runtime.getAdminEndpoint().baseRequest()
@@ -464,6 +481,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);
@@ -502,6 +520,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .jsonSchemaUrl("http://example.com/schema")
                     .credentialType("MembershipCredential")
                     .participantContextId(USER)
+                    .format(VC1_0_JWT)
                     .build();
 
             service.createCredentialDefinition(definition);

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestApiEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestApiEndToEndTest.java
@@ -66,6 +66,7 @@ import static io.restassured.http.ContentType.JSON;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.identityhub.tests.dcp.TestData.ISSUER_RUNTIME_ID;
 import static org.eclipse.edc.identityhub.tests.dcp.TestData.ISSUER_RUNTIME_MEM_MODULES;
 import static org.eclipse.edc.identityhub.tests.dcp.TestData.ISSUER_RUNTIME_NAME;
@@ -207,6 +208,7 @@ public class DcpCredentialRequestApiEndToEndTest {
                         .mapping(new MappingDefinition("participant.name", "credentialSubject.name", true))
                         .rule(new CredentialRuleDefinition("expression", credentialRuleConfiguration))
                         .participantContextId("participantContextId")
+                        .format(VC1_0_JWT)
                         .build();
 
 
@@ -412,6 +414,7 @@ public class DcpCredentialRequestApiEndToEndTest {
                     .attestation("attestation-id")
                     .rule(new CredentialRuleDefinition("expression", credentialRuleConfiguration))
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             credentialDefinitionService.createCredentialDefinition(credentialDefinition);

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
@@ -55,6 +55,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.identityhub.tests.dcp.TestData.IH_RUNTIME_ID;
 import static org.eclipse.edc.identityhub.tests.dcp.TestData.IH_RUNTIME_MEM_MODULES;
 import static org.eclipse.edc.identityhub.tests.dcp.TestData.IH_RUNTIME_NAME;
@@ -226,6 +227,7 @@ public class DcpIssuanceFlowEndToEndTest {
                     .mapping(mappingDefinition)
                     .rule(new CredentialRuleDefinition("expression", ruleConfiguration))
                     .participantContextId("participantContextId")
+                    .format(VC1_0_JWT)
                     .build();
 
             credentialDefinitionService.createCredentialDefinition(credentialDefinition);

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/model/CredentialDefinitionDto.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/model/CredentialDefinitionDto.java
@@ -18,14 +18,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.DataModelVersion;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialRuleDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -39,11 +42,11 @@ public class CredentialDefinitionDto {
     private final List<String> attestations = new ArrayList<>();
     private final List<CredentialRuleDefinition> rules = new ArrayList<>();
     private final List<MappingDefinition> mappings = new ArrayList<>();
+    private final Set<String> formats = new HashSet<>();
     private String credentialType;
     private String jsonSchema;
     private String jsonSchemaUrl;
     private long validity;
-    private DataModelVersion dataModel = DataModelVersion.V_1_1;
     private String id;
 
     private CredentialDefinitionDto() {
@@ -57,8 +60,8 @@ public class CredentialDefinitionDto {
         return credentialType;
     }
 
-    public DataModelVersion getDataModel() {
-        return dataModel;
+    public Set<String> getFormats() {
+        return formats;
     }
 
     public String getJsonSchema() {
@@ -92,7 +95,7 @@ public class CredentialDefinitionDto {
                 .jsonSchema(jsonSchema)
                 .jsonSchemaUrl(jsonSchemaUrl)
                 .validity(validity)
-                .dataModel(dataModel)
+                .formats(formats.stream().map(String::toUpperCase).map(CredentialFormat::valueOf).collect(Collectors.toSet()))
                 .attestations(attestations)
                 .rules(rules)
                 .mappings(mappings)
@@ -139,8 +142,8 @@ public class CredentialDefinitionDto {
             return this;
         }
 
-        public Builder dataModel(DataModelVersion dataModel) {
-            this.entity.dataModel = dataModel;
+        public Builder formats(Collection<String> formats) {
+            this.entity.formats.addAll(formats);
             return this;
         }
 

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/IssuerCredentialDefinitionAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/IssuerCredentialDefinitionAdminApiControllerTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.notNullValue;
@@ -52,7 +53,7 @@ class IssuerCredentialDefinitionAdminApiControllerTest extends RestControllerTes
     void setUp() {
         when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
     }
-    
+
     @Test
     void createCredentialDefinition() {
         when(credentialDefinitionService.createCredentialDefinition(any())).thenReturn(ServiceResult.success());
@@ -185,6 +186,7 @@ class IssuerCredentialDefinitionAdminApiControllerTest extends RestControllerTes
                 .jsonSchema("json-schema")
                 .jsonSchemaUrl("json-schema-url")
                 .participantContextId(PARTICIPANT_ID)
+                .format(VC1_0_JWT)
                 .build();
     }
 }

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-03-10T11:00:00Z",
+    "lastUpdated": "2025-03-13T11:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/BaseSqlDialectStatements.java
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/BaseSqlDialectStatements.java
@@ -41,7 +41,7 @@ public class BaseSqlDialectStatements implements CredentialDefinitionStoreStatem
                 .jsonColumn(getJsonSchemaColumn())
                 .column(getJsonSchemaUrlColumn())
                 .column(getValidityColumn())
-                .column(getDataModelColumn())
+                .jsonColumn(getFormatsColumn())
                 .column(getCreateTimestampColumn())
                 .column(getLastModifiedTimestampColumn())
                 .insertInto(getCredentialDefinitionTable());
@@ -57,7 +57,7 @@ public class BaseSqlDialectStatements implements CredentialDefinitionStoreStatem
                 .jsonColumn(getJsonSchemaColumn())
                 .column(getJsonSchemaUrlColumn())
                 .column(getValidityColumn())
-                .column(getDataModelColumn())
+                .jsonColumn(getFormatsColumn())
                 .column(getLastModifiedTimestampColumn())
                 .update(getCredentialDefinitionTable(), getIdColumn());
     }

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/CredentialDefinitionStoreStatements.java
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/CredentialDefinitionStoreStatements.java
@@ -64,8 +64,8 @@ public interface CredentialDefinitionStoreStatements extends SqlStatements {
         return "validity";
     }
 
-    default String getDataModelColumn() {
-        return "data_model";
+    default String getFormatsColumn() {
+        return "formats";
     }
 
     default String getCreateTimestampColumn() {

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/SqlCredentialDefinitionStore.java
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/SqlCredentialDefinitionStore.java
@@ -16,7 +16,7 @@ package org.eclipse.edc.issuerservice.store.sql.credentialdefinition;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.DataModelVersion;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.store.CredentialDefinitionStore;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialRuleDefinition;
@@ -54,6 +54,9 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
     };
 
     private static final TypeReference<List<MappingDefinition>> MAPPINGS_LIST_REF = new TypeReference<>() {
+    };
+
+    private static final TypeReference<List<CredentialFormat>> FORMATS_LIST_REF = new TypeReference<>() {
     };
 
     private final CredentialDefinitionStoreStatements statements;
@@ -109,7 +112,7 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
                         toJson(credentialDefinition.getJsonSchema()),
                         credentialDefinition.getJsonSchemaUrl(),
                         credentialDefinition.getValidity(),
-                        credentialDefinition.getDataModel().name(),
+                        toJson(credentialDefinition.getFormats()),
                         timestamp,
                         timestamp
                 );
@@ -145,7 +148,7 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
                             toJson(credentialDefinition.getJsonSchema()),
                             credentialDefinition.getJsonSchemaUrl(),
                             credentialDefinition.getValidity(),
-                            credentialDefinition.getDataModel().name(),
+                            toJson(credentialDefinition.getFormats()),
                             clock.millis(),
                             credentialDefinition.getId()
                     );
@@ -213,7 +216,7 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
                 .jsonSchema(resultSet.getString(statements.getJsonSchemaColumn()))
                 .jsonSchemaUrl(resultSet.getString(statements.getJsonSchemaUrlColumn()))
                 .validity(resultSet.getLong(statements.getValidityColumn()))
-                .dataModel(DataModelVersion.valueOf(resultSet.getString(statements.getDataModelColumn())))
+                .formats(fromJson(resultSet.getString(statements.getFormatsColumn()), FORMATS_LIST_REF))
                 .build();
     }
 }

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/schema/postgres/CredentialDefinitionMapping.java
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/schema/postgres/CredentialDefinitionMapping.java
@@ -36,7 +36,7 @@ public class CredentialDefinitionMapping extends TranslationMapping {
     public static final String FIELD_JSON_SCHEMA = "jsonSchema";
     public static final String FIELD_JSON_SCHEMA_URL = "jsonSchemaUrl";
     public static final String FIELD_VALIDITY = "validity";
-    public static final String FIELD_DATAMODEL = "dataModel";
+    public static final String FIELD_FORMATS = "formats";
     public static final String FIELD_ATTESTATIONS = "attestations";
     public static final String FIELD_RULES = "rules";
     public static final String FIELD_MAPPINGS = "mappings";
@@ -51,7 +51,7 @@ public class CredentialDefinitionMapping extends TranslationMapping {
         add(FIELD_JSON_SCHEMA, new JsonFieldTranslator(statements.getJsonSchemaColumn()));
         add(FIELD_JSON_SCHEMA_URL, statements.getJsonSchemaUrlColumn());
         add(FIELD_VALIDITY, statements.getValidityColumn());
-        add(FIELD_DATAMODEL, statements.getDataModelColumn());
+        add(FIELD_FORMATS, new JsonArrayTranslator(statements.getFormatsColumn()));
         add(FIELD_ATTESTATIONS, new JsonArrayTranslator(statements.getAttestationsColumn()));
         add(FIELD_RULES, new JsonFieldTranslator(RULES_ALIAS));
         add(FIELD_MAPPINGS, new JsonFieldTranslator(MAPPING_ALIAS));

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/resources/credential-definition-schema.sql
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/resources/credential-definition-schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS credential_definitions
     json_schema                  JSON,
     json_schema_url              VARCHAR,
     validity                     BIGINT   NOT NULL,
-    data_model                   VARCHAR  NOT NULL,
+    formats                      JSON     NOT NULL DEFAULT '[]',
     created_date                 BIGINT   NOT NULL, -- POSIX timestamp of the creation of the PC
     last_modified_date           BIGINT,            -- POSIX timestamp of the last modified date
     PRIMARY KEY (id)

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -77,6 +78,7 @@ public class DcpIssuerServiceImplTest {
                 .attestations(attestations)
                 .participantContextId("participantContextId")
                 .rule(credentialRuleDefinition)
+                .format(VC1_0_JWT)
                 .build();
 
         var holder = Holder.Builder.newInstance().holderId("holderId").did("participantDid").holderName("name").participantContextId("participantContextId").build();
@@ -106,5 +108,5 @@ public class DcpIssuerServiceImplTest {
         assertThat(issuanceProcess.getParticipantContextId()).isEqualTo("participantContextId");
         assertThat(issuanceProcess.getHolderPid()).isEqualTo(message.getHolderPid());
     }
-    
+
 }

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/model/CredentialDefinition.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/model/CredentialDefinition.java
@@ -18,13 +18,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.DataModelVersion;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.AbstractParticipantResource;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -39,11 +41,11 @@ public class CredentialDefinition extends AbstractParticipantResource {
     private final List<String> attestations = new ArrayList<>();
     private final List<CredentialRuleDefinition> rules = new ArrayList<>();
     private final List<MappingDefinition> mappings = new ArrayList<>();
+    private final Set<CredentialFormat> formats = new HashSet<>();
     private String credentialType;
     private String jsonSchema;
     private String jsonSchemaUrl;
     private long validity;
-    private DataModelVersion dataModel = DataModelVersion.V_1_1;
     private String id;
 
     private CredentialDefinition() {
@@ -57,8 +59,8 @@ public class CredentialDefinition extends AbstractParticipantResource {
         return credentialType;
     }
 
-    public DataModelVersion getDataModel() {
-        return dataModel;
+    public Set<CredentialFormat> getFormats() {
+        return formats;
     }
 
     public String getJsonSchema() {
@@ -123,8 +125,14 @@ public class CredentialDefinition extends AbstractParticipantResource {
             return this;
         }
 
-        public Builder dataModel(DataModelVersion dataModel) {
-            this.entity.dataModel = dataModel;
+        @JsonIgnore
+        public Builder format(CredentialFormat format) {
+            this.entity.formats.add(format);
+            return this;
+        }
+
+        public Builder formats(Collection<CredentialFormat> formats) {
+            this.entity.formats.addAll(formats);
             return this;
         }
 
@@ -175,6 +183,10 @@ public class CredentialDefinition extends AbstractParticipantResource {
 
             if (entity.jsonSchema == null && entity.jsonSchemaUrl == null) {
                 throw new IllegalStateException("Either jsonSchema or jsonSchemaUrl must be non-null");
+            }
+
+            if (entity.formats.isEmpty()) {
+                throw new IllegalStateException("Credential formats cannot be empty");
             }
             Objects.requireNonNull(entity.participantContextId, "Must have an participantContextId");
             return super.build();


### PR DESCRIPTION

## What this PR changes/adds

 removes `dataModel` and introduced `formats` in `CredentialDefiniition`. 
 
 This will allow expressing on which format a `CredentialDefiniition` is available and it will bridge with the DCP profile in #676 


## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #677 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
