### PR TITLE
feat: introduce DCP profile

### DIFF
--- a/dist/bom/identityhub-base-bom/build.gradle.kts
+++ b/dist/bom/identityhub-base-bom/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     runtimeOnly(project(":core:identity-hub-participants"))
     runtimeOnly(project(":core:identity-hub-keypairs"))
     runtimeOnly(project(":extensions:did:local-did-publisher"))
+    runtimeOnly(project(":protocols:dcp:dcp-core"))
     runtimeOnly(project(":protocols:dcp:dcp-identityhub:presentation-api"))
     runtimeOnly(project(":protocols:dcp:dcp-identityhub:storage-api"))
     runtimeOnly(project(":protocols:dcp:dcp-identityhub:dcp-identityhub-core"))

--- a/dist/bom/issuerservice-base-bom/build.gradle.kts
+++ b/dist/bom/issuerservice-base-bom/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     runtimeOnly(project(":core:issuerservice:issuerservice-issuance"))
     runtimeOnly(project(":extensions:did:local-did-publisher"))
     // API modules
+    runtimeOnly(project(":protocols:dcp:dcp-core"))
     runtimeOnly(project(":protocols:dcp:dcp-issuer:dcp-issuer-core"))
     runtimeOnly(project(":protocols:dcp:dcp-issuer:dcp-issuer-api"))
     runtimeOnly(project(":extensions:api:identity-api:participant-context-api"))

--- a/protocols/dcp/dcp-core/build.gradle.kts
+++ b/protocols/dcp/dcp-core/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    api(project(":protocols:dcp:dcp-spi"))
+
+    testImplementation(libs.edc.junit)
+}
+

--- a/protocols/dcp/dcp-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/DcpCoreExtension.java
+++ b/protocols/dcp/dcp-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/DcpCoreExtension.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstringstatuslist.BitstringStatusListStatus;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpProfileRegistry;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpProfile;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import static org.eclipse.edc.identityhub.protocols.dcp.DcpCoreExtension.NAME;
+
+@Extension(NAME)
+public class DcpCoreExtension implements ServiceExtension {
+
+    public static final String NAME = "DCP Core Extension";
+
+    public static final String VC_20_BSSL_JWT = "vc20-bssl/jwt";
+    public static final String VC_11_SL_2021_JWT = "vc11-sl2021/jwt";
+    private DcpProfileRegistry registry;
+
+    @Provider
+    public DcpProfileRegistry dcpProfileRegistry() {
+
+        if (registry == null) {
+            registry = new DcpProfileRegistryImpl();
+        }
+        // Register DCP profiles https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD/#profiles-of-the-decentralized-claims-protocol
+        registry.registerProfile(new DcpProfile(VC_20_BSSL_JWT, CredentialFormat.VC2_0_JOSE, BitstringStatusListStatus.TYPE));
+        registry.registerProfile(new DcpProfile(VC_11_SL_2021_JWT, CredentialFormat.VC1_0_JWT, StatusList2021Status.TYPE));
+        return registry;
+    }
+
+
+}

--- a/protocols/dcp/dcp-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/DcpProfileRegistryImpl.java
+++ b/protocols/dcp/dcp-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/DcpProfileRegistryImpl.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpProfileRegistry;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpProfile;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DcpProfileRegistryImpl implements DcpProfileRegistry {
+    private final Map<String, DcpProfile> profiles = new HashMap<>();
+
+    @Override
+    public void registerProfile(DcpProfile profile) {
+        profiles.put(profile.name(), profile);
+    }
+
+    @Override
+    public List<DcpProfile> profilesFor(CredentialFormat format) {
+        return profiles.values().stream()
+                .filter(dcpProfile -> dcpProfile.format().equals(format))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public @Nullable DcpProfile getProfile(String name) {
+        return profiles.get(name);
+    }
+}

--- a/protocols/dcp/dcp-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/protocols/dcp/dcp-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Cofinity-X - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.protocols.dcp.DcpCoreExtension

--- a/protocols/dcp/dcp-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/DcpCoreExtensionTest.java
+++ b/protocols/dcp/dcp-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/DcpCoreExtensionTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.bitstringstatuslist.BitstringStatusListStatus;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.revocation.statuslist2021.StatusList2021Status;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpProfile;
+import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.identityhub.protocols.dcp.DcpCoreExtension.VC_11_SL_2021_JWT;
+import static org.eclipse.edc.identityhub.protocols.dcp.DcpCoreExtension.VC_20_BSSL_JWT;
+
+@ExtendWith(DependencyInjectionExtension.class)
+public class DcpCoreExtensionTest {
+    
+
+    @Test
+    void initialize_verifyTokenRules(DcpCoreExtension extension, ServiceExtensionContext context) {
+
+        assertThat(extension.dcpProfileRegistry()).isInstanceOf(DcpProfileRegistryImpl.class)
+                .satisfies(registry -> {
+                    assertThat(registry.getProfile(VC_20_BSSL_JWT)).isEqualTo(new DcpProfile(VC_20_BSSL_JWT, CredentialFormat.VC2_0_JOSE, BitstringStatusListStatus.TYPE));
+                    assertThat(registry.getProfile(VC_11_SL_2021_JWT)).isEqualTo(new DcpProfile(VC_11_SL_2021_JWT, CredentialFormat.VC1_0_JWT, StatusList2021Status.TYPE));
+                });
+
+    }
+}

--- a/protocols/dcp/dcp-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/DcpProfileRegistryImplTest.java
+++ b/protocols/dcp/dcp-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/DcpProfileRegistryImplTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpProfileRegistry;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpProfile;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DcpProfileRegistryImplTest {
+
+    private final DcpProfileRegistry registry = new DcpProfileRegistryImpl();
+
+
+    @Test
+    void register() {
+        var profile = new DcpProfile("profile", CredentialFormat.VC1_0_JWT, "type");
+        registry.registerProfile(profile);
+
+        assertThat(registry.getProfile("profile")).isEqualTo(profile);
+    }
+
+    @Test
+    void profilesFor() {
+        var profile = new DcpProfile("profile", CredentialFormat.VC1_0_JWT, "type");
+        var profile1 = new DcpProfile("profile1", CredentialFormat.VC1_0_JWT, "type2");
+
+        registry.registerProfile(profile);
+        registry.registerProfile(profile1);
+
+        assertThat(registry.profilesFor(CredentialFormat.VC1_0_JWT)).containsOnly(profile, profile1);
+    }
+}

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/build.gradle.kts
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     api(project(":spi:verifiable-credential-spi"))
     api(project(":spi:issuerservice:issuerservice-holder-spi"))
     api(project(":spi:issuerservice:issuerservice-issuance-spi"))
+    api(project(":protocols:dcp:dcp-spi"))
     api(project(":protocols:dcp:dcp-issuer:dcp-issuer-spi"))
     api(libs.edc.spi.jwt)
     api(libs.edc.spi.http)

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerCoreExtension.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerCoreExtension.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.edc.iam.identitytrust.spi.CredentialServiceUrlResolver;
 import org.eclipse.edc.identityhub.protocols.dcp.issuer.spi.DcpIssuerService;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpHolderTokenVerifier;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpProfileRegistry;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.participantcontext.store.ParticipantContextStore;
 import org.eclipse.edc.issuerservice.spi.holder.store.HolderStore;
@@ -102,6 +103,9 @@ public class DcpIssuerCoreExtension implements ServiceExtension {
     @Inject
     private DidResolverRegistry didResolverRegistry;
 
+    @Inject
+    private DcpProfileRegistry profileRegistry;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         rulesRegistry.addRule(DCP_ISSUER_SELF_ISSUED_TOKEN_CONTEXT, new IssuerEqualsSubjectRule());
@@ -110,7 +114,7 @@ public class DcpIssuerCoreExtension implements ServiceExtension {
 
     @Provider
     public DcpIssuerService createIssuerService() {
-        return new DcpIssuerServiceImpl(transactionContext, credentialDefinitionService, issuanceProcessStore, attestationPipeline, credentialRuleDefinitionEvaluator);
+        return new DcpIssuerServiceImpl(transactionContext, credentialDefinitionService, issuanceProcessStore, attestationPipeline, credentialRuleDefinitionEvaluator, profileRegistry);
     }
 
     @Provider

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
@@ -15,8 +15,10 @@
 package org.eclipse.edc.identityhub.protocols.dcp.issuer;
 
 import org.eclipse.edc.identityhub.protocols.dcp.issuer.spi.DcpIssuerService;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpProfileRegistry;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequest;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialRequestMessage;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpProfile;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpRequestContext;
 import org.eclipse.edc.issuerservice.spi.holder.model.Holder;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationPipeline;
@@ -55,8 +57,9 @@ public class DcpIssuerServiceImplTest {
     private final TransactionContext transactionContext = new NoopTransactionContext();
     private final IssuanceProcessStore issuanceProcessStore = mock();
     private final CredentialRuleDefinitionEvaluator credentialRuleDefinitionEvaluator = mock();
+    private final DcpProfileRegistry dcpProfileRegistry = mock();
 
-    private final DcpIssuerService dcpIssuerService = new DcpIssuerServiceImpl(transactionContext, credentialDefinitionService, issuanceProcessStore, attestationPipeline, credentialRuleDefinitionEvaluator);
+    private final DcpIssuerService dcpIssuerService = new DcpIssuerServiceImpl(transactionContext, credentialDefinitionService, issuanceProcessStore, attestationPipeline, credentialRuleDefinitionEvaluator, dcpProfileRegistry);
 
 
     @Test
@@ -89,6 +92,7 @@ public class DcpIssuerServiceImplTest {
         when(credentialDefinitionService.queryCredentialDefinitions(any())).thenReturn(ServiceResult.success(List.of(credentialDefinition)));
         when(attestationPipeline.evaluate(eq(attestations), any())).thenReturn(Result.success(claims));
         when(credentialRuleDefinitionEvaluator.evaluate(eq(List.of(credentialRuleDefinition)), any())).thenReturn(Result.success());
+        when(dcpProfileRegistry.profilesFor(VC1_0_JWT)).thenReturn(List.of(new DcpProfile("profile", VC1_0_JWT, "statusType")));
 
         var result = dcpIssuerService.initiateCredentialsIssuance("participantContextId", message, participant);
 

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/DcpProfileRegistry.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/DcpProfileRegistry.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.spi;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.DcpProfile;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Registry for {@link DcpProfile}.
+ */
+public interface DcpProfileRegistry {
+
+    void registerProfile(DcpProfile profile);
+
+    List<DcpProfile> profilesFor(CredentialFormat format);
+
+    @Nullable
+    DcpProfile getProfile(String name);
+}

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/DcpProfile.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/DcpProfile.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.protocols.dcp.spi.model;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+
+/**
+ * Represents a DCP profile identified by an alias and identifies a combination of a credential format and a status list type.
+ */
+public record DcpProfile(String name, CredentialFormat format, String statusListType) {
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -77,6 +77,7 @@ include(":extensions:sts:sts-api")
 
 // DCP protocol modules
 include(":protocols:dcp:dcp-spi")
+include(":protocols:dcp:dcp-core")
 include(":protocols:dcp:dcp-issuer:dcp-issuer-spi")
 include(":protocols:dcp:dcp-transform-lib")
 include(":protocols:dcp:dcp-validation-lib")


### PR DESCRIPTION
## What this PR changes/adds

- Introduces a `DcpProfileRegistry` for supporting DCP [profiles](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/HEAD/#profiles-of-the-decentralized-claims-protocol)

- Bundle by default two profiles defined in DCP spec
- Added profiles check on credential request, `holder -> issuer`, with the input formats.
  

## Why it does that

_Briefly state why the change was necessary._

## Further notes

Currently the profile is not used in the `IssuerMetadata` which will come in #601 
but also in this PR it's not applied when sending the `CredentialOffer`


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #676 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
