### PR TITLE
feat: holder-side Credential Offer API

### DIFF
--- a/protocols/dcp/dcp-identityhub/credential-offer-api/build.gradle.kts
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/build.gradle.kts
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/build.gradle.kts
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+plugins {
+    `java-library`
+    `maven-publish`
+    id("io.swagger.core.v3.swagger-gradle-plugin")
+}
+
+dependencies {
+    api(project(":spi:identity-hub-spi"))
+    api(project(":protocols:dcp:dcp-spi"))
+
+    api(libs.edc.spi.jsonld)
+    api(libs.edc.spi.jwt)
+    api(libs.edc.spi.core)
+
+    implementation(project(":protocols:dcp:dcp-identityhub:credentials-api-configuration"))
+    implementation(project(":protocols:dcp:dcp-transform-lib"))
+    implementation(libs.edc.spi.validator)
+    implementation(libs.edc.spi.web)
+    implementation(libs.edc.spi.dcp)
+    implementation(libs.edc.lib.jerseyproviders)
+    implementation(libs.edc.lib.transform)
+    implementation(libs.edc.dcp.transform)
+    implementation(libs.jakarta.rsApi)
+    testImplementation(libs.edc.junit)
+    testImplementation(libs.edc.jsonld)
+    testImplementation(testFixtures(libs.edc.core.jersey))
+    testImplementation(testFixtures(project(":spi:verifiable-credential-spi")))
+    testImplementation(libs.nimbus.jwt)
+    testImplementation(libs.restAssured)
+}
+
+edcBuild {
+    swagger {
+        apiGroup.set("credentials-api")
+    }
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/CredentialOfferApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/CredentialOfferApiExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/CredentialOfferApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/CredentialOfferApiExtension.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api;
+
+import org.eclipse.edc.identityhub.api.credentialoffer.CredentialOfferApiController;
+import org.eclipse.edc.identityhub.api.validation.CredentialOfferMessageValidator;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpIssuerTokenVerifier;
+import org.eclipse.edc.identityhub.protocols.dcp.transform.to.JsonObjectToCredentialObjectTransformer;
+import org.eclipse.edc.identityhub.protocols.dcp.transform.to.JsonObjectToCredentialOfferMessageTransformer;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriter;
+import org.eclipse.edc.jsonld.spi.JsonLd;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.jersey.providers.jsonld.ObjectMapperProvider;
+import org.eclipse.edc.web.spi.WebService;
+
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.api.CredentialOfferApiExtension.NAME;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIAL_MESSAGE_TERM;
+import static org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext.CREDENTIALS;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
+
+@Extension(value = NAME)
+public class CredentialOfferApiExtension implements ServiceExtension {
+
+    public static final String NAME = "Storage API Extension";
+
+    @Inject
+    private TypeTransformerRegistry typeTransformer;
+    @Inject
+    private JsonObjectValidatorRegistry validatorRegistry;
+    @Inject
+    private WebService webService;
+    @Inject
+    private JsonLd jsonLd;
+    @Inject
+    private TypeManager typeManager;
+    @Inject
+    private CredentialWriter writer;
+    @Inject
+    private DcpIssuerTokenVerifier issuerTokenVerifier;
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private ParticipantContextService participantContextService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void initialize(ServiceExtensionContext context) {
+
+        validatorRegistry.register(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_MESSAGE_TERM), new CredentialOfferMessageValidator());
+
+        var controller = new CredentialOfferApiController(validatorRegistry, typeTransformer, context.getMonitor().withPrefix("CredentialOfferApi"), issuerTokenVerifier, participantContextService);
+        webService.registerResource(CREDENTIALS, new ObjectMapperProvider(typeManager, JSON_LD));
+        webService.registerResource(CREDENTIALS, controller);
+
+        registerTransformers();
+    }
+
+    void registerTransformers() {
+        var scopedTransformerRegistry = typeTransformer.forContext(DCP_SCOPE_V_1_0);
+
+        // inbound
+        scopedTransformerRegistry.register(new JsonObjectToCredentialOfferMessageTransformer(DSPACE_DCP_NAMESPACE_V_1_0));
+        scopedTransformerRegistry.register(new JsonObjectToCredentialObjectTransformer(typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
+    }
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/ApiSchema.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/ApiSchema.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/ApiSchema.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/ApiSchema.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.credentialoffer;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public interface ApiSchema {
+    @Schema(name = "ApiErrorDetail", example = ApiErrorDetailSchema.API_ERROR_EXAMPLE)
+    record ApiErrorDetailSchema(
+            String message,
+            String type,
+            String path,
+            String invalidValue
+    ) {
+        public static final String API_ERROR_EXAMPLE = """
+                {
+                    "message": "error message",
+                    "type": "ErrorType",
+                    "path": "object.error.path",
+                    "invalidValue": "this value is not valid"
+                }
+                """;
+    }
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApi.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApi.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.credentialoffer;
+
+
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.Response;
+
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SPECIFICATION_URL;
+
+@OpenAPIDefinition(
+        info = @Info(description = "This implements the Credential Offer API as per DCP specification. It serves as notification facility for a holder.", title = "Credential Offer API",
+                version = "1"))
+@SecurityScheme(name = "Authentication",
+        description = "Self-Issued ID",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT")
+public interface CredentialOfferApi {
+
+    @Tag(name = "Credential Offer API")
+    @Operation(description = "Notifies the holder about the availability of a particular credential for issuance",
+            requestBody = @RequestBody(content = @Content(schema = @Schema(externalDocs = @ExternalDocumentation(description = "DCP Credential Offer API", url = DCP_SPECIFICATION_URL)))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The offer notification was successfully received."),
+                    @ApiResponse(responseCode = "400", description = "Request body was malformed",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "401", description = "No Authorization header was given.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class)))),
+                    @ApiResponse(responseCode = "403", description = "The given authentication token could not be validated.",
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiSchema.ApiErrorDetailSchema.class))))
+
+            }
+    )
+    Response offerCredential(String participantContextId, JsonObject credentialOfferMessage, String authHeader);
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApi.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApi.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiController.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiController.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiController.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiController.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.credentialoffer;
+
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpIssuerTokenVerifier;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.web.spi.exception.AuthenticationFailedException;
+import org.eclipse.edc.web.spi.exception.InvalidRequestException;
+import org.eclipse.edc.web.spi.exception.NotAuthorizedException;
+import org.eclipse.edc.web.spi.exception.ValidationFailureException;
+
+import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.DCP_SCOPE_V_1_0;
+import static org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextId.onEncoded;
+
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
+@Path("/v1/participants/{participantContextId}/offers")
+public class CredentialOfferApiController implements CredentialOfferApi {
+
+    private final JsonObjectValidatorRegistry validatorRegistry;
+    private final TypeTransformerRegistry transformerRegistry;
+    private final Monitor monitor;
+    private final DcpIssuerTokenVerifier issuerTokenVerifier;
+    private final ParticipantContextService participantContextService;
+
+    public CredentialOfferApiController(JsonObjectValidatorRegistry validatorRegistry,
+                                        TypeTransformerRegistry transformerRegistry,
+                                        Monitor monitor,
+                                        DcpIssuerTokenVerifier issuerTokenVerifier,
+                                        ParticipantContextService participantContextService) {
+        this.validatorRegistry = validatorRegistry;
+        this.transformerRegistry = transformerRegistry;
+        this.monitor = monitor;
+        this.issuerTokenVerifier = issuerTokenVerifier;
+        this.participantContextService = participantContextService;
+    }
+
+
+    @POST
+    @Override
+    public Response offerCredential(@PathParam("participantContextId") String participantContextId, JsonObject credentialOfferMessage, @HeaderParam(AUTHORIZATION) String authHeader) {
+        if (credentialOfferMessage == null) {
+            throw new InvalidRequestException("Request body is null");
+        }
+        if (authHeader == null) {
+            throw new AuthenticationFailedException("Authorization header missing");
+        }
+        var authToken = authHeader.replace("Bearer", "").trim();
+        validatorRegistry.validate(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_OFFER_MESSAGE_TERM), credentialOfferMessage).orElseThrow(ValidationFailureException::new);
+        var protocolRegistry = transformerRegistry.forContext(DCP_SCOPE_V_1_0);
+
+        participantContextId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);
+
+        var offerMessage = protocolRegistry.forContext(DCP_SCOPE_V_1_0).transform(credentialOfferMessage, CredentialOfferMessage.class).orElseThrow(InvalidRequestException::new);
+
+        var participantContext = participantContextService.getParticipantContext(participantContextId)
+                .orElseThrow((f) -> new AuthenticationFailedException("Invalid participant"));
+
+        // validate Issuer's SI token
+        issuerTokenVerifier.verify(participantContext, authToken)
+                .orElseThrow(f -> new NotAuthorizedException("ID token verification failed: %s".formatted(f.getFailureDetail())));
+
+
+        //todo: process credential offer message
+        monitor.warning("Credential offer was received but processing it is not yet implemented");
+        return Response.ok().build();
+    }
+
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialObjectValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialObjectValidator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialObjectValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialObjectValidator.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.validation;
+
+import jakarta.json.JsonObject;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.validator.spi.ValidationResult;
+
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.ValidationResult.success;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+public class CredentialObjectValidator extends JsonValidator {
+    private final JsonLdNamespace namespace = DSPACE_DCP_NAMESPACE_V_1_0;
+
+    @Override
+    public ValidationResult validate(JsonObject input) {
+        if (input == null) {
+            return failure(violation("CredentialObject was null", "."));
+        }
+
+        var credentialType = input.get(namespace.toIri(CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM));
+        if (isNullObject(credentialType)) {
+            return failure(violation("Must contain a '%s' property.".formatted(CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM), null));
+        }
+
+        return success();
+    }
+
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidator.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.validation;
+
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+import org.eclipse.edc.validator.spi.ValidationResult;
+
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIAL_ISSUER_TERM;
+import static org.eclipse.edc.validator.spi.ValidationResult.failure;
+import static org.eclipse.edc.validator.spi.ValidationResult.success;
+import static org.eclipse.edc.validator.spi.Violation.violation;
+
+/**
+ * Validates that a JsonObject representing a {@link org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage} contains
+ * a {@code issuer} identifier and a {@code credentials} property
+ */
+public class CredentialOfferMessageValidator extends JsonValidator {
+
+    private final JsonLdNamespace namespace = DSPACE_DCP_NAMESPACE_V_1_0;
+
+    private final CredentialObjectValidator credentialObjectValidator = new CredentialObjectValidator();
+
+
+    @Override
+    public ValidationResult validate(JsonObject input) {
+        if (input == null) {
+            return failure(violation("CredentialOfferMessage was null", "."));
+        }
+        var issuer = input.get(namespace.toIri(CREDENTIAL_ISSUER_TERM));
+        if (isNullObject(issuer)) {
+            return failure(violation("Must contain a '%s' property.".formatted(CREDENTIAL_ISSUER_TERM), null));
+        }
+
+        //sending an empty offer is nonsensical, but strictly speaking, it's allowed
+
+        var array = input.get(namespace.toIri(CREDENTIALS_TERM));
+        if (!isNullObject(array) && array.getValueType() == JsonValue.ValueType.ARRAY) {
+            var results = array.asJsonArray().stream().map(jv -> credentialObjectValidator.validate(jv.asJsonObject()));
+            return results.reduce(ValidationResult::merge).orElse(success());
+        }
+
+        return success();
+    }
+
+
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/JsonValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/JsonValidator.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/JsonValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/JsonValidator.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.validation;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.validator.spi.Validator;
+
+import static java.util.Optional.ofNullable;
+
+public abstract class JsonValidator implements Validator<JsonObject> {
+    /**
+     * Checks if the given JsonValue object is the Null-Object. Due to JSON-LD expansion, a {@code "key": null}
+     * would get expanded to an array, thus a simple equals-null check is not sufficient.
+     *
+     * @param value the JsonValue to check
+     * @return true if the JsonValue object is either null, or its value type is NULL, false otherwise
+     */
+    protected boolean isNullObject(JsonValue value) {
+        if (value instanceof JsonArray jarray) {
+            if (jarray.isEmpty()) {
+                return false; // empty arrays are OK
+            }
+            value = jarray.get(0).asJsonObject().get(JsonLdKeywords.VALUE);
+            return ofNullable(value).map(jv -> jv.getValueType() == JsonValue.ValueType.NULL).orElse(false);
+        }
+        return value == null;
+    }
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2025 Cofinity-X
+#  Copyright (c) 2025 Metaform Systems Inc.
 #
 #  This program and the accompanying materials are made available under the
 #  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 #  Contributors:
-#       Cofinity-X - initial API and implementation
+#       Metaform Systems Inc. - initial API and implementation
 #
 #
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2025 Cofinity-X
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Contributors:
+#       Cofinity-X - initial API and implementation
+#
+#
+
+org.eclipse.edc.identityhub.api.CredentialOfferApiExtension

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiControllerTest.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiControllerTest.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/credentialoffer/CredentialOfferApiControllerTest.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.credentialoffer;
+
+import io.restassured.specification.RequestSpecification;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpIssuerTokenVerifier;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
+import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContextState;
+import org.eclipse.edc.spi.iam.ClaimToken;
+import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
+import org.eclipse.edc.validator.spi.JsonObjectValidatorRegistry;
+import org.eclipse.edc.validator.spi.ValidationResult;
+import org.eclipse.edc.validator.spi.Violation;
+import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_BINDING_METHODS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_OFFER_REASON_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_PROFILES_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIAL_ISSUER_TERM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CredentialOfferApiControllerTest extends RestControllerTestBase {
+
+    private static final String PARTICIPANT_ID = "test-participant";
+    private final JsonObjectValidatorRegistry validatorRegistry = mock();
+    private final TypeTransformerRegistry typeTransformerRegistry = mock();
+    private final DcpIssuerTokenVerifier tokenVerifier = mock();
+    private final ParticipantContextService participantContextService = mock();
+    private final CredentialOfferApiController controller = new CredentialOfferApiController(validatorRegistry, typeTransformerRegistry, mock(), tokenVerifier, participantContextService);
+
+    @BeforeEach
+    void setUp() {
+        when(validatorRegistry.validate(anyString(), any())).thenReturn(ValidationResult.success());
+
+        when(tokenVerifier.verify(any(), anyString())).thenReturn(Result.success(
+                ClaimToken.Builder.newInstance()
+                        .claim("foo", "bar")
+                        .build()
+        ));
+
+        when(typeTransformerRegistry.forContext(anyString())).thenReturn(typeTransformerRegistry);
+        when(typeTransformerRegistry.forContext(anyString())).thenReturn(typeTransformerRegistry);
+        when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(CredentialOfferMessage.class)))
+                .thenReturn(Result.success(CredentialOfferMessage.Builder.newInstance().build()));
+
+        when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.success(
+                ParticipantContext.Builder.newInstance()
+                        .participantContextId("test-id")
+                        .did("did:web:test-id")
+                        .state(ParticipantContextState.CREATED)
+                        .apiTokenAlias("test-alias")
+                        .build()
+        ));
+    }
+
+    @Test
+    void offerCredential_success() {
+        baseRequest()
+                .body(createRequestBody())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200);
+    }
+
+    @Test
+    void offerCredential_missingRequestBody_expect400() {
+        baseRequest()
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+    }
+
+    @Test
+    void offerCredential_invalidRequest_expect400() {
+        when(validatorRegistry.validate(anyString(), any())).thenReturn(ValidationResult.failure(Violation.violation("foo", null)));
+        baseRequest()
+                .body(createRequestBody())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+    }
+
+    @Test
+    void offerCredential_invalidAuthToken_expect403() {
+        when(tokenVerifier.verify(any(), anyString())).thenReturn(Result.failure("foobar"));
+        baseRequest()
+                .body(createRequestBody())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(403);
+    }
+
+    @Test
+    void offerCredential_missingAuthHeader_expect401() {
+        given()
+                .contentType("application/json")
+                .baseUri("http://localhost:" + port + "/v1/participants/" + PARTICIPANT_ID + "/offers")
+                //missing: Auth header
+                .body(createRequestBody())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(401);
+    }
+
+    @Test
+    void offerCredential_missingParticipantContextId_expect401() {
+        when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.notFound("foobar"));
+        baseRequest()
+                .body(createRequestBody())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(401);
+    }
+
+    @Test
+    void offerCredential_transformationFailed_expect400() {
+        when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(CredentialOfferMessage.class)))
+                .thenReturn(Result.failure("foobar"));
+        baseRequest()
+                .body(createRequestBody())
+                .post()
+                .then()
+                .log().ifValidationFails()
+                .statusCode(400);
+    }
+
+    @Override
+    protected Object controller() {
+        return controller;
+    }
+
+    private RequestSpecification baseRequest() {
+        return given()
+                .contentType("application/json")
+                .baseUri("http://localhost:" + port + "/v1/participants/" + PARTICIPANT_ID + "/offers")
+                .header("Authorization", "Bearer test-token")
+                .when();
+    }
+
+    private JsonObject createRequestBody() {
+        var credentialsArray = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add(toIri(CREDENTIAL_OBJECT_PROFILES_TERM), Json.createArrayBuilder(List.of("profile")))
+                        .add(toIri(CREDENTIAL_OBJECT_OFFER_REASON_TERM), "offerReason")
+                        .add(toIri(CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM), "MembershipCredential")
+                        .add(toIri(CREDENTIAL_OBJECT_BINDING_METHODS_TERM), Json.createArrayBuilder(List.of("binding")))
+                        .build());
+        return Json.createObjectBuilder()
+                .add(toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(toIri(CREDENTIALS_TERM), credentialsArray)
+                .build();
+    }
+
+    private String toIri(String term) {
+        return DSPACE_DCP_NAMESPACE_V_1_0.toIri(term);
+    }
+}

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidatorTest.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Cofinity-X
+ *  Copyright (c) 2025 Metaform Systems Inc.
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Cofinity-X - initial API and implementation
+ *       Metaform Systems Inc. - initial API and implementation
  *
  */
 

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidatorTest.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidatorTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.api.validation;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
+import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_BINDING_METHODS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_ISSUANCE_POLICY_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_OFFER_REASON_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_PROFILES_TERM;
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+class CredentialOfferMessageValidatorTest {
+    private final CredentialOfferMessageValidator validator = new CredentialOfferMessageValidator();
+
+    @Test
+    void validate_noCredentials_success() {
+        var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .build();
+
+        assertThat(validator.validate(msg)).isSucceeded();
+    }
+
+    @Test
+    void validate_missingIssuer() {
+        var msg = Json.createObjectBuilder()
+                .add(JsonLdKeywords.TYPE, "CredentialOfferMessage")
+                .build();
+
+        assertThat(validator.validate(msg)).isFailed()
+                .detail().contains("Must contain a 'credentialIssuer' property.");
+    }
+
+    @Test
+    void validate_withCredentials_success() {
+        var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIALS_TERM), Json.createArrayBuilder()
+                        .add(createCredentialObject())
+                        .add(createCredentialObject()))
+                .build();
+        assertThat(validator.validate(msg)).isSucceeded();
+    }
+
+    @Test
+    void validate_withCredentials_withViolation() {
+        var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIALS_TERM), Json.createArrayBuilder()
+                        .add(Json.createObjectBuilder().add("invalid-key", "invalid-value").build()))
+                .build();
+        assertThat(validator.validate(msg)).isFailed();
+    }
+
+    private JsonObject createCredentialObject() {
+        return Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_OBJECT_ISSUANCE_POLICY_TERM), Json.createArrayBuilder()
+                        .add(Json.createObjectBuilder()
+                                .add(JsonLdKeywords.TYPE, JsonLdKeywords.JSON)
+                                .add(JsonLdKeywords.VALUE, Json.createObjectBuilder()
+                                        .add("id", "test-id")
+                                        .build())))
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_OBJECT_PROFILES_TERM), Json.createArrayBuilder(List.of("profile")))
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_OBJECT_OFFER_REASON_TERM), "offerReason")
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM), "MembershipCredential")
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_OBJECT_BINDING_METHODS_TERM), Json.createArrayBuilder(List.of("binding")))
+                .build();
+    }
+}

--- a/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/credentials-api-version.json
+++ b/protocols/dcp/dcp-identityhub/credentials-api-configuration/src/main/resources/credentials-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1",
-    "lastUpdated": "2025-02-26T12:00:00Z",
+    "lastUpdated": "2025-03-24T09:00:00Z",
     "maturity": "stable"
   }
 ]

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/DcpConstants.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/DcpConstants.java
@@ -24,4 +24,6 @@ public interface DcpConstants {
     @Deprecated(since = "0.12.0")
     String DCP_SCOPE_V_0_8 = DCP_SCOPE_PREFIX + DCP_SCOPE_SEPARATOR + V_0_8;
     String DCP_SCOPE_V_1_0 = DCP_SCOPE_PREFIX + DCP_SCOPE_SEPARATOR + V_1_0;
+    // URL where the DCP Specification resides. Could be used for externalDocs properties in Swagger
+    String DCP_SPECIFICATION_URL = "https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol";
 }

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialOfferMessage.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialOfferMessage.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CredentialOfferMessage {
-    public static final String TYPE = "CredentialOfferMessage";
+    public static final String CREDENTIAL_OFFER_MESSAGE_TERM = "CredentialOfferMessage";
     public static final String CREDENTIAL_ISSUER_TERM = "credentialIssuer";
     public static final String CREDENTIALS_TERM = "credentials";
     private List<CredentialObject> credentials = new ArrayList<>();

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialOfferMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialOfferMessageTransformer.java
@@ -38,7 +38,7 @@ public class JsonObjectFromCredentialOfferMessageTransformer extends AbstractNam
                 .collect(toJsonArray());
 
         return Json.createObjectBuilder()
-                .add(TYPE, forNamespace(CredentialOfferMessage.TYPE))
+                .add(TYPE, forNamespace(CredentialOfferMessage.CREDENTIAL_OFFER_MESSAGE_TERM))
                 .add(forNamespace(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), credentialOfferMessage.getIssuer())
                 .add(forNamespace(CredentialOfferMessage.CREDENTIALS_TERM), credentials)
                 .build();

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformer.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class JsonObjectToCredentialOfferMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, CredentialOfferMessage> {
-    protected JsonObjectToCredentialOfferMessageTransformer(JsonLdNamespace namespace) {
+    public JsonObjectToCredentialOfferMessageTransformer(JsonLdNamespace namespace) {
         super(JsonObject.class, CredentialOfferMessage.class, namespace);
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -86,6 +86,7 @@ include(":protocols:dcp:dcp-issuer:dcp-issuer-core")
 include(":protocols:dcp:dcp-identityhub:credentials-api-configuration")
 include(":protocols:dcp:dcp-identityhub:presentation-api")
 include(":protocols:dcp:dcp-identityhub:storage-api")
+include(":protocols:dcp:dcp-identityhub:credential-offer-api")
 include(":protocols:dcp:dcp-identityhub:dcp-identityhub-transform-lib")
 include(":protocols:dcp:dcp-identityhub:dcp-identityhub-core")
 


### PR DESCRIPTION
## What this PR changes/adds

this PR adds the holder-side Credential Offer API to receive credential offers from the issuer

## Why it does that

notifying holders about available credentials 

## Further notes


- the credential offer is not yet processed. this will come in a subsequent pull-request


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #672 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
