### PR TITLE
fix: prevent 'invalid Uri' error

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java
@@ -159,11 +159,12 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
     }
 
     private JsonObject signPresentation(JsonObject presentationObject, SignatureSuite suite, String suiteIdentifier, PrivateKey pk, String publicKeyId, String controller) {
+        var composedKeyId = publicKeyId;
         if (!publicKeyId.startsWith(controller)) {
-            publicKeyId = controller + "#" + publicKeyId;
+            composedKeyId = controller + "#" + publicKeyId;
         }
 
-        var keyIdUri = URI.create(publicKeyId);
+        var keyIdUri = URI.create(composedKeyId);
         var controllerUri = URI.create(controller);
         var verificationMethodType = URI.create(suiteIdentifier);
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java
@@ -159,6 +159,10 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
     }
 
     private JsonObject signPresentation(JsonObject presentationObject, SignatureSuite suite, String suiteIdentifier, PrivateKey pk, String publicKeyId, String controller) {
+        if (!publicKeyId.startsWith(controller)) {
+            publicKeyId = controller + "#" + publicKeyId;
+        }
+
         var keyIdUri = URI.create(publicKeyId);
         var controllerUri = URI.create(controller);
         var verificationMethodType = URI.create(suiteIdentifier);
@@ -169,7 +173,7 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
 
         var proofDraft = Jws2020ProofDraft.Builder.newInstance()
                 .proofPurpose(ASSERTION_METHOD)
-                .verificationMethod(new JsonWebKeyPair(URI.create(controller + "#" + publicKeyId), verificationMethodType, controllerUri, null))
+                .verificationMethod(new JsonWebKeyPair(keyIdUri, verificationMethodType, controllerUri, null))
                 .created(Instant.now())
                 .mapper(typeManager.getMapper(typeContext))
                 .build();

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGeneratorTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGeneratorTest.java
@@ -154,6 +154,17 @@ class LdpPresentationGeneratorTest extends PresentationGeneratorTest {
         assertThat(result).isNotNull();
     }
 
+    @Test
+    public void create_whenPublicKeyContainsController() {
+        var ldpVc = TestData.LDP_VC_WITH_PROOF;
+        var vcc = new VerifiableCredentialContainer(ldpVc, CredentialFormat.VC1_0_LD, createDummyCredential());
+        var publicKeyIdWithController = ADDITIONAL_DATA.get("controller").toString() + "#" + PUBLIC_KEY_ID;
+
+        var result = creator.generatePresentation(List.of(vcc), PRIVATE_KEY_ALIAS, publicKeyIdWithController, issuerId, ADDITIONAL_DATA);
+        assertThat(result).isNotNull();
+        assertThat(result.get("https://w3id.org/security#proof")).isNotNull();
+    }
+
     @NotNull
     private TitaniumJsonLd initializeJsonLd() {
         var jld = new TitaniumJsonLd(mock());


### PR DESCRIPTION
## What this PR changes/adds

Add an if-statement to check whether the keyId already contains the controller. If not, the publicKeyId is extended by controller + # publicKeyId.

## Why it does that

If the controller is already included in the publicKeyId, and a uri is still created together with the controller and publicKeyId, an “invalid Uri” error occurs.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #688

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
