### PR TITLE
feat: implement automatic credential renewal

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImpl.java
@@ -41,29 +41,30 @@ public class CredentialStatusCheckServiceImpl implements CredentialStatusCheckSe
     }
 
     @Override
-    public Result<VcStatus> checkStatus(VerifiableCredentialResource resource) {
-
-        if (isExpired(resource)) {
-            return success(VcStatus.EXPIRED);
-        }
-        VcStatus targetStatus;
-        if (isNotYetValid(resource)) {
-            targetStatus = VcStatus.NOT_YET_VALID;
-        } else {
-            targetStatus = VcStatus.ISSUED;
-        }
+    public Result<VcStatus> checkStatus(VerifiableCredentialResource credential) {
 
         try {
-            if (isRevoked(resource)) {
+            if (isRevoked(credential)) {
                 return success(VcStatus.REVOKED); //irreversible, cannot be overwritten
-            }
-            if (isSuspended(resource)) {
-                targetStatus = VcStatus.SUSPENDED;
+            } else if (isSuspended(credential)) {
+                return success(VcStatus.SUSPENDED);
             }
 
         } catch (EdcException ex) {
             return failure(ex.getMessage());
         }
+
+        if (isExpired(credential)) {
+            return success(VcStatus.EXPIRED);
+        }
+        VcStatus targetStatus;
+        if (isNotYetValid(credential)) {
+            targetStatus = VcStatus.NOT_YET_VALID;
+        } else {
+            targetStatus = VcStatus.ISSUED;
+        }
+
+
         return success(targetStatus);
     }
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImplTest.java
@@ -35,7 +35,9 @@ import java.util.UUID;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class CredentialStatusCheckServiceImplTest {
@@ -139,7 +141,7 @@ class CredentialStatusCheckServiceImplTest {
                 .build();
         assertThat(service.checkStatus(createCredentialBuilder(credential).build()))
                 .isSucceeded()
-                .isEqualTo(VcStatus.EXPIRED);
+                .isEqualTo(VcStatus.REVOKED);
     }
 
     @Test
@@ -234,8 +236,9 @@ class CredentialStatusCheckServiceImplTest {
 
         assertThat(service.checkStatus(createCredentialBuilder(credential).state(VcStatus.ISSUED).build()))
                 .isSucceeded()
-                .isEqualTo(VcStatus.EXPIRED);
-        verifyNoInteractions(revocationServiceRegistry);
+                .isEqualTo(VcStatus.REVOKED);
+        verify(revocationServiceRegistry).getRevocationStatus(credential);
+        verifyNoMoreInteractions(revocationServiceRegistry);
     }
 
     @Test
@@ -247,8 +250,9 @@ class CredentialStatusCheckServiceImplTest {
 
         assertThat(service.checkStatus(createCredentialBuilder(credential).state(VcStatus.ISSUED).build()))
                 .isSucceeded()
-                .isEqualTo(VcStatus.EXPIRED);
-        verifyNoInteractions(revocationServiceRegistry);
+                .isEqualTo(VcStatus.SUSPENDED);
+        verify(revocationServiceRegistry, times(2)).getRevocationStatus(credential);
+        verifyNoMoreInteractions(revocationServiceRegistry);
     }
 
     private VerifiableCredentialResource.Builder createCredentialBuilder(VerifiableCredential credential) {

--- a/extensions/common/credential-watchdog/src/main/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdog.java
+++ b/extensions/common/credential-watchdog/src/main/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdog.java
@@ -58,7 +58,12 @@ public class CredentialWatchdog implements Runnable {
     private final Duration expiryGracePeriod;
     private final CredentialRequestManager credentialRequestManager;
 
-    public CredentialWatchdog(CredentialStore credentialStore, CredentialStatusCheckService credentialStatusCheckService, Monitor monitor, TransactionContext transactionContext, Duration expiryGracePeriod, CredentialRequestManager credentialRequestManager) {
+    public CredentialWatchdog(CredentialStore credentialStore,
+                              CredentialStatusCheckService credentialStatusCheckService,
+                              Monitor monitor,
+                              TransactionContext transactionContext,
+                              Duration expiryGracePeriod,
+                              CredentialRequestManager credentialRequestManager) {
         this.credentialStore = credentialStore;
         this.credentialStatusCheckService = credentialStatusCheckService;
         this.monitor = monitor;

--- a/extensions/common/credential-watchdog/src/test/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdogTest.java
+++ b/extensions/common/credential-watchdog/src/test/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdogTest.java
@@ -14,21 +14,24 @@
 
 package org.eclipse.edc.identityhub.common.credentialwatchdog;
 
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.CredentialRequestManager;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.CredentialStatusCheckService;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -36,11 +39,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
 import static org.eclipse.edc.identityhub.common.credentialwatchdog.CredentialWatchdog.ALLOWED_STATES;
 import static org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus.ISSUED;
 import static org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus.REVOKED;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -51,13 +59,18 @@ import static org.mockito.Mockito.when;
 
 class CredentialWatchdogTest {
 
+    private static final long GRACE_PERIOD = 20;
     private final CredentialStore credentialStore = mock();
     private final CredentialStatusCheckService credentialStatusCheckService = mock();
-    private final CredentialWatchdog watchdog = new CredentialWatchdog(credentialStore, credentialStatusCheckService, mock(), new NoopTransactionContext());
+    private final CredentialRequestManager credentialRequestManager = mock();
+    private final Monitor monitor = mock();
+    private final CredentialWatchdog watchdog = new CredentialWatchdog(credentialStore, credentialStatusCheckService, monitor, new NoopTransactionContext(),
+            Duration.ofSeconds(GRACE_PERIOD), credentialRequestManager);
 
     @BeforeEach
     void setUp() {
         when(credentialStatusCheckService.checkStatus(any())).thenReturn(Result.success(VcStatus.ISSUED));
+        when(credentialRequestManager.initiateRequest(anyString(), anyString(), anyString(), anyMap())).thenReturn(ServiceResult.success());
     }
 
     @Test
@@ -103,7 +116,6 @@ class CredentialWatchdogTest {
         verifyNoMoreInteractions(credentialStatusCheckService);
     }
 
-
     @Test
     void run_whenCheckServiceFails_shouldTransitionError() {
         when(credentialStore.query(any()))
@@ -120,6 +132,57 @@ class CredentialWatchdogTest {
         verify(credentialStatusCheckService, times(2)).checkStatus(any());
     }
 
+    @Test
+    void run_whenCredentialIsExpiring_shouldInitiateRenewal() {
+        var cred = createCredentialBuilder()
+                .credential(new VerifiableCredentialContainer("raw-vc-content", VC1_0_JWT, createVerifiableCredential()
+                        .expirationDate(Instant.now().plusSeconds(GRACE_PERIOD / 2))
+                        .build()))
+                .build();
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(cred)));
+
+        watchdog.run();
+
+        // verify the store was queried with the proper filter expressions
+        verify(credentialStore).query(argThat(querySpec ->
+                querySpec.getFilterExpression().size() == 1 &&
+                        querySpec.getFilterExpression().get(0).toString().equals("state in " + ALLOWED_STATES)));
+
+        verify(credentialRequestManager)
+                .initiateRequest(eq(cred.getParticipantContextId()), eq(cred.getIssuerId()), anyString(), argThat(map ->
+                        map.size() == 2 &&
+                                map.get("VerifiableCredential").equals(VC1_0_JWT.toString()) &&
+                                map.get("DemoCredential").equals(VC1_0_JWT.toString())));
+    }
+
+
+    @Test
+    void run_whenCredentialIsExpiring_renewalFails() {
+        var cred = createCredentialBuilder()
+                .credential(new VerifiableCredentialContainer("raw-vc-content", VC1_0_JWT, createVerifiableCredential()
+                        .expirationDate(Instant.now().plusSeconds(GRACE_PERIOD / 2))
+                        .build()))
+                .build();
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(cred)));
+        when(credentialRequestManager.initiateRequest(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(ServiceResult.badRequest("foobarbaz"));
+
+        watchdog.run();
+
+        // verify the store was queried with the proper filter expressions
+        verify(credentialStore).query(argThat(querySpec ->
+                querySpec.getFilterExpression().size() == 1 &&
+                        querySpec.getFilterExpression().get(0).toString().equals("state in " + ALLOWED_STATES)));
+
+        verify(credentialRequestManager)
+                .initiateRequest(eq(cred.getParticipantContextId()), eq(cred.getIssuerId()), anyString(), argThat(map ->
+                        map.size() == 2 &&
+                                map.get("VerifiableCredential").equals(VC1_0_JWT.toString()) &&
+                                map.get("DemoCredential").equals(VC1_0_JWT.toString())));
+
+        verify(monitor).warning(contains("foobarbaz"));
+    }
+
     private VerifiableCredentialResource.Builder createCredentialBuilder() {
 
         return VerifiableCredentialResource.Builder.newInstance()
@@ -127,7 +190,7 @@ class CredentialWatchdogTest {
                 .holderId("test-holder")
                 .state(VcStatus.ISSUED)
                 .participantContextId("participant-id")
-                .credential(new VerifiableCredentialContainer("raw-vc-content", CredentialFormat.JSON_LD, createVerifiableCredential().build()))
+                .credential(new VerifiableCredentialContainer("raw-vc-content", VC1_0_JWT, createVerifiableCredential().build()))
                 .id(UUID.randomUUID().toString());
     }
 
@@ -135,7 +198,9 @@ class CredentialWatchdogTest {
         return VerifiableCredential.Builder.newInstance()
                 .credentialSubject(CredentialSubject.Builder.newInstance().id("test-subject").claim("test-key", "test-val").build())
                 .issuanceDate(Instant.now().minus(10, ChronoUnit.DAYS))
+                .expirationDate(Instant.now().plus(365, ChronoUnit.DAYS))
                 .type("VerifiableCredential")
+                .type("DemoCredential")
                 .issuer(new Issuer("test-issuer", Map.of()))
                 .id("did:web:test-credential");
     }


### PR DESCRIPTION
## What this PR changes/adds

this PR enhances the existing `CredentialWatchdog` to also check for credentials that are nearing expiry and kicks off a (re-)issuance request in that case.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

slight change to the credential check service: expired credentials can get revoked too, so we need to include them in the check.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #692

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
