### PR TITLE
fix: Support for custom URL for status list API

### DIFF
--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalStatusListCredentialPublisherExtension.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalStatusListCredentialPublisherExtension.java
@@ -33,6 +33,8 @@ import org.eclipse.edc.web.spi.configuration.PortMapping;
 import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 import org.jetbrains.annotations.NotNull;
 
+import static java.util.Optional.ofNullable;
+
 
 @Extension(value = LocalStatusListCredentialPublisherExtension.NAME)
 public class LocalStatusListCredentialPublisherExtension implements ServiceExtension {
@@ -59,6 +61,9 @@ public class LocalStatusListCredentialPublisherExtension implements ServiceExten
         return NAME;
     }
 
+    @Setting(description = "Configures endpoint for reaching the StatusList API in the form \"<hostname:protocol.port/protocol.path>\"", key = "edc.statuslist.callback.address", required = false)
+    private String callbackAddress;
+
     @Override
     public void initialize(ServiceExtensionContext context) {
         portMappingRegistry.register(new PortMapping(STATUS_LIST, config.port(), config.path()));
@@ -72,7 +77,7 @@ public class LocalStatusListCredentialPublisherExtension implements ServiceExten
     }
 
     private @NotNull String baseUrl() {
-        return "http://%s:%s%s".formatted(hostname.get(), config.port(), config.path());
+        return ofNullable(callbackAddress).orElse("http://%s:%s%s".formatted(hostname.get(), config.port(), config.path()));
     }
 
     @Settings


### PR DESCRIPTION
## What this PR changes/adds
Making sure StatusList API can be exposed to production URL.

## Why it does that
Sometimes API can be exposed behind an API gateway, for example https://apigateway.com/statusList. We are not mentioning any port, the load balancer will do redirection based on the URI path. 

## Linked Issue(s)

Closes #704 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
