### PR TITLE
fix: use mapper embedding date-time in LocalStatusListCredentialPublisherExtension

### DIFF
--- a/extensions/issuance/local-statuslist-publisher/build.gradle.kts
+++ b/extensions/issuance/local-statuslist-publisher/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.edc.spi.transaction)
     implementation(libs.jakarta.rsApi)
     implementation(libs.edc.spi.web)
+    implementation(libs.edc.lib.jsonld)
 
     testImplementation(libs.edc.junit)
     testImplementation(libs.restAssured)

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalStatusListCredentialPublisherExtension.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalStatusListCredentialPublisherExtension.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.edc.issuerservice.publisher;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.issuerservice.publisher.api.StatusListCredentialController;
 import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialPublisher;
@@ -24,9 +23,11 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.runtime.metamodel.annotation.Settings;
+import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.system.Hostname;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.web.spi.WebService;
 import org.eclipse.edc.web.spi.configuration.PortMapping;
@@ -34,41 +35,49 @@ import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import static java.util.Optional.ofNullable;
+import static org.eclipse.edc.spi.constants.CoreConstants.JSON_LD;
 
 
 @Extension(value = LocalStatusListCredentialPublisherExtension.NAME)
 public class LocalStatusListCredentialPublisherExtension implements ServiceExtension {
     public static final String NAME = "IssuerService Default Services Extension";
     private static final String STATUS_LIST = "statuslist";
+
     @Inject
     private CredentialStore store;
 
     @Inject
     private PortMappingRegistry portMappingRegistry;
+
     @Inject
     private Hostname hostname;
 
     @Inject
     private WebService webServer;
 
+    @Inject
+    private Monitor monitor;
+
+    @Inject
+    private TypeManager typeManager;
+
     @Configuration
     private StatusListCredentialEndpointConfig config;
     @Inject
     private TransactionContext transactionContext;
+    @Setting(description = "Configures endpoint for reaching the StatusList API.", key = "edc.statuslist.callback.address", required = false)
+    private String callbackAddress;
 
     @Override
     public String name() {
         return NAME;
     }
 
-    @Setting(description = "Configures endpoint for reaching the StatusList API.", key = "edc.statuslist.callback.address", required = false)
-    private String callbackAddress;
-
     @Override
     public void initialize(ServiceExtensionContext context) {
         portMappingRegistry.register(new PortMapping(STATUS_LIST, config.port(), config.path()));
 
-        webServer.registerResource(STATUS_LIST, new StatusListCredentialController(store, context.getMonitor(), new ObjectMapper()));
+        webServer.registerResource(STATUS_LIST, new StatusListCredentialController(store, monitor, () -> typeManager.getMapper(JSON_LD)));
     }
 
     @Provider(isDefault = true)

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialController.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialController.java
@@ -33,6 +33,7 @@ import org.eclipse.edc.web.spi.exception.InvalidRequestException;
 import org.eclipse.edc.web.spi.exception.ObjectConflictException;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -41,9 +42,9 @@ public class StatusListCredentialController {
     private static final List<String> SUPPORTED_TYPES = List.of(APPLICATION_JSON, "application/vc+jwt", MediaType.WILDCARD);
     private final CredentialStore store;
     private final Monitor monitor;
-    private final ObjectMapper mapper;
+    private final Supplier<ObjectMapper> mapper;
 
-    public StatusListCredentialController(CredentialStore store, Monitor monitor, ObjectMapper mapper) {
+    public StatusListCredentialController(CredentialStore store, Monitor monitor, Supplier<ObjectMapper> mapper) {
         this.store = store;
         this.monitor = monitor;
         this.mapper = mapper;
@@ -89,7 +90,7 @@ public class StatusListCredentialController {
         var contentType = "application/vc+jwt";
         if (acceptHeader.equals(APPLICATION_JSON)) {
             try {
-                body = mapper.writeValueAsString(selectedCredential.getVerifiableCredential().credential());
+                body = mapper.get().writeValueAsString(selectedCredential.getVerifiableCredential().credential());
                 contentType = APPLICATION_JSON;
             } catch (JsonProcessingException e) {
                 throw new EdcException(e);

--- a/extensions/issuance/local-statuslist-publisher/src/test/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialControllerTest.java
+++ b/extensions/issuance/local-statuslist-publisher/src/test/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialControllerTest.java
@@ -22,6 +22,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.junit.annotations.ApiTest;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.web.jersey.testfixtures.RestControllerTestBase;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+@ApiTest
 class StatusListCredentialControllerTest extends RestControllerTestBase {
 
 
@@ -149,7 +151,7 @@ class StatusListCredentialControllerTest extends RestControllerTestBase {
 
     @Override
     protected Object controller() {
-        return new StatusListCredentialController(store, monitor, objectMapper);
+        return new StatusListCredentialController(store, monitor, () -> objectMapper);
     }
 
     private RequestSpecification baseRequest() {


### PR DESCRIPTION
## What this PR changes/adds

Use mapper including date/time modules in `LocalStatusListCredentialPublisherExtension`.

## Why it does that

Fix error during mapping to VC.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

@bscholtes1A 


## Linked Issue(s)

Closes #710 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
