### PR TITLE
feat: add Credential Issuance tests

### DIFF
--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialOfferApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialOfferApiEndToEndTest.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.CREDENTIALS_NAMESPACE_W3C;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_BINDING_METHODS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_OFFER_REASON_TERM;
@@ -234,7 +235,7 @@ public class CredentialOfferApiEndToEndTest {
             var credentialsArray = Json.createArrayBuilder();
             Arrays.stream(credentials).forEach(credentialsArray::add);
             return Json.createObjectBuilder()
-                    .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                    .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
                     .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIALS_TERM), credentialsArray)
                     .build();
 

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/StorageApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/StorageApiEndToEndTest.java
@@ -62,6 +62,7 @@ import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAME
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIALS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.HOLDER_PID_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.ISSUER_PID_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.STATUS_TERM;
 import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.CREATED;
 import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState.REQUESTED;
 import static org.eclipse.edc.identityhub.tests.fixtures.TestData.IH_RUNTIME_ID;
@@ -339,6 +340,7 @@ public class StorageApiEndToEndTest {
                             .add(JsonLdKeywords.VALUE, credentialContainers.build()));
 
             return Json.createObjectBuilder()
+                    .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                     .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(ISSUER_PID_TERM), "test-request-id")
                     .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(HOLDER_PID_TERM), holderPid)
                     .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIALS_TERM), credentialsJsonArray)

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/TckTransformer.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/TckTransformer.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.test.e2e.tck.presentation;
+package org.eclipse.edc.test.e2e.tck;
 
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.spi.query.Criterion;
@@ -27,7 +27,7 @@ import static org.eclipse.edc.spi.result.Result.success;
  * A simple test stub that transforms a scope string that is used by the TCK (e.g. "org.eclipse.dspace.dcp.vc.type:CredentialType:read") into
  * a Criterion object. This is very similar to the {@code EdcScopeToCriterionTransformer} but uses a different alias literal.
  */
-class TckTransformer implements ScopeToCriterionTransformer {
+public class TckTransformer implements ScopeToCriterionTransformer {
     public static final String TYPE_OPERAND = "verifiableCredential.credential.type";
     public static final String ALIAS_LITERAL = "org.eclipse.dspace.dcp.vc.type";
     public static final String CONTAINS_OPERATOR = "contains";

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowTestWithDocker.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowTestWithDocker.java
@@ -12,7 +12,7 @@
  *
  */
 
-package org.eclipse.edc.test.e2e.tck.presentation;
+package org.eclipse.edc.test.e2e.tck.issuance;
 
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.util.Base64;
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 import java.util.Map;
@@ -50,18 +49,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.mockito.Mockito.mock;
 
-/**
- * Asserts the correct functionality of the presentation flow according to the Technology Compatibility Kit (TCK).
- * <p>
- * IdentityHub is started in an in-mem runtime, the TCK is started in another runtime, and executes its test cases against
- * IdentityHubs Presentation API.
- *
- * @see <a href="https://github.com/eclipse-dataspacetck/dcp-tck">Eclipse Dataspace TCK - DCP</a>
- */
 @EndToEndTest
-@Testcontainers
-public class DcpPresentationFlowTestWithDocker {
-    public static final String ISSUANCE_CORRELATION_ID = UUID.randomUUID().toString();
+public class DcpIssuanceFlowTestWithDocker {
+    private static final String ISSUANCE_CORRELATION_ID = "issuance-correlation-id";
     private static final String TEST_PARTICIPANT_CONTEXT_ID = "holder";
     private static final RevocationServiceRegistry REVOCATION_LIST_REGISTRY = mock();
     private static final int CALLBACK_PORT = 42420;
@@ -96,9 +86,9 @@ public class DcpPresentationFlowTestWithDocker {
                 .build());
     }
 
-    @DisplayName("Run TCK Presentation Flow tests (using docker)")
+    @DisplayName("Run TCK Issuance Flow tests (using docker)")
     @Test
-    void runPresentationFlowTestsDocker(IdentityHubRuntime runtime) throws InterruptedException {
+    void runIssuanceFlowTests(IdentityHubRuntime runtime) throws InterruptedException {
 
         var monitor = new ConsoleMonitor("TCK", ConsoleMonitor.Level.DEBUG, true);
         var credentialsPort = IDENTITY_HUB_EXTENSION.getCredentialsEndpoint().getUrl().getPort();
@@ -123,7 +113,7 @@ public class DcpPresentationFlowTestWithDocker {
                         "dataspacetck.sts.client.id", response.clientId(),
                         "dataspacetck.sts.client.secret", response.clientSecret(),
                         "dataspacetck.credentials.correlation.id", ISSUANCE_CORRELATION_ID,
-                        "dataspacetck.test.package", "org.eclipse.dataspacetck.dcp.verification.presentation"
+                        "dataspacetck.test.package", "org.eclipse.dataspacetck.dcp.verification.issuance.cs"
                 ))
         ) {
             tckContainer.setPortBindings(List.of("%s:%s".formatted(CALLBACK_PORT, CALLBACK_PORT)));

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowTest.java
@@ -33,11 +33,11 @@ import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubE
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubRuntime;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTransformer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.Map;
 import java.util.UUID;
@@ -55,9 +55,8 @@ import static org.mockito.Mockito.mock;
  * @see <a href="https://github.com/eclipse-dataspacetck/dcp-tck">Eclipse Dataspace TCK - DCP</a>
  */
 @EndToEndTest
-@Testcontainers
 public class DcpPresentationFlowTest {
-    public static final String ISSUANCE_CORRELATION_ID = UUID.randomUUID().toString();
+    public static final String ISSUANCE_CORRELATION_ID = "issuance-correlation-id";
     private static final String TEST_PARTICIPANT_CONTEXT_ID = "holder";
     private static final RevocationServiceRegistry REVOCATION_LIST_REGISTRY = mock();
     private static final int CALLBACK_PORT = 42420;
@@ -121,6 +120,9 @@ public class DcpPresentationFlowTest {
                 .build()
                 .execute();
 
+        monitor.enableBold().message("DCP Tests done: %s succeeded, %s failed".formatted(
+                result.getTestsSucceededCount(), result.getTotalFailureCount()
+        )).resetMode();
         if (!result.getFailures().isEmpty()) {
             var failures = result.getFailures().stream()
                     .map(f -> "- " + f.getTestIdentifier().getDisplayName() + " (" + f.getException() + ")")
@@ -128,7 +130,6 @@ public class DcpPresentationFlowTest {
             Assertions.fail(result.getTotalFailureCount() + " TCK test cases failed:\n" + failures);
         }
     }
-
 
     private CreateParticipantContextResponse createParticipant(IdentityHubRuntime runtime, String credentialServiceUrl) {
         var service = runtime.getService(ParticipantContextService.class);

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidator.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidator.java
@@ -20,6 +20,7 @@ import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.validator.spi.ValidationResult;
 
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.CREDENTIALS_NAMESPACE_W3C;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIALS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIAL_ISSUER_TERM;
 import static org.eclipse.edc.validator.spi.ValidationResult.failure;
@@ -42,7 +43,7 @@ public class CredentialOfferMessageValidator extends JsonValidator {
         if (input == null) {
             return failure(violation("CredentialOfferMessage was null", "."));
         }
-        var issuer = input.get(namespace.toIri(CREDENTIAL_ISSUER_TERM));
+        var issuer = input.get(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM));
         if (isNullObject(issuer)) {
             return failure(violation("Invalid format: must contain a '%s' property.".formatted(CREDENTIAL_ISSUER_TERM), null));
         }

--- a/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidatorTest.java
+++ b/protocols/dcp/dcp-identityhub/credential-offer-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialOfferMessageValidatorTest.java
@@ -16,18 +16,20 @@ package org.eclipse.edc.identityhub.api.validation;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.CREDENTIALS_NAMESPACE_W3C;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_BINDING_METHODS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_ISSUANCE_POLICY_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_OFFER_REASON_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_PROFILES_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIAL_ISSUER_TERM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
 class CredentialOfferMessageValidatorTest {
@@ -36,7 +38,7 @@ class CredentialOfferMessageValidatorTest {
     @Test
     void validate_noCredentials_success() {
         var msg = Json.createObjectBuilder()
-                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
                 .build();
 
         assertThat(validator.validate(msg)).isSucceeded();
@@ -55,8 +57,8 @@ class CredentialOfferMessageValidatorTest {
     @Test
     void validate_withCredentials_success() {
         var msg = Json.createObjectBuilder()
-                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), "test-issuer")
-                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIALS_TERM), Json.createArrayBuilder()
+                .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIALS_TERM), Json.createArrayBuilder()
                         .add(createCredentialObject())
                         .add(createCredentialObject()))
                 .build();
@@ -66,8 +68,8 @@ class CredentialOfferMessageValidatorTest {
     @Test
     void validate_withCredentials_withViolation() {
         var msg = Json.createObjectBuilder()
-                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM), "test-issuer")
-                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CredentialOfferMessage.CREDENTIALS_TERM), Json.createArrayBuilder()
+                .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIALS_TERM), Json.createArrayBuilder()
                         .add(Json.createObjectBuilder().add("invalid-key", "invalid-value").build()))
                 .build();
         assertThat(validator.validate(msg)).isFailed();

--- a/protocols/dcp/dcp-identityhub/dcp-identityhub-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpHolderCoreExtension.java
+++ b/protocols/dcp/dcp-identityhub/dcp-identityhub-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpHolderCoreExtension.java
@@ -16,9 +16,12 @@ package org.eclipse.edc.identityhub.protocols.dcp.issuer;
 
 import org.eclipse.edc.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpIssuerTokenVerifier;
+import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.rules.AudienceValidationRule;
@@ -27,6 +30,7 @@ import org.eclipse.edc.token.rules.NotBeforeValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationRule;
 import org.eclipse.edc.token.spi.TokenValidationService;
 import org.eclipse.edc.verifiablecredentials.jwt.rules.IssuerEqualsSubjectRule;
+import org.eclipse.edc.verifiablecredentials.jwt.rules.JtiValidationRule;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -35,6 +39,7 @@ import java.util.List;
 @Extension("DCP Holder Core Extension")
 public class DcpHolderCoreExtension implements ServiceExtension {
 
+    static final String ACCESSTOKEN_JTI_VALIDATION_ACTIVATE = "edc.iam.accesstoken.jti.validation";
     private List<TokenValidationRule> rules;
     @Inject
     private Clock clock;
@@ -42,15 +47,27 @@ public class DcpHolderCoreExtension implements ServiceExtension {
     private TokenValidationService tokenValidationService;
     @Inject
     private DidPublicKeyResolver didPublicKeyResolver;
+    @Setting(description = "Activates the JTI check: access tokens can only be used once to guard against replay attacks", defaultValue = "false", key = ACCESSTOKEN_JTI_VALIDATION_ACTIVATE)
+    private boolean activateJtiCheck;
+
+    @Inject(required = false)
+    private JtiValidationStore jtiValidationStore;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        rules = List.of(
+        rules = new ArrayList<>();
+        if (activateJtiCheck) {
+            if (jtiValidationStore == null) {
+                throw new EdcException("JTI validation is activated ('%s') but no JtiValidationStore is provided.".formatted(ACCESSTOKEN_JTI_VALIDATION_ACTIVATE));
+            }
+            rules.add(new JtiValidationRule(jtiValidationStore, context.getMonitor()));
+        }
+        rules.addAll(List.of(
                 new IssuerEqualsSubjectRule(),
                 new NotBeforeValidationRule(clock, 5, true),
                 new ExpirationIssuedAtValidationRule(clock, 5, false)
                 //todo: add rule to only allow trusted issuers
-        );
+        ));
     }
 
     @Provider

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/StorageApiExtension.java
@@ -25,7 +25,6 @@ import org.eclipse.edc.identityhub.protocols.dcp.transform.to.JsonObjectToCreden
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriter;
 import org.eclipse.edc.jsonld.spi.JsonLd;
-import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.spi.monitor.Monitor;
@@ -87,20 +86,20 @@ public class StorageApiExtension implements ServiceExtension {
         webService.registerResource(contextString, new ObjectMapperProvider(typeManager, JSON_LD));
         webService.registerResource(contextString, controller);
 
-        registerTransformers(DCP_SCOPE_V_1_0, DSPACE_DCP_NAMESPACE_V_1_0);
+        registerTransformers();
     }
 
-    void registerTransformers(String scope, JsonLdNamespace namespace) {
+    void registerTransformers() {
 
         var factory = Json.createBuilderFactory(Map.of());
-        var scopedTransformerRegistry = typeTransformer.forContext(scope);
+        var scopedTransformerRegistry = typeTransformer.forContext(DCP_SCOPE_V_1_0);
 
         // inbound
-        scopedTransformerRegistry.register(new JsonObjectToCredentialMessageTransformer(typeManager, JSON_LD, namespace));
+        scopedTransformerRegistry.register(new JsonObjectToCredentialMessageTransformer(typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
         scopedTransformerRegistry.register(new JsonValueToGenericTypeTransformer(typeManager, JSON_LD));
 
         //outbound
-        scopedTransformerRegistry.register(new JsonObjectFromCredentialMessageTransformer(factory, typeManager, JSON_LD, namespace));
+        scopedTransformerRegistry.register(new JsonObjectFromCredentialMessageTransformer(factory, typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
         scopedTransformerRegistry.register(new JsonObjectFromCredentialRequestMessageTransformer(factory, typeManager, JSON_LD, DSPACE_DCP_NAMESPACE_V_1_0));
 
         typeTransformer.register(new JwtToVerifiableCredentialTransformer(monitor));

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/storage/StorageApiController.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/storage/StorageApiController.java
@@ -84,13 +84,13 @@ public class StorageApiController implements StorageApi {
             throw new AuthenticationFailedException("Invalid authorization header, must start with 'Bearer'");
         }
         var authToken = authHeader.replace("Bearer ", "").trim();
-        credentialMessageJson = jsonLd.expand(credentialMessageJson).orElseThrow(InvalidRequestException::new);
-        validatorRegistry.validate(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_MESSAGE_TERM), credentialMessageJson).orElseThrow(ValidationFailureException::new);
+        var expanded = jsonLd.expand(credentialMessageJson).orElseThrow(InvalidRequestException::new);
+        validatorRegistry.validate(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIAL_MESSAGE_TERM), expanded).orElseThrow(ValidationFailureException::new);
         var protocolRegistry = transformerRegistry.forContext(DCP_SCOPE_V_1_0);
 
         participantContextId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);
 
-        var credentialMessage = protocolRegistry.forContext(DCP_SCOPE_V_1_0).transform(credentialMessageJson, CredentialMessage.class).orElseThrow(InvalidRequestException::new);
+        var credentialMessage = protocolRegistry.forContext(DCP_SCOPE_V_1_0).transform(expanded, CredentialMessage.class).orElseThrow(InvalidRequestException::new);
 
 
         var participantContext = participantContextService.getParticipantContext(participantContextId)

--- a/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialMessageValidator.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/main/java/org/eclipse/edc/identityhub/api/validation/CredentialMessageValidator.java
@@ -27,6 +27,7 @@ import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAME
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIALS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.HOLDER_PID_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.ISSUER_PID_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.STATUS_TERM;
 import static org.eclipse.edc.validator.spi.ValidationResult.failure;
 import static org.eclipse.edc.validator.spi.ValidationResult.success;
 import static org.eclipse.edc.validator.spi.Violation.violation;
@@ -53,6 +54,12 @@ public class CredentialMessageValidator implements Validator<JsonObject> {
         if (isNullObject(holderPid)) {
             return failure(violation("Must contain a 'holderPid' property.", null));
         }
+
+        var status = input.get(namespace.toIri(STATUS_TERM));
+        if (isNullObject(status)) {
+            return failure(violation("Must contain a 'status' property.", null));
+        }
+
         var credentialsObject = input.get(namespace.toIri(CREDENTIALS_TERM));
         if (isNullObject(credentialsObject)) {
             return failure(violation("Credentials array was null", null));
@@ -74,7 +81,9 @@ public class CredentialMessageValidator implements Validator<JsonObject> {
                 return false; // empty arrays are OK
             }
             value = jarray.get(0).asJsonObject().get(JsonLdKeywords.VALUE);
-            return ofNullable(value).map(jv -> jv.getValueType() == JsonValue.ValueType.NULL).orElse(false);
+            return ofNullable(value)
+                    .map(jv -> jv.getValueType() == JsonValue.ValueType.NULL)
+                    .orElse(false);
         }
         return value == null;
     }

--- a/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/storage/StorageApiControllerTest.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/storage/StorageApiControllerTest.java
@@ -232,12 +232,14 @@ class StorageApiControllerTest extends RestControllerTestBase {
         return CredentialMessage.Builder.newInstance()
                 .issuerPid(UUID.randomUUID().toString())
                 .holderPid(UUID.randomUUID().toString())
+                .status("ISSUED")
                 .credential(new CredentialContainer("SomeCredential", "vcdm11_jwt", "SOME_JWT_STRING"))
                 .build();
     }
 
     private JsonObject credentialMessageJson() {
         return Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("status"), "ISSUED")
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("requestId"), UUID.randomUUID().toString())
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("credentials"), Json.createArrayBuilder()
                         .add(Json.createObjectBuilder()

--- a/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialMessageValidatorTest.java
+++ b/protocols/dcp/dcp-identityhub/storage-api/src/test/java/org/eclipse/edc/identityhub/api/validation/CredentialMessageValidatorTest.java
@@ -26,6 +26,7 @@ import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAME
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIALS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.HOLDER_PID_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.ISSUER_PID_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.STATUS_TERM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -37,6 +38,7 @@ class CredentialMessageValidatorTest {
     @Test
     void validate_success() {
         var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(ISSUER_PID_TERM), UUID.randomUUID().toString())
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(HOLDER_PID_TERM), UUID.randomUUID().toString())
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIALS_TERM), Json.createArrayBuilder()
@@ -51,6 +53,7 @@ class CredentialMessageValidatorTest {
     @Test
     void validate_emptyCredentials_success() {
         var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(ISSUER_PID_TERM), UUID.randomUUID().toString())
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(HOLDER_PID_TERM), UUID.randomUUID().toString())
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIALS_TERM), Json.createArrayBuilder())
@@ -61,6 +64,7 @@ class CredentialMessageValidatorTest {
     @Test
     void validate_requestIdMissing_failure() {
         var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                 // missing: requestId
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(CREDENTIALS_TERM), Json.createArrayBuilder()
                         .add(Json.createObjectBuilder()
@@ -74,6 +78,7 @@ class CredentialMessageValidatorTest {
     @Test
     void validate_requestIdNull_failure() {
         var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("requestId"), JsonValue.NULL)
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("credentials"), Json.createArrayBuilder()
                         .add(Json.createObjectBuilder()
@@ -87,6 +92,7 @@ class CredentialMessageValidatorTest {
     @Test
     void validate_credentialsArrayNull_failure() {
         var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("requestId"), UUID.randomUUID().toString())
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("credentials"), JsonValue.NULL)
                 .build();
@@ -96,6 +102,7 @@ class CredentialMessageValidatorTest {
     @Test
     void validate_credentialsArrayMissing_failure() {
         var msg = Json.createObjectBuilder()
+                .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri(STATUS_TERM), "ISSUED")
                 .add(DSPACE_DCP_NAMESPACE_V_1_0.toIri("requestId"), UUID.randomUUID().toString())
                 // missing: credentials array
                 .build();

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpCredentialStorageClient.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpCredentialStorageClient.java
@@ -49,6 +49,7 @@ import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMess
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIAL_MESSAGE_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.HOLDER_PID_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.ISSUER_PID_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.STATUS_TERM;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.AUDIENCE;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.EXPIRATION_TIME;
 import static org.eclipse.edc.jwt.spi.JwtRegisteredClaimNames.ISSUED_AT;
@@ -138,6 +139,7 @@ public class DcpCredentialStorageClient implements CredentialStorageClient {
                 .add(ISSUER_PID_TERM, issuanceProcess.getId())
                 .add(HOLDER_PID_TERM, issuanceProcess.getHolderPid())
                 .add(CREDENTIALS_TERM, credentials.stream().map(this::toJson).collect(toJsonArray()))
+                .add(STATUS_TERM, "ISSUED")
                 .build();
     }
 

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/DcpConstants.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/DcpConstants.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.protocols.dcp.spi;
 
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
+
 public interface DcpConstants {
 
     String V_1_0 = "v1.0";
@@ -26,4 +28,5 @@ public interface DcpConstants {
     String DCP_SCOPE_V_1_0 = DCP_SCOPE_PREFIX + DCP_SCOPE_SEPARATOR + V_1_0;
     // URL where the DCP Specification resides. Could be used for externalDocs properties in Swagger
     String DCP_SPECIFICATION_URL = "https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol";
+    JsonLdNamespace CREDENTIALS_NAMESPACE_W3C = new JsonLdNamespace("https://www.w3.org/2018/credentials#");
 }

--- a/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialMessage.java
+++ b/protocols/dcp/dcp-spi/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/spi/model/CredentialMessage.java
@@ -16,17 +16,26 @@ package org.eclipse.edc.identityhub.protocols.dcp.spi.model;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Objects;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 public class CredentialMessage {
     public static final String CREDENTIALS_TERM = "credentials";
     public static final String ISSUER_PID_TERM = "issuerPid";
     public static final String HOLDER_PID_TERM = "holderPid";
+    public static final String STATUS_TERM = "status";
     public static final String CREDENTIAL_MESSAGE_TERM = "CredentialMessage";
+    private static final List<String> ALLOWED_STATUS = List.of("ISSUED", "REJECTED");
 
     private Collection<CredentialContainer> credentials = new ArrayList<>();
     private String issuerPid;
     private String holderPid;
+    private String status;
+
+    public String getStatus() {
+        return status;
+    }
 
     public Collection<CredentialContainer> getCredentials() {
         return credentials;
@@ -71,9 +80,19 @@ public class CredentialMessage {
             return this;
         }
 
+        public Builder status(String status) {
+            this.credentialMessage.status = status;
+            return this;
+        }
+
         public CredentialMessage build() {
-            Objects.requireNonNull(credentialMessage.issuerPid, "issuerPid");
-            Objects.requireNonNull(credentialMessage.holderPid, "holderPid");
+            requireNonNull(credentialMessage.issuerPid, "issuerPid");
+            requireNonNull(credentialMessage.holderPid, "holderPid");
+            requireNonNull(credentialMessage.status, "status");
+
+            if (!ALLOWED_STATUS.contains(credentialMessage.status.toUpperCase())) {
+                throw new IllegalArgumentException("Invalid status value! Expected %s but got %s".formatted(ALLOWED_STATUS, credentialMessage.status));
+            }
             return credentialMessage;
         }
     }

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialMessageTransformer.java
@@ -60,6 +60,9 @@ public class JsonObjectToCredentialMessageTransformer extends AbstractNamespaceA
         var holderPid = transformString(jsonObject.get(forNamespace(HOLDER_PID_TERM)), transformerContext);
         requestMessage.holderPid(holderPid);
 
+        var status = transformString(jsonObject.get(forNamespace(CredentialMessage.STATUS_TERM)), transformerContext);
+        requestMessage.status(status);
+
         if (credentials != null) {
             ofNullable(readCredentialContainers(credentials, transformerContext))
                     .map(requestMessage::credentials);

--- a/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformer.java
+++ b/protocols/dcp/dcp-transform-lib/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformer.java
@@ -23,7 +23,9 @@ import org.eclipse.edc.transform.spi.TransformerContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.CREDENTIALS_NAMESPACE_W3C;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIALS_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialOfferMessage.CREDENTIAL_ISSUER_TERM;
 
 public class JsonObjectToCredentialOfferMessageTransformer extends AbstractNamespaceAwareJsonLdTransformer<JsonObject, CredentialOfferMessage> {
     public JsonObjectToCredentialOfferMessageTransformer(JsonLdNamespace namespace) {
@@ -34,7 +36,7 @@ public class JsonObjectToCredentialOfferMessageTransformer extends AbstractNames
     public @Nullable CredentialOfferMessage transform(@NotNull JsonObject jsonObject, @NotNull TransformerContext transformerContext) {
         var builder = CredentialOfferMessage.Builder.newInstance();
 
-        builder.issuer(transformString(jsonObject.get(forNamespace(CredentialOfferMessage.CREDENTIAL_ISSUER_TERM)), transformerContext));
+        builder.issuer(transformString(jsonObject.get(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM)), transformerContext));
 
         var credentialsArray = jsonObject.getJsonArray(forNamespace(CREDENTIALS_TERM));
 

--- a/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialMessageTransformerTest.java
+++ b/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/from/JsonObjectFromCredentialMessageTransformerTest.java
@@ -64,6 +64,7 @@ public class JsonObjectFromCredentialMessageTransformerTest {
         var status = Builder.newInstance()
                 .issuerPid("issuerId")
                 .holderPid("holderId")
+                .status("ISSUED")
                 .credential(new CredentialContainer("MembershipCredential", "myFormat", "SOMEPAYLOAD"))
                 .build();
 
@@ -92,6 +93,7 @@ public class JsonObjectFromCredentialMessageTransformerTest {
         var status = Builder.newInstance()
                 .issuerPid("requestId")
                 .holderPid("holderId")
+                .status("ISSUED")
                 .build();
 
         var jsonLd = transformer.transform(status, context);

--- a/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialMessageTransformerTest.java
+++ b/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialMessageTransformerTest.java
@@ -28,6 +28,7 @@ import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAME
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.CREDENTIALS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.HOLDER_PID_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.ISSUER_PID_TERM;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialMessage.STATUS_TERM;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -65,6 +66,7 @@ public class JsonObjectToCredentialMessageTransformerTest {
         var input = Json.createObjectBuilder()
                 .add(toIri(ISSUER_PID_TERM), "test-request-id")
                 .add(toIri(HOLDER_PID_TERM), "test-holder-id")
+                .add(toIri(STATUS_TERM), "ISSUED")
                 .add(toIri(CREDENTIALS_TERM), credentialsJsonArray)
                 .build();
 
@@ -87,6 +89,7 @@ public class JsonObjectToCredentialMessageTransformerTest {
                 .add(toIri(ISSUER_PID_TERM), "test-request-id")
                 .add(toIri(HOLDER_PID_TERM), "test-holder-id")
                 .add(toIri(CREDENTIALS_TERM), credentialsJsonArray)
+                .add(toIri(STATUS_TERM), "ISSUED")
                 .build();
 
         var credentialRequestMessage = transformer.transform(input, context);
@@ -112,6 +115,7 @@ public class JsonObjectToCredentialMessageTransformerTest {
         var input = Json.createObjectBuilder()
                 .add(toIri(ISSUER_PID_TERM), "test-request-id")
                 .add(toIri(HOLDER_PID_TERM), "test-holder-id")
+                .add(toIri(STATUS_TERM), "ISSUED")
                 .add(toIri(CREDENTIALS_TERM), credentialsJsonArray)
                 .build();
 

--- a/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformerTest.java
+++ b/protocols/dcp/dcp-transform-lib/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/transform/to/JsonObjectToCredentialOfferMessageTransformerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+import static org.eclipse.edc.identityhub.protocols.dcp.spi.DcpConstants.CREDENTIALS_NAMESPACE_W3C;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_BINDING_METHODS_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM;
 import static org.eclipse.edc.identityhub.protocols.dcp.spi.model.CredentialObject.CREDENTIAL_OBJECT_OFFER_REASON_TERM;
@@ -58,7 +59,7 @@ class JsonObjectToCredentialOfferMessageTransformerTest {
                         .add(toIri(CREDENTIAL_OBJECT_BINDING_METHODS_TERM), Json.createArrayBuilder(List.of("binding")))
                         .build());
         var msg = Json.createObjectBuilder()
-                .add(toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
                 .add(toIri(CREDENTIALS_TERM), credentialsArray)
                 .build();
         var result = transformer.transform(msg, transformerContext);
@@ -69,10 +70,37 @@ class JsonObjectToCredentialOfferMessageTransformerTest {
     }
 
     @Test
+    void transform_noIssuer() {
+
+        var credentialsObj = CredentialObject.Builder.newInstance()
+                .credentialType("TestCredential")
+                .profile("test-profile")
+                .build();
+        when(transformerContext.transform(isA(JsonObject.class), eq(CredentialObject.class)))
+                .thenReturn(credentialsObj);
+
+        var credentialsArray = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add(toIri(CREDENTIAL_OBJECT_PROFILES_TERM), Json.createArrayBuilder(List.of("profile")))
+                        .add(toIri(CREDENTIAL_OBJECT_OFFER_REASON_TERM), "offerReason")
+                        .add(toIri(CREDENTIAL_OBJECT_CREDENTIAL_TYPE_TERM), "MembershipCredential")
+                        .add(toIri(CREDENTIAL_OBJECT_BINDING_METHODS_TERM), Json.createArrayBuilder(List.of("binding")))
+                        .build());
+        var msg = Json.createObjectBuilder()
+                // missing: .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(toIri(CREDENTIALS_TERM), credentialsArray)
+                .build();
+        var result = transformer.transform(msg, transformerContext);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getIssuer()).isNull();
+    }
+
+    @Test
     void transform_noCredentials() {
 
         var msg = Json.createObjectBuilder()
-                .add(toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
+                .add(CREDENTIALS_NAMESPACE_W3C.toIri(CREDENTIAL_ISSUER_TERM), "test-issuer")
                 .build();
         var result = transformer.transform(msg, transformerContext);
 


### PR DESCRIPTION
## What this PR changes/adds

adds an end-to-end test to assert compliance with the DCP Issuance protocol (including credential offers), targeting the CredentialService.

## Why it does that

DCP compliance


## Further notes

- issuance tests targeting the IssuerService will follow in a later iteration
- requires https://github.com/eclipse-dataspacetck/dcp-tck/pull/22

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
