### PR TITLE
fix: restrict TCK test package

### DIFF
--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowTest.java
@@ -116,7 +116,7 @@ public class DcpPresentationFlowTest {
                         "dataspacetck.sts.client.secret", response.clientSecret(),
                         "dataspacetck.credentials.correlation.id", ISSUANCE_CORRELATION_ID
                 ))
-                .addPackage("org.eclipse.dataspacetck.dcp.verification.presentation")
+                .addPackage("org.eclipse.dataspacetck.dcp.verification.presentation.cs")
                 .monitor(monitor)
                 .build()
                 .execute();

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
@@ -124,7 +124,7 @@ public class DcpPresentationFlowWithDockerTest {
                         "dataspacetck.sts.client.id", response.clientId(),
                         "dataspacetck.sts.client.secret", response.clientSecret(),
                         "dataspacetck.credentials.correlation.id", ISSUANCE_CORRELATION_ID,
-                        "dataspacetck.test.package", "org.eclipse.dataspacetck.dcp.verification.presentation"
+                        "dataspacetck.test.package", "org.eclipse.dataspacetck.dcp.verification.presentation.cs"
                 ))
         ) {
             tckContainer.setPortBindings(List.of("%s:%s".formatted(CALLBACK_PORT, CALLBACK_PORT)));

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/resources/issuer-api-version.json
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/resources/issuer-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-05-02T16:00:00Z",
+    "lastUpdated": "2025-05-26T16:00:00Z",
     "maturity": null
   }
 ]


### PR DESCRIPTION
## What this PR changes/adds

restrict the TCK Test package

## Why it does that

do not run verifier tests (they are run in the connector repo)

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
