### PR TITLE
fix: pass additional properties to revocation service

### DIFF
--- a/core/common-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/common-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -164,9 +164,9 @@ public class DefaultServicesExtension implements ServiceExtension {
 
     @Provider(isDefault = true)
     public RevocationServiceRegistry createRevocationListService(ServiceExtensionContext context) {
-        var acceptedContentTypes = List.of(contentTypes.split(","));
         if (revocationService == null) {
             revocationService = new RevocationServiceRegistryImpl(context.getMonitor());
+            var acceptedContentTypes = List.of(contentTypes.split(","));
             revocationService.addService(StatusList2021Status.TYPE, new StatusList2021RevocationService(typeManager.getMapper(), revocationCacheValidity, acceptedContentTypes, httpClient));
             revocationService.addService(BitstringStatusListStatus.TYPE, new BitstringStatusListRevocationService(typeManager.getMapper(), revocationCacheValidity, acceptedContentTypes, httpClient));
         }


### PR DESCRIPTION
## What this PR changes/adds

passes additional params to the revocation services, as needed after upstream change.

## Why it does that

upstream change

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
