### PR TITLE
feat: prohibit empty scope array

### DIFF
--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
@@ -196,7 +196,7 @@ public class PresentationApiEndToEndTest {
         }
 
         @Test
-        void query_withPresentationDefinition_shouldReturn503(IdentityHubRuntime runtime) {
+        void query_withPresentationDefinition_shouldReturn501(IdentityHubRuntime runtime) {
 
             var query = """
                     {
@@ -206,6 +206,9 @@ public class PresentationApiEndToEndTest {
                       ],
                       "@type": "PresentationQueryMessage",
                       "presentationDefinition":{
+                        "id": "presentation1",
+                            "input_descriptors": [
+                            ]
                       }
                     }
                     """;
@@ -215,7 +218,7 @@ public class PresentationApiEndToEndTest {
                     .body(query)
                     .post("/v1/participants/%s/presentations/query".formatted(TEST_PARTICIPANT_CONTEXT_ID_ENCODED))
                     .then()
-                    .statusCode(503)
+                    .statusCode(501)
                     .extract().body().asString();
         }
 

--- a/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/validation/PresentationQueryValidator.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/validation/PresentationQueryValidator.java
@@ -51,11 +51,11 @@ public class PresentationQueryValidator implements Validator<JsonObject> {
         var presentationDef = input.get(namespace.toIri(PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM));
 
         if (isNullObject(scope) && isNullObject(presentationDef)) {
-            return failure(violation("Must contain either a 'scope' or a 'presentationDefinition' property.", null));
+            return failure(violation("Must contain either a non-null, non-empty 'scopes' property or a non-empty 'presentationDefinition' property.", null));
         }
 
         if (!isNullObject(scope) && !isNullObject(presentationDef)) {
-            return failure(violation("Must contain either a 'scope' or a 'presentationDefinition', not both.", null));
+            return failure(violation("Must contain either a non-null, non-empty 'scopes' property or a non-empty 'presentationDefinition' property, not both.", null));
         }
 
         return success();
@@ -69,11 +69,17 @@ public class PresentationQueryValidator implements Validator<JsonObject> {
      * @return true if the JsonValue object is either null, or its value type is NULL, false otherwise
      */
     private boolean isNullObject(JsonValue value) {
-        if (value instanceof JsonArray) {
-            value = ((JsonArray) value).get(0).asJsonObject().get(JsonLdKeywords.VALUE);
+        if (value instanceof JsonArray jsonArray) {
+            if (jsonArray.isEmpty()) {
+                return true;
+            }
+            value = jsonArray.get(0).asJsonObject().get(JsonLdKeywords.VALUE);
 
-            return value.getValueType() == JsonValue.ValueType.NULL;
+            if (value.getValueType() == JsonValue.ValueType.NULL) {
+                return true;
+            }
+            return isNullObject(value);
         }
-        return value == null;
+        return value == null || (value instanceof JsonObject jsonObject && jsonObject.isEmpty());
     }
 }

--- a/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredential/PresentationApiController.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredential/PresentationApiController.java
@@ -172,7 +172,7 @@ public class PresentationApiController implements PresentationApi {
                 .message("Not implemented.")
                 .type("Not implemented.")
                 .build();
-        return Response.status(503)
+        return Response.status(501)
                 .entity(error)
                 .build();
     }

--- a/protocols/dcp/dcp-identityhub/presentation-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/test/java/org/eclipse/edc/identityservice/api/v1/PresentationApiControllerTest.java
@@ -138,7 +138,7 @@ class PresentationApiControllerTest extends RestControllerTestBase {
         when(typeTransformerRegistry.transform(isA(JsonObject.class), eq(PresentationQueryMessage.class))).thenReturn(Result.success(presentationQueryBuilder.build()));
 
         var response = controller().queryPresentation(PARTICIPANT_ID, createObjectBuilder().build(), generateAuthToken());
-        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(response.getStatus()).isEqualTo(501);
         assertThat(response.getEntity()).extracting(o -> (ApiErrorDetail) o).satisfies(ed -> {
             assertThat(ed.getMessage()).isEqualTo("Not implemented.");
             assertThat(ed.getType()).isEqualTo("Not implemented.");

--- a/protocols/dcp/dcp-identityhub/presentation-api/src/test/java/org/eclipse/edc/identityservice/api/validation/PresentationQueryValidatorTest.java
+++ b/protocols/dcp/dcp-identityhub/presentation-api/src/test/java/org/eclipse/edc/identityservice/api/validation/PresentationQueryValidatorTest.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage;
+import org.eclipse.edc.iam.identitytrust.spi.DcpConstants;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.presentationdefinition.Constraints;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.presentationdefinition.Field;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.presentationdefinition.InputDescriptor;
@@ -28,6 +28,7 @@ import org.eclipse.edc.identityhub.api.validation.PresentationQueryValidator;
 import org.eclipse.edc.jsonld.TitaniumJsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.spi.JsonLdKeywords;
+import org.eclipse.edc.jsonld.spi.JsonLdNamespace;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.junit.jupiter.api.Test;
 
@@ -36,23 +37,33 @@ import java.util.UUID;
 
 import static jakarta.json.Json.createArrayBuilder;
 import static jakarta.json.Json.createObjectBuilder;
-import static org.eclipse.edc.iam.identitytrust.spi.DcpConstants.DSPACE_DCP_NAMESPACE_V_0_8;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM;
+import static org.eclipse.edc.iam.identitytrust.spi.model.PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_SCOPE_TERM;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 class PresentationQueryValidatorTest {
     public static final ObjectMapper MAPPER = JacksonJsonLd.createObjectMapper();
-    private final PresentationQueryValidator validator = new PresentationQueryValidator(DSPACE_DCP_NAMESPACE_V_0_8);
     private final JsonLd jsonLd = new TitaniumJsonLd(mock());
-
+    private final JsonLdNamespace namespace = DcpConstants.DSPACE_DCP_NAMESPACE_V_1_0;
+    private final PresentationQueryValidator validator = new PresentationQueryValidator(namespace);
 
     @Test
     void validate_withScope_success() {
         var jo = createObjectBuilder()
-                .add(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_SCOPE_PROPERTY, createScopeArray())
+                .add(namespace.toIri(PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM), createScopeArray())
                 .build();
 
         assertThat(validator.validate(jo)).isSucceeded();
+    }
+
+    @Test
+    void validate_withEmptyScopeArray_fails() {
+        var jo = createObjectBuilder()
+                .add(namespace.toIri(PRESENTATION_QUERY_MESSAGE_SCOPE_TERM), createArrayBuilder().build())
+                .build();
+
+        assertThat(validator.validate(jo)).isFailed().detail().contains("Must contain either a non-null, non-empty 'scopes' property or a non-empty 'presentationDefinition' property.");
     }
 
     @Test
@@ -62,17 +73,16 @@ class PresentationQueryValidatorTest {
                 .inputDescriptors(List.of(InputDescriptor.Builder.newInstance().id(UUID.randomUUID().toString()).constraints(new Constraints(List.of(Field.Builder.newInstance().build()))).build()))
                 .build();
         var jo = createObjectBuilder()
-                .add(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_DEFINITION_PROPERTY, createPresentationDefArray(presDef))
+                .add(namespace.toIri(PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM), createPresentationDefArray(presDef))
                 .build();
 
         assertThat(validator.validate(jo)).isSucceeded();
     }
 
-
     @Test
     void validate_withNone_fails() {
         var jo = createObjectBuilder().build();
-        assertThat(validator.validate(jo)).isFailed().detail().contains("Must contain either a 'scope' or a 'presentationDefinition' property.");
+        assertThat(validator.validate(jo)).isFailed().detail().contains("Must contain either a non-null, non-empty 'scopes' property or a non-empty 'presentationDefinition' property.");
     }
 
     @Test
@@ -82,11 +92,11 @@ class PresentationQueryValidatorTest {
                 .inputDescriptors(List.of(InputDescriptor.Builder.newInstance().id(UUID.randomUUID().toString()).constraints(new Constraints(List.of(Field.Builder.newInstance().build()))).build()))
                 .build();
         var jo = createObjectBuilder()
-                .add(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_SCOPE_PROPERTY, createScopeArray())
-                .add(PresentationQueryMessage.PRESENTATION_QUERY_MESSAGE_DEFINITION_PROPERTY, createPresentationDefArray(presDef))
+                .add(namespace.toIri(PRESENTATION_QUERY_MESSAGE_SCOPE_TERM), createScopeArray())
+                .add(namespace.toIri(PRESENTATION_QUERY_MESSAGE_DEFINITION_TERM), createPresentationDefArray(presDef))
                 .build();
 
-        assertThat(validator.validate(jo)).isFailed().detail().contains("Must contain either a 'scope' or a 'presentationDefinition', not both.");
+        assertThat(validator.validate(jo)).isFailed().detail().contains("Must contain either a non-null, non-empty 'scopes' property or a non-empty 'presentationDefinition' property, not both.");
     }
 
     private JsonArray createScopeArray() {


### PR DESCRIPTION
## What this PR changes/adds

prohibits empty `scope` array values in the `PresentationQueryMessage`

## Why it does that

recent change in DCP and the TCK

## Further notes

- a HTTP 501 is returned when clients send a `presentationDefinition` instead of HTTP 503

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
