### PR TITLE
fix: use longer credential expiry in test

### DIFF
--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
@@ -221,7 +221,7 @@ public class DcpIssuanceFlowEndToEndTest {
                     .jsonSchemaUrl("https://example.com/schema")
                     .jsonSchema("{}")
                     .attestation(attestationDefinition.getId())
-                    .validity(3600)
+                    .validity(Duration.ofDays(365).toSeconds()) // one year
                     .mapping(mappingDefinition)
                     .rule(new CredentialRuleDefinition("expression", ruleConfiguration))
                     .participantContextId("participantContextId")


### PR DESCRIPTION
## What this PR changes/adds

use a credential validity of 1 year for test credentials

## Why it does that

using a credential validity of 1 hour could cause the credential watchdog to consider the credential as "expiring soon", because its grace period is 1 week by default.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
