### PR TITLE
feat: separate out TCK tests

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -128,6 +128,15 @@ jobs:
       - name: Postgresql Tests
         run: ./gradlew compileJava compileTestJava test -DincludeTags="PostgresqlIntegrationTest"
 
+  TCK-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+      - name: TCK Tests
+        run: ./gradlew compileJava compileTestJava test -DincludeTags="TckTest" -PverboseTest=true
+
   Verify-OpenApi:
     if: github.event_name == 'pull_request'
     uses: eclipse-edc/.github/.github/workflows/verify-openapi.yml@main

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/TckTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/TckTest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025 Metaform Systems Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.test.e2e.tck;
+
+import org.eclipse.edc.junit.annotations.IntegrationTest;
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@IntegrationTest
+@Tag("TckTest")
+public @interface TckTest {
+}

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowTest.java
@@ -31,8 +31,8 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManif
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubExtension;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubRuntime;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.eclipse.edc.test.e2e.tck.TckTransformer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,7 +47,7 @@ import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.Ver
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.Mockito.mock;
 
-@EndToEndTest
+@TckTest
 public class DcpIssuanceFlowTest {
     private static final String ISSUANCE_CORRELATION_ID = "issuance-correlation-id";
     private static final String TEST_PARTICIPANT_CONTEXT_ID = "holder";

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowWithDockerTest.java
@@ -28,15 +28,16 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManif
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubExtension;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubRuntime;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.eclipse.edc.test.e2e.tck.TckTransformer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,8 @@ import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.Ver
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 import static org.mockito.Mockito.mock;
 
-@EndToEndTest
+@TckTest
+@Testcontainers
 public class DcpIssuanceFlowWithDockerTest {
     private static final String ISSUANCE_CORRELATION_ID = "issuance-correlation-id";
     private static final String TEST_PARTICIPANT_CONTEXT_ID = "holder";
@@ -104,7 +106,7 @@ public class DcpIssuanceFlowWithDockerTest {
 
         var response = createParticipant(runtime, baseCredentialServiceUrl);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:latest")
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC3")
                 .withExtraHost("host.docker.internal", "host-gateway")
                 .withExposedPorts(CALLBACK_PORT)
                 .withEnv(Map.of(

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowTest.java
@@ -34,8 +34,8 @@ import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.Credentia
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ import java.util.stream.Stream;
 import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
-@EndToEndTest
+@TckTest
 public class DcpIssuerIssuanceFlowTest {
     @RegisterExtension
     public static final IssuerExtension ISSUER_EXTENSION = IssuerExtension.Builder.newInstance()

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowWithDockerTest.java
@@ -31,14 +31,15 @@ import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.Credentia
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.identityhub.verifiablecredentials.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.edc.util.io.Ports.getFreePort;
 
-@EndToEndTest
+@TckTest
+@Testcontainers
 public class DcpIssuerIssuanceFlowWithDockerTest {
     @RegisterExtension
     public static final IssuerExtension ISSUER_EXTENSION = IssuerExtension.Builder.newInstance()
@@ -94,7 +96,7 @@ public class DcpIssuerIssuanceFlowWithDockerTest {
         var response = createParticipantContext(runtime, baseIssuerServiceUrl);
         createDefinitions(runtime);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:latest")
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC3")
                 .withExtraHost("host.docker.internal", "host-gateway")
                 .withExposedPorts(CALLBACK_PORT)
                 .withEnv(Map.of(

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowTest.java
@@ -31,8 +31,8 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManif
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubExtension;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubRuntime;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.eclipse.edc.test.e2e.tck.TckTransformer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.mock;
  *
  * @see <a href="https://github.com/eclipse-dataspacetck/dcp-tck">Eclipse Dataspace TCK - DCP</a>
  */
-@EndToEndTest
+@TckTest
 public class DcpPresentationFlowTest {
     public static final String ISSUANCE_CORRELATION_ID = "issuance-correlation-id";
     private static final String TEST_PARTICIPANT_CONTEXT_ID = "holder";

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
@@ -28,9 +28,9 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManif
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubExtension;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHubRuntime;
-import org.eclipse.edc.junit.annotations.EndToEndTest;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.eclipse.edc.test.e2e.tck.TckTransformer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.mock;
  *
  * @see <a href="https://github.com/eclipse-dataspacetck/dcp-tck">Eclipse Dataspace TCK - DCP</a>
  */
-@EndToEndTest
+@TckTest
 @Testcontainers
 public class DcpPresentationFlowWithDockerTest {
     public static final String ISSUANCE_CORRELATION_ID = UUID.randomUUID().toString();
@@ -114,7 +114,7 @@ public class DcpPresentationFlowWithDockerTest {
 
         var response = createParticipant(runtime, baseCredentialServiceUrl);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:latest")
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC3")
                 .withExtraHost("host.docker.internal", "host-gateway")
                 .withExposedPorts(CALLBACK_PORT)
                 .withEnv(Map.of(


### PR DESCRIPTION
## What this PR changes/adds

separates out the TCK tests and adds verbose logging. Also pins the version of the TCK to `1.0.0-RC3`, which is the latest release version at the time of writing.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
