### PR TITLE
docs(README): correct image name in Docker run example (#792)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker run -d --rm --name identityhub \
             -e "WEB_HTTP_PRESENTATION_PATH=/api/presentation" \
             -e "EDC_IAM_STS_PRIVATEKEY_ALIAS=privatekey-alias" \
             -e "EDC_IAM_STS_PUBLICKEY_ID=publickey-id" \
-            identityhub:latest
+            identity-hub:latest
 ```
 
 ## Architectural concepts of IdentityHub


### PR DESCRIPTION
## What this PR changes/adds
Replaces the incorrect image name `identityhub:latest` with the correct `identity-hub:latest` in all documentation and sample files.

## Why it does that
The current example fails because the image `identityhub:latest` does not exist, blocking users from starting the Identity Hub.

## Linked Issue(s)
Closes #792 