### PR TITLE
docs(identityhub): fix incorrect Docker image name in run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker run -d --rm --name identityhub \
             -e "WEB_HTTP_PRESENTATION_PATH=/api/presentation" \
             -e "EDC_IAM_STS_PRIVATEKEY_ALIAS=privatekey-alias" \
             -e "EDC_IAM_STS_PUBLICKEY_ID=publickey-id" \
-            identityhub:latest
+            identity-hub:latest
 ```
 
 ## Architectural concepts of IdentityHub


### PR DESCRIPTION
## What this PR changes/adds
Updates the Docker run example in README.md to use the correct image name `identity-hub:latest` instead of the non-existent `identityhub:latest`.

## Why it does that
The current command fails with "repository not found" because the image `identityhub:latest` does not exist, blocking users from starting the Identity Hub container.

## Further notes
Only documentation changed; no source code or tests affected.


## Linked Issue(s)
Closes #792