### PR TITLE
feat: add authn/z on participant context api on issuer

### DIFF
--- a/dist/bom/issuerservice-base-bom/build.gradle.kts
+++ b/dist/bom/issuerservice-base-bom/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     runtimeOnly(project(":protocols:dcp:dcp-issuer:dcp-issuer-core"))
     runtimeOnly(project(":protocols:dcp:dcp-issuer:dcp-issuer-api"))
     runtimeOnly(project(":extensions:api:identity-api:participant-context-api"))
+    runtimeOnly(project(":extensions:api:identityhub-api-authentication"))
+    runtimeOnly(project(":extensions:api:identityhub-api-authorization"))
 
     runtimeOnly(project(":extensions:issuance:issuerservice-presentation-attestations"))
     runtimeOnly(project(":extensions:issuance:issuerservice-issuance-rules"))


### PR DESCRIPTION
## What this PR changes/adds

I discovered that the issuer base bom defines the `participant-context-api` but not the authentication, making it not authenticated by default.

Added the necessary modules

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
