### PR TITLE
feat: add ownership check on authorization service

### DIFF
--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/DidManagementApiEndToEndTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
@@ -104,7 +105,7 @@ public class DidManagementApiEndToEndTest {
                                "did": "did:web:user1"
                             }
                             """)
-                    .post("/v1alpha/participants/%s/dids/publish".formatted(user1))
+                    .post("/v1alpha/participants/%s/dids/publish".formatted(toBase64(user1)))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403)
@@ -133,7 +134,7 @@ public class DidManagementApiEndToEndTest {
                                            "did": "did:web:test-user"
                                         }
                                         """)
-                                .post("/v1alpha/participants/%s/dids/publish".formatted(user))
+                                .post("/v1alpha/participants/%s/dids/publish".formatted(toBase64(user)))
                                 .then()
                                 .log().ifValidationFails()
                                 .statusCode(204)
@@ -172,7 +173,7 @@ public class DidManagementApiEndToEndTest {
                                            "did": "did:web:test-user"
                                         }
                                         """)
-                                .post("/v1alpha/participants/%s/dids/publish".formatted(user))
+                                .post("/v1alpha/participants/%s/dids/publish".formatted(toBase64(user)))
                                 .then()
                                 .log().ifValidationFails()
                                 .statusCode(400)
@@ -212,7 +213,7 @@ public class DidManagementApiEndToEndTest {
                                "did": "did:web:user1"
                             }
                             """)
-                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(user1))
+                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(toBase64(user1)))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403)
@@ -241,7 +242,7 @@ public class DidManagementApiEndToEndTest {
                                "did": "did:web:test-user"
                             }
                             """)
-                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(user))
+                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(toBase64(user)))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(204)
@@ -271,7 +272,7 @@ public class DidManagementApiEndToEndTest {
                                "did": "did:web:test-user"
                             }
                             """)
-                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(user))
+                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(toBase64(user)))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(204)
@@ -298,7 +299,7 @@ public class DidManagementApiEndToEndTest {
                                "did": "did:web:test-user"
                             }
                             """)
-                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(user))
+                    .post("/v1alpha/participants/%s/dids/unpublish".formatted(toBase64(user)))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(400)
@@ -324,7 +325,7 @@ public class DidManagementApiEndToEndTest {
                                "did": "did:web:user1"
                             }
                             """)
-                    .post("/v1alpha/participants/%s/dids/state".formatted(user1))
+                    .post("/v1alpha/participants/%s/dids/state".formatted(toBase64(user1)))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
@@ -393,6 +394,10 @@ public class DidManagementApiEndToEndTest {
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
+        }
+
+        private String toBase64(String s) {
+            return Base64.getUrlEncoder().encodeToString(s.getBytes());
         }
 
     }

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/KeyPairResourceApiEndToEndTest.java
@@ -478,7 +478,7 @@ public class KeyPairResourceApiEndToEndTest {
                     .contentType(JSON)
                     .header(new Header("x-api-key", token2))
                     .body(keyDesc)
-                    .post("/v1alpha/participants/%s/keypairs/%s/rotate".formatted(user1, keyId))
+                    .post("/v1alpha/participants/%s/keypairs/%s/rotate".formatted(toBase64(user1), keyId))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403)

--- a/extensions/api/identity-api/did-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
+++ b/extensions/api/identity-api/did-api/src/main/java/org/eclipse/edc/identityhub/api/didmanagement/DidManagementApiExtension.java
@@ -47,11 +47,19 @@ public class DidManagementApiExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        authorizationService.addLookupFunction(DidResource.class, s -> didDocumentService.findById(s));
+        authorizationService.addLookupFunction(DidResource.class, this::findById);
         var controller = new DidManagementApiController(didDocumentService, authorizationService);
         var getAllController = new GetAllDidsApiController(didDocumentService);
         webService.registerResource(IdentityHubApiContext.IDENTITY, controller);
         webService.registerResource(IdentityHubApiContext.IDENTITY, getAllController);
+    }
+
+    private DidResource findById(String owner, String id) {
+        var resource = didDocumentService.findById(id);
+        if (resource.getParticipantContextId().equals(owner)) {
+            return resource;
+        }
+        return null;
     }
 
 }

--- a/extensions/api/identity-api/did-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/unstable/DidManagementApiControllerTest.java
+++ b/extensions/api/identity-api/did-api/src/test/java/org/eclipse/edc/identityhub/api/didmanagement/v1/unstable/DidManagementApiControllerTest.java
@@ -55,7 +55,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Override
@@ -87,14 +87,14 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
         @Test
         void removeEndpoint_unauthorized403() {
-            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
             baseRequest()
                     .body(new DidRequestPayload(TEST_DID))
                     .delete("/%s/endpoints?serviceId=test-service-id".formatted(Base64.getUrlEncoder().encodeToString(TEST_DID.getBytes())))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
-            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(authService).isAuthorized(any(), anyString(), anyString(), eq(DidResource.class));
             verifyNoMoreInteractions(didDocumentServiceMock, authService);
         }
 
@@ -172,14 +172,14 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
         @Test
         void replaceEndpoint_unauthorized403() {
-            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
             baseRequest()
                     .body(new DidRequestPayload(TEST_DID))
                     .patch("/%s/endpoints".formatted(Base64.getUrlEncoder().encodeToString(TEST_DID.getBytes())))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
-            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(authService).isAuthorized(any(), anyString(), anyString(), eq(DidResource.class));
             verifyNoMoreInteractions(didDocumentServiceMock, authService);
         }
 
@@ -257,14 +257,14 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
         @Test
         void addEndpoint_unauthorized403() {
-            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
             baseRequest()
                     .body(new DidRequestPayload(TEST_DID))
                     .post("/%s/endpoints".formatted(Base64.getUrlEncoder().encodeToString(TEST_DID.getBytes())))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
-            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(authService).isAuthorized(any(), anyString(), anyString(), eq(DidResource.class));
             verifyNoMoreInteractions(didDocumentServiceMock, authService);
         }
 
@@ -363,7 +363,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
         void query_unauthorized403() {
             var resultList = List.of(createDidDocument().build());
             when(didDocumentServiceMock.queryDocuments(any())).thenReturn(ServiceResult.success(resultList));
-            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test-message"));
+            when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test-message"));
             var q = QuerySpec.Builder.newInstance().build();
 
             var result = baseRequest()
@@ -376,7 +376,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
             assertThat(result).isEmpty();
 
-            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(authService).isAuthorized(any(), anyString(), anyString(), eq(DidResource.class));
             verify(didDocumentServiceMock).queryDocuments(eq(q));
             verifyNoMoreInteractions(didDocumentServiceMock, authService);
         }
@@ -401,7 +401,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
         @Test
         void unpublish_unauthorized403() {
-            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
+            when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test message"));
 
             baseRequest()
                     .body(new DidRequestPayload(TEST_DID))
@@ -410,7 +410,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
                     .log().ifValidationFails()
                     .statusCode(403);
 
-            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(authService).isAuthorized(any(), anyString(), anyString(), eq(DidResource.class));
             verifyNoMoreInteractions(didDocumentServiceMock, authService);
         }
 
@@ -471,7 +471,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
 
         @Test
         void publish_unauthorized403() {
-            when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test-msg"));
+            when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.unauthorized("test-msg"));
 
             baseRequest()
                     .body(new DidRequestPayload(TEST_DID))
@@ -479,7 +479,7 @@ class DidManagementApiControllerTest extends RestControllerTestBase {
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
-            verify(authService).isAuthorized(any(), anyString(), eq(DidResource.class));
+            verify(authService).isAuthorized(any(), anyString(), anyString(), eq(DidResource.class));
             verifyNoMoreInteractions(didDocumentServiceMock, authService);
         }
 

--- a/extensions/api/identity-api/identity-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/IdentityApiConfigurationExtension.java
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/IdentityApiConfigurationExtension.java
@@ -36,7 +36,7 @@ import org.eclipse.edc.web.spi.configuration.PortMapping;
 import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.identityhub.api.configuration.IdentityApiConfigurationExtension.NAME;
@@ -102,14 +102,15 @@ public class IdentityApiConfigurationExtension implements ServiceExtension {
     private static class AllowAllAuthorizationService implements AuthorizationService {
 
         @Override
-        public ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceId, Class<? extends ParticipantResource> resourceClass) {
+        public ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceOwnerId, String resourceId, Class<? extends ParticipantResource> resourceClass) {
             return ServiceResult.success();
         }
 
         @Override
-        public void addLookupFunction(Class<?> resourceClass, Function<String, ParticipantResource> checkFunction) {
+        public void addLookupFunction(Class<?> resourceClass, BiFunction<String, String, ParticipantResource> checkFunction) {
 
         }
+
 
     }
 }

--- a/extensions/api/identity-api/keypair-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/KeyPairResourceManagementApiExtension.java
+++ b/extensions/api/identity-api/keypair-api/src/main/java/org/eclipse/edc/identityhub/api/keypair/KeyPairResourceManagementApiExtension.java
@@ -20,12 +20,12 @@ import org.eclipse.edc.identityhub.api.keypair.validation.KeyDescriptorValidator
 import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
-import org.eclipse.edc.identityhub.spi.participantcontext.model.AbstractParticipantResource;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
@@ -60,12 +60,13 @@ public class KeyPairResourceManagementApiExtension implements ServiceExtension {
         webService.registerResource(IdentityHubApiContext.IDENTITY, getAllApi);
     }
 
-    private AbstractParticipantResource findById(String keyPairId) {
-        var q = KeyPairResource.queryById(keyPairId).build();
-        return keyPairService.query(q)
-                .orElseThrow(f -> new EdcException(f.getFailureDetail()))
-                .stream()
-                .findFirst()
+    private ParticipantResource findById(String owner, String id) {
+        var query = KeyPairResource.queryById(id)
+                .filter(new Criterion("participantContextId", "=", owner))
+                .build();
+        return keyPairService.query(query)
+                .map(list -> list.stream().findFirst().orElse(null))
                 .orElse(null);
     }
+
 }

--- a/extensions/api/identity-api/keypair-api/src/test/java/org/eclipse/edc/identityhub/api/keypair/v1/unstable/KeyPairResourceApiControllerTest.java
+++ b/extensions/api/identity-api/keypair-api/src/test/java/org/eclipse/edc/identityhub/api/keypair/v1/unstable/KeyPairResourceApiControllerTest.java
@@ -71,7 +71,7 @@ class KeyPairResourceApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Test

--- a/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredential/ParticipantContextManagementApiExtension.java
+++ b/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredential/ParticipantContextManagementApiExtension.java
@@ -19,6 +19,7 @@ import org.eclipse.edc.identityhub.api.verifiablecredential.validation.Participa
 import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -50,8 +51,12 @@ public class ParticipantContextManagementApiExtension implements ServiceExtensio
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        authorizationService.addLookupFunction(ParticipantContext.class, s -> participantContextService.getParticipantContext(s).orElseThrow(exceptionMapper(ParticipantContext.class, s)));
+        authorizationService.addLookupFunction(ParticipantContext.class, this::findByOwnerAndId);
         var controller = new ParticipantContextApiController(new ParticipantManifestValidator(monitor), participantContextService, authorizationService);
         webService.registerResource(IdentityHubApiContext.IDENTITY, controller);
+    }
+
+    private ParticipantResource findByOwnerAndId(String owner, String participantContextId) {
+        return participantContextService.getParticipantContext(participantContextId).orElseThrow(exceptionMapper(ParticipantContext.class, participantContextId));
     }
 }

--- a/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/ParticipantContextApiController.java
+++ b/extensions/api/identity-api/participant-context-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/ParticipantContextApiController.java
@@ -75,7 +75,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Path("/{participantContextId}")
     public ParticipantContext getParticipant(@PathParam("participantContextId") String participantContextId, @Context SecurityContext securityContext) {
         return onEncoded(participantContextId)
-                .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, ParticipantContext.class)
+                .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, decoded, ParticipantContext.class)
                         .compose(u -> participantContextService.getParticipantContext(decoded))
                         .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
                 .orElseThrow(InvalidRequestException::new);
@@ -86,7 +86,7 @@ public class ParticipantContextApiController implements ParticipantContextApi {
     @Path("/{participantContextId}/token")
     public String regenerateParticipantToken(@PathParam("participantContextId") String participantContextId, @Context SecurityContext securityContext) {
         return onEncoded(participantContextId)
-                .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, ParticipantContext.class)
+                .map(decoded -> authorizationService.isAuthorized(securityContext, decoded, decoded, ParticipantContext.class)
                         .compose(u -> participantContextService.regenerateApiToken(decoded))
                         .orElseThrow(exceptionMapper(ParticipantContext.class, decoded)))
                 .orElseThrow(InvalidRequestException::new);

--- a/extensions/api/identity-api/participant-context-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/ParticipantContextApiControllerTest.java
+++ b/extensions/api/identity-api/participant-context-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/ParticipantContextApiControllerTest.java
@@ -69,7 +69,7 @@ class ParticipantContextApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Test

--- a/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiControllerTest.java
@@ -83,7 +83,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Override
@@ -133,7 +133,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
             var manifest = createManifest(credential);
             var resource = mock(VerifiableCredentialResource.class);
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(VerifiableCredentialResource.class))).thenReturn(Result.success(resource));
             when(credentialStore.create(resource)).thenReturn(StoreResult.success());
 
@@ -162,7 +162,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         @Test
         void notAuthorized_returns403() {
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(unauthorized("test-message"));
+            when(authorizationService.isAuthorized(any(), anyString(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(unauthorized("test-message"));
 
             baseRequest()
                     .contentType(JSON)
@@ -176,7 +176,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         @Test
         void transformFails_returns400() {
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(VerifiableCredentialResource.class))).thenReturn(failure("transform-failure"));
 
             baseRequest()
@@ -191,7 +191,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         @Test
         void vcAlreadyExists_returns() {
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(PARTICIPANT_ID), eq(ParticipantContext.class))).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(VerifiableCredentialResource.class))).thenReturn(Result.success(mock(VerifiableCredentialResource.class)));
             when(credentialStore.create(any())).thenReturn(alreadyExists("already-exists"));
 
@@ -213,7 +213,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
             var manifest = createManifest(credential);
             var resource = mock(VerifiableCredentialResource.class);
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(manifest.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(manifest.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(VerifiableCredentialResource.class))).thenReturn(Result.success(resource));
             when(credentialStore.update(resource)).thenReturn(StoreResult.success());
 
@@ -242,7 +242,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         @Test
         void notAuthorized_returns403() {
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), any(), eq(VerifiableCredentialResource.class))).thenReturn(unauthorized("test-message"));
+            when(authorizationService.isAuthorized(any(), anyString(), any(), eq(VerifiableCredentialResource.class))).thenReturn(unauthorized("test-message"));
 
             baseRequest()
                     .contentType(JSON)
@@ -257,7 +257,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         void transformFails_returns400() {
             var manifest = createManifest(createCredential("type"));
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(manifest.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(manifest.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(VerifiableCredentialResource.class))).thenReturn(failure("transform-failure"));
 
             baseRequest()
@@ -273,7 +273,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
         void vcAlreadyExists_returns() {
             var manifest = createManifest(createCredential("type"));
             when(validator.validate(any())).thenReturn(ValidationResult.success());
-            when(authorizationService.isAuthorized(any(), eq(manifest.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(manifest.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
             when(typeTransformerRegistry.transform(any(), eq(VerifiableCredentialResource.class))).thenReturn(Result.success(mock(VerifiableCredentialResource.class)));
             when(credentialStore.create(any())).thenReturn(alreadyExists("already-exists"));
 
@@ -312,8 +312,8 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
             var credential1 = createCredentialResource("test-type").build();
             var credential2 = createCredentialResource("test-type").build();
             when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(credential1, credential2)));
-            when(authorizationService.isAuthorized(any(), eq(credential1.getId()), eq(VerifiableCredentialResource.class))).thenReturn(unauthorized("test-message"));
-            when(authorizationService.isAuthorized(any(), eq(credential2.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
+            when(authorizationService.isAuthorized(any(), anyString(), eq(credential1.getId()), eq(VerifiableCredentialResource.class))).thenReturn(unauthorized("test-message"));
+            when(authorizationService.isAuthorized(any(), anyString(), eq(credential2.getId()), eq(VerifiableCredentialResource.class))).thenReturn(ServiceResult.success());
 
             var result = baseRequest()
                     .get("?type=test-type")
@@ -381,14 +381,14 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
 
         @Test
         void notAuthorized_returns403() {
-            when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(unauthorized("test-message"));
+            when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(unauthorized("test-message"));
 
             baseRequest()
                     .delete("/%s".formatted(CREDENTIAL_ID))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
-            verify(authorizationService).isAuthorized(any(), anyString(), eq(VerifiableCredentialResource.class));
+            verify(authorizationService).isAuthorized(any(), anyString(), anyString(), eq(VerifiableCredentialResource.class));
             verifyNoMoreInteractions(credentialStore, authorizationService);
         }
 
@@ -430,13 +430,13 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
 
         @Test
         void notAuthorized_returns403() {
-            when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(unauthorized("test-message"));
+            when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(unauthorized("test-message"));
             baseRequest()
                     .get("/%s".formatted(CREDENTIAL_ID))
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403);
-            verify(authorizationService).isAuthorized(any(), anyString(), eq(VerifiableCredentialResource.class));
+            verify(authorizationService).isAuthorized(any(), anyString(), anyString(), eq(VerifiableCredentialResource.class));
             verifyNoMoreInteractions(credentialStore, authorizationService);
         }
 
@@ -510,7 +510,7 @@ class VerifiableCredentialsApiControllerTest extends RestControllerTestBase {
             var request = new CredentialRequestDto("did:web:issuer", UUID.randomUUID().toString(), List.of(
                     new CredentialDescriptor(CredentialFormat.VC1_0_JWT, "FooCredential", UUID.randomUUID().toString())
             ));
-            when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(unauthorized("test-message"));
+            when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(unauthorized("test-message"));
             baseRequest()
                     .contentType(JSON)
                     .body(request)

--- a/extensions/api/issuer-admin-api/attestation-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiController.java
+++ b/extensions/api/issuer-admin-api/attestation-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiController.java
@@ -60,7 +60,7 @@ public class IssuerAttestationAdminApiController implements IssuerAttestationAdm
 
         var decodedParticipantContextId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);
 
-        return authorizationService.isAuthorized(securityContext, decodedParticipantContextId, ParticipantContext.class)
+        return authorizationService.isAuthorized(securityContext, decodedParticipantContextId, decodedParticipantContextId, ParticipantContext.class)
                 .compose(u -> attestationDefinitionService.createAttestation(createAttestationDefinition(decodedParticipantContextId, attestationRequest)))
                 .map(u -> Response.created(URI.create(Versions.UNSTABLE + "/participants/%s/attestations/%s".formatted(participantContextId, attestationRequest.id()))).build())
                 .orElseThrow(AuthorizationResultHandler.exceptionMapper(AttestationDefinition.class));
@@ -70,7 +70,7 @@ public class IssuerAttestationAdminApiController implements IssuerAttestationAdm
     @Path("/{attestationDefinitionId}")
     @Override
     public void deleteAttestationDefinition(@PathParam("participantContextId") String participantContextId, @PathParam("attestationDefinitionId") String attestationDefinitionId, @Context SecurityContext context) {
-        authorizationService.isAuthorized(context, attestationDefinitionId, AttestationDefinition.class)
+        authorizationService.isAuthorized(context, onEncoded(participantContextId).orElseThrow(InvalidRequestException::new), attestationDefinitionId, AttestationDefinition.class)
                 .compose(u -> attestationDefinitionService.deleteAttestation(attestationDefinitionId))
                 .orElseThrow(exceptionMapper(AttestationDefinition.class, attestationDefinitionId));
     }
@@ -86,7 +86,7 @@ public class IssuerAttestationAdminApiController implements IssuerAttestationAdm
                 .orElseThrow(exceptionMapper(AttestationDefinition.class, null));
 
         return attestations.stream()
-                .filter(attestation -> authorizationService.isAuthorized(context, attestation.getId(), AttestationDefinition.class).succeeded())
+                .filter(attestation -> authorizationService.isAuthorized(context, decodedParticipantContextId, attestation.getId(), AttestationDefinition.class).succeeded())
                 .toList();
     }
 

--- a/extensions/api/issuer-admin-api/attestation-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/attestation-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerAttestationAdminApiControllerTest.java
@@ -49,7 +49,7 @@ class IssuerAttestationAdminApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Test

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/IssuerCredentialDefinitionAdminApiExtension.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/IssuerCredentialDefinitionAdminApiExtension.java
@@ -15,12 +15,15 @@
 package org.eclipse.edc.issuerservice.api.admin.credentialdefinition;
 
 import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext;
 import org.eclipse.edc.issuerservice.api.admin.credentialdefinition.v1.unstable.IssuerCredentialDefinitionAdminApiController;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.CredentialDefinitionService;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
@@ -50,7 +53,14 @@ public class IssuerCredentialDefinitionAdminApiExtension implements ServiceExten
         webService.registerResource(IdentityHubApiContext.ISSUERADMIN, controller);
     }
 
-    public CredentialDefinition findById(String id) {
-        return credentialDefinitionService.findCredentialDefinitionById(id).getContent();
+    private ParticipantResource findById(String owner, String id) {
+
+        var query = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("id", "=", id))
+                .filter(new Criterion("participantContextId", "=", owner))
+                .build();
+        return credentialDefinitionService.queryCredentialDefinitions(query)
+                .map(list -> list.stream().findFirst().orElse(null))
+                .orElse(null);
     }
 }

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/IssuerCredentialDefinitionAdminApiController.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/IssuerCredentialDefinitionAdminApiController.java
@@ -60,7 +60,7 @@ public class IssuerCredentialDefinitionAdminApiController implements IssuerCrede
     @Override
     public Response createCredentialDefinition(@PathParam("participantContextId") String participantContextId, CredentialDefinitionDto definitionDto, @Context SecurityContext context) {
         var decodedParticipantContextId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);
-        return authorizationService.isAuthorized(context, decodedParticipantContextId, ParticipantContext.class)
+        return authorizationService.isAuthorized(context, decodedParticipantContextId, decodedParticipantContextId, ParticipantContext.class)
                 .compose(u -> credentialDefinitionService.createCredentialDefinition(definitionDto.toCredentialDefinition(decodedParticipantContextId)))
                 .map(v -> Response.created(URI.create(Versions.UNSTABLE + "/participants/%s/credentialdefinitions/%s".formatted(participantContextId, definitionDto.getId()))).build())
                 .orElseThrow(exceptionMapper(CredentialDefinition.class, definitionDto.getId()));
@@ -70,7 +70,7 @@ public class IssuerCredentialDefinitionAdminApiController implements IssuerCrede
     @Override
     public Response updateCredentialDefinition(@PathParam("participantContextId") String participantContextId, CredentialDefinitionDto credentialDefinition, @Context SecurityContext context) {
         var decodedParticipantContextId = onEncoded(participantContextId).orElseThrow(InvalidRequestException::new);
-        return authorizationService.isAuthorized(context, credentialDefinition.getId(), CredentialDefinition.class)
+        return authorizationService.isAuthorized(context, decodedParticipantContextId, credentialDefinition.getId(), CredentialDefinition.class)
                 .compose(u -> credentialDefinitionService.updateCredentialDefinition(credentialDefinition.toCredentialDefinition(decodedParticipantContextId)))
                 .map(v -> Response.ok().build())
                 .orElseThrow(exceptionMapper(CredentialDefinition.class, credentialDefinition.getId()));
@@ -80,7 +80,7 @@ public class IssuerCredentialDefinitionAdminApiController implements IssuerCrede
     @Path("/{credentialDefinitionId}")
     @Override
     public CredentialDefinition getCredentialDefinitionById(@PathParam("participantContextId") String participantContextId, @PathParam("credentialDefinitionId") String credentialDefinitionId, @Context SecurityContext context) {
-        return authorizationService.isAuthorized(context, credentialDefinitionId, CredentialDefinition.class)
+        return authorizationService.isAuthorized(context, onEncoded(participantContextId).orElseThrow(InvalidRequestException::new), credentialDefinitionId, CredentialDefinition.class)
                 .compose(u -> credentialDefinitionService.findCredentialDefinitionById(credentialDefinitionId))
                 .orElseThrow(exceptionMapper(CredentialDefinition.class, credentialDefinitionId));
     }
@@ -95,7 +95,7 @@ public class IssuerCredentialDefinitionAdminApiController implements IssuerCrede
                 .orElseThrow(exceptionMapper(CredentialDefinition.class, null));
 
         return definitions.stream()
-                .filter(definition -> authorizationService.isAuthorized(context, definition.getId(), CredentialDefinition.class).succeeded())
+                .filter(definition -> authorizationService.isAuthorized(context, decodedParticipantContextId, definition.getId(), CredentialDefinition.class).succeeded())
                 .toList();
     }
 
@@ -103,7 +103,7 @@ public class IssuerCredentialDefinitionAdminApiController implements IssuerCrede
     @Path("/{credentialDefinitionId}")
     @Override
     public void deleteCredentialDefinitionById(@PathParam("participantContextId") String participantContextId, @PathParam("credentialDefinitionId") String credentialDefinitionId, @Context SecurityContext context) {
-        authorizationService.isAuthorized(context, credentialDefinitionId, CredentialDefinition.class)
+        authorizationService.isAuthorized(context, onEncoded(participantContextId).orElseThrow(InvalidRequestException::new), credentialDefinitionId, CredentialDefinition.class)
                 .compose(u -> credentialDefinitionService.deleteCredentialDefinition(credentialDefinitionId))
                 .orElseThrow(exceptionMapper(CredentialDefinition.class, credentialDefinitionId));
     }

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/IssuerCredentialDefinitionAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/IssuerCredentialDefinitionAdminApiControllerTest.java
@@ -51,7 +51,7 @@ class IssuerCredentialDefinitionAdminApiControllerTest extends RestControllerTes
 
     @BeforeEach
     void setUp() {
-        when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Test

--- a/extensions/api/issuer-admin-api/credentials-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/credentials-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApiControllerTest.java
@@ -67,7 +67,7 @@ class IssuerCredentialsAdminApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
         when(credentialOfferService.sendCredentialOffer(anyString(), anyString(), anyCollection())).thenReturn(ServiceResult.success());
     }
 
@@ -196,23 +196,23 @@ class IssuerCredentialsAdminApiControllerTest extends RestControllerTestBase {
 
     @Test
     void sendCredentialOffer_whenHolderNotFound() {
-        when(authorizationService.isAuthorized(any(), anyString(), any()))
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any()))
                 .thenReturn(ServiceResult.notFound("holder"));
         baseRequest()
                 .body(new CredentialOfferDto("holder", List.of(CREDENTIAL_OBJECT_ID)))
                 .post("/offer")
                 .then()
                 .log().ifValidationFails()
-                .statusCode(400)
-                .body(containsString("Holder not found"));
+                .statusCode(404)
+                .body(containsString("Object of type Holder with ID=holder was not found"));
 
-        verify(authorizationService).isAuthorized(any(), anyString(), any());
+        verify(authorizationService).isAuthorized(any(), anyString(), anyString(), any());
         verifyNoMoreInteractions(authorizationService, credentialOfferService);
     }
 
     @Test
     void sendCredentialOffer_whenNotAuthorized() {
-        when(authorizationService.isAuthorized(any(), anyString(), any()))
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any()))
                 .thenReturn(ServiceResult.unauthorized("barbaz"));
         baseRequest()
                 .body(new CredentialOfferDto("holder", List.of(CREDENTIAL_OBJECT_ID)))
@@ -222,7 +222,7 @@ class IssuerCredentialsAdminApiControllerTest extends RestControllerTestBase {
                 .statusCode(403)
                 .body(containsString("barbaz"));
 
-        verify(authorizationService).isAuthorized(any(), anyString(), any());
+        verify(authorizationService).isAuthorized(any(), anyString(), anyString(), any());
         verifyNoMoreInteractions(authorizationService, credentialOfferService);
     }
 

--- a/extensions/api/issuer-admin-api/holder-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/holder/IssuerHolderAdminApiExtension.java
+++ b/extensions/api/issuer-admin-api/holder-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/holder/IssuerHolderAdminApiExtension.java
@@ -15,12 +15,15 @@
 package org.eclipse.edc.issuerservice.api.admin.holder;
 
 import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResource;
 import org.eclipse.edc.identityhub.spi.webcontext.IdentityHubApiContext;
 import org.eclipse.edc.issuerservice.api.admin.holder.v1.unstable.IssuerHolderAdminApiController;
 import org.eclipse.edc.issuerservice.spi.holder.HolderService;
 import org.eclipse.edc.issuerservice.spi.holder.model.Holder;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.web.spi.WebService;
@@ -52,5 +55,15 @@ public class IssuerHolderAdminApiExtension implements ServiceExtension {
 
     public Holder findById(String holderId) {
         return holderService.findById(holderId).getContent();
+    }
+
+    private ParticipantResource findById(String owner, String id) {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("holderId", "=", id))
+                .filter(new Criterion("participantContextId", "=", owner))
+                .build();
+        return holderService.queryHolders(query)
+                .map(list -> list.stream().findFirst().orElse(null))
+                .orElse(null);
     }
 }

--- a/extensions/api/issuer-admin-api/holder-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/holder/v1/unstable/IssuerHolderAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/holder-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/holder/v1/unstable/IssuerHolderAdminApiControllerTest.java
@@ -50,7 +50,7 @@ class IssuerHolderAdminApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authorizationService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authorizationService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Test
@@ -165,6 +165,11 @@ class IssuerHolderAdminApiControllerTest extends RestControllerTestBase {
         assertThat(dto).isEmpty();
     }
 
+    @Override
+    protected Object controller() {
+        return new IssuerHolderAdminApiController(authorizationService, holderService);
+    }
+
     private Holder createHolder(String id, String did, String name) {
         return Holder.Builder.newInstance()
                 .participantContextId(PARTICIPANT_ID)
@@ -172,11 +177,6 @@ class IssuerHolderAdminApiControllerTest extends RestControllerTestBase {
                 .did(did)
                 .holderName(name)
                 .build();
-    }
-
-    @Override
-    protected Object controller() {
-        return new IssuerHolderAdminApiController(authorizationService, holderService);
     }
 
     private RequestSpecification baseRequest() {

--- a/extensions/api/issuer-admin-api/issuance-process-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/issuance/v1/unstable/IssuanceProcessAdminApiController.java
+++ b/extensions/api/issuer-admin-api/issuance-process-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/issuance/v1/unstable/IssuanceProcessAdminApiController.java
@@ -59,7 +59,7 @@ public class IssuanceProcessAdminApiController implements IssuanceProcessAdminAp
                                                      @PathParam("issuanceProcessId") String issuanceProcessId,
                                                      @Context SecurityContext securityContext) {
 
-        authorizationService.isAuthorized(securityContext, issuanceProcessId, IssuanceProcess.class)
+        authorizationService.isAuthorized(securityContext, onEncoded(participantContextId).orElseThrow(InvalidRequestException::new), issuanceProcessId, IssuanceProcess.class)
                 .orElseThrow(exceptionMapper(IssuanceProcess.class, issuanceProcessId));
 
         var issuanceProcess = issuanceProcessService.findById(issuanceProcessId);
@@ -79,7 +79,7 @@ public class IssuanceProcessAdminApiController implements IssuanceProcessAdminAp
             return issuanceProcessService.search(spec)
                     .orElseThrow(exceptionMapper(IssuanceProcess.class, null))
                     .stream()
-                    .filter(issuanceProcess -> authorizationService.isAuthorized(securityContext, issuanceProcess.getId(), IssuanceProcess.class).succeeded())
+                    .filter(issuanceProcess -> authorizationService.isAuthorized(securityContext, decoded, issuanceProcess.getId(), IssuanceProcess.class).succeeded())
                     .map(IssuanceProcessDto::fromIssuanceProcess)
                     .collect(toList());
         }).orElseThrow(InvalidRequestException::new);

--- a/extensions/api/issuer-admin-api/issuance-process-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/issuance/v1/unstable/IssuanceProcessAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/issuance-process-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/issuance/v1/unstable/IssuanceProcessAdminApiControllerTest.java
@@ -47,7 +47,7 @@ class IssuanceProcessAdminApiControllerTest extends RestControllerTestBase {
 
     @BeforeEach
     void setUp() {
-        when(authService.isAuthorized(any(), anyString(), any())).thenReturn(ServiceResult.success());
+        when(authService.isAuthorized(any(), anyString(), anyString(), any())).thenReturn(ServiceResult.success());
     }
 
     @Test

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/IssuerAdminApiConfigurationExtension.java
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/java/org/eclipse/edc/identityhub/api/configuration/IssuerAdminApiConfigurationExtension.java
@@ -35,7 +35,7 @@ import org.eclipse.edc.web.spi.configuration.PortMapping;
 import org.eclipse.edc.web.spi.configuration.PortMappingRegistry;
 
 import java.io.IOException;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import static org.eclipse.edc.identityhub.api.configuration.IssuerAdminApiConfigurationExtension.NAME;
@@ -101,12 +101,12 @@ public class IssuerAdminApiConfigurationExtension implements ServiceExtension {
     private static class AllowAllAuthorizationService implements AuthorizationService {
 
         @Override
-        public ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceId, Class<? extends ParticipantResource> resourceClass) {
+        public ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceOwnerId, String resourceId, Class<? extends ParticipantResource> resourceClass) {
             return ServiceResult.success();
         }
 
         @Override
-        public void addLookupFunction(Class<?> resourceClass, Function<String, ParticipantResource> checkFunction) {
+        public void addLookupFunction(Class<?> resourceClass, BiFunction<String, String, ParticipantResource> checkFunction) {
 
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,9 +118,16 @@ dcp-system = { module = "org.eclipse.dataspacetck.dcp:dcp-system", version.ref =
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 
 [bundles]
-connector = ["edc-boot", "edc-core-connector", "edc-core-runtime", "edc-http", "edc-observability", "edc-jsonld", "edc-config-fs"]
+connector = [
+    "edc-boot",
+    "edc-core-connector",
+    "edc-core-runtime",
+    "edc-http",
+    "edc-observability",
+    "edc-jsonld",
+    "edc-config-fs",
+]
 
 [plugins]
 edc-build = { id = "org.eclipse.edc.edc-build", version = "1.1.1" }
 shadow = { id = "com.gradleup.shadow", version = "9.2.2" }
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "identity-hub"
 
 pluginManagement {
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         mavenCentral()
         maven {

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authorization/AuthorizationService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authorization/AuthorizationService.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantResou
 import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.security.Principal;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * This service takes a {@link Principal}, that is typically obtained from the {@link jakarta.ws.rs.core.SecurityContext} of an incoming
@@ -30,16 +30,18 @@ public interface AuthorizationService {
     /**
      * Checks whether the principal is authorized to access a particular resource.
      *
-     * @param securityContext The {@link SecurityContext} that was obtained during the authentication phase of the request. Not null.
+     * @param securityContext The {@link SecurityContext} that was obtained during the authentication phase of the request.
+     *                        This represents the user to whom the auth token belongs. Not null.
+     * @param resourceOwnerId The ID of the resource owner. This is typically the ID of the participant context. Not null.
      * @param resourceId      The ID of the resource. The resource must be of type {@link AbstractParticipantResource}.
      * @param resourceClass   The concrete type of the resource.
-     * @return success if authorized, {@link ServiceResult#unauthorized(String)} if not authorized
+     * @return success if authorized, {@link ServiceResult#unauthorized(String)} if the principal is not authorized, or {@link ServiceResult#notFound(String)} if the resource owner does not own the resource.
      */
-    ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceId, Class<? extends ParticipantResource> resourceClass);
+    ServiceResult<Void> isAuthorized(SecurityContext securityContext, String resourceOwnerId, String resourceId, Class<? extends ParticipantResource> resourceClass);
 
     /**
-     * Register a function, that can lookup a particular resource type by ID. Typically, every resource that should be protected with
-     * authorization, registers a lookup function for the type of resource.
+     * Register a function that can look up a particular resource type by ID. Typically, every resource that should be protected with
+     * authorization registers a lookup function for the type of resource.
      */
-    void addLookupFunction(Class<?> resourceClass, Function<String, ParticipantResource> checkFunction);
+    void addLookupFunction(Class<?> resourceClass, BiFunction<String, String, ParticipantResource> checkFunction);
 }


### PR DESCRIPTION
## What this PR changes/adds

This PR adds an _ownership check_ on the `AuthorizationService`.

Specifically, it adds a parameter `resourceOwnerId` to the auth service method, that should contain the `participantContextId` to which the respective entity (e.g. DidResource, VerifiableCredentialResource,...) belongs.

## Why it does that

Prior to this PR it was possible for elevated users (admins) to manipulate resources, that belong to a different participant context than the one specified in the API url. For example:

`KeyPairResourceId`, which belongs to participant context `testParticipant1`, therefore the API URL would be `/api/v1alpha/participants/testParticipant1/keyPairId1`.

If it was `testParticipant1` who made the request, all would work out fine, because the `SecurityPrincipal` would also contain `testParticipant1`.

The problem arises when it's a SecurityPrincipal with the `ADMIN` role, because then, the lookup function would simply return the entity by-ID, and ownership wasn't verified.

This means, that an admin could have used:

`/api/v1alpha/participants/differentPArticipantX/keyPairId1` and _still_ have gotten `testParticipant1`'s key pair. An admin does have that right, but semantically it's incorrect.

## Further notes

this is a **breaking** change, although the APIs are still in alpha, therefor backwards compatibility is not warranted.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
