### PR TITLE
fix: add id to VerifiableCredentialResourceDto

### DIFF
--- a/extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApi.java
+++ b/extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApi.java
@@ -27,7 +27,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.CredentialOfferDto;
 import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.CredentialStatusResponse;
-import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.VerifiableCredentialDto;
+import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.VerifiableCredentialResourceDto;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.web.spi.ApiErrorDetail;
 
@@ -43,15 +43,14 @@ public interface IssuerCredentialsAdminApi {
             requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = QuerySpec.class), mediaType = "application/json")),
             responses = {
                     @ApiResponse(responseCode = "200", description = "A list of verifiable credential metadata. Note that these are not actual VerifiableCredentials.",
-                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = VerifiableCredentialDto.class)), mediaType = "application/json")),
+                            content = @Content(array = @ArraySchema(schema = @Schema(implementation = VerifiableCredentialResourceDto.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "400", description = "Request body was malformed, or the request could not be processed",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json")),
                     @ApiResponse(responseCode = "401", description = "The request could not be completed, because either the authentication was missing or was not valid.",
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = ApiErrorDetail.class)), mediaType = "application/json"))
             }
     )
-    Collection<VerifiableCredentialDto> queryCredentials(String participantContextId, QuerySpec query, SecurityContext context);
-
+    Collection<VerifiableCredentialResourceDto> queryCredentials(String participantContextId, QuerySpec query, SecurityContext context);
 
     @Operation(description = "Revokes a credential with the given ID for the given participant. Revoked credentials will be added to the Revocation List",
             operationId = "revokeCredential",
@@ -66,7 +65,6 @@ public interface IssuerCredentialsAdminApi {
             }
     )
     void revokeCredential(String participantContextId, String credentialId, SecurityContext context);
-
 
     @Operation(description = "Suspends a credential with the given ID for the given participant. Suspended credentials will be added to the Revocation List. Suspension is reversible.",
             operationId = "suspendCredential",

--- a/extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/model/VerifiableCredentialResourceDto.java
+++ b/extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/model/VerifiableCredentialResourceDto.java
@@ -21,11 +21,16 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 /**
  * Returns metadata about a verifiable credential
  *
+ * @param id                   The credential resource id
+ * @param participantContextId The participant context id related to the credential resource
  * @param format               The {@link CredentialFormat} of the credential
  * @param verifiableCredential Structured metadata about the VC, not the actual VC. This will not contain the proof!
  */
-public record VerifiableCredentialDto(@JsonProperty("participantContextId") String participantContextId,
-                                      @JsonProperty("format") CredentialFormat format,
-                                      @JsonProperty("credential") VerifiableCredential verifiableCredential) {
+public record VerifiableCredentialResourceDto(
+        String id,
+        String participantContextId,
+        CredentialFormat format,
+        @JsonProperty("credential") VerifiableCredential verifiableCredential
+) {
 
 }

--- a/extensions/api/issuer-admin-api/credentials-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApiControllerTest.java
+++ b/extensions/api/issuer-admin-api/credentials-api/src/test/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApiControllerTest.java
@@ -25,7 +25,7 @@ import org.eclipse.edc.identityhub.spi.authorization.AuthorizationService;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.CredentialOfferDto;
-import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.VerifiableCredentialDto;
+import org.eclipse.edc.issuerservice.api.admin.credentials.v1.unstable.model.VerifiableCredentialResourceDto;
 import org.eclipse.edc.issuerservice.spi.credentials.CredentialStatusService;
 import org.eclipse.edc.issuerservice.spi.credentials.IssuerCredentialOfferService;
 import org.eclipse.edc.spi.query.QuerySpec;
@@ -82,11 +82,10 @@ class IssuerCredentialsAdminApiControllerTest extends RestControllerTestBase {
                 .then()
                 .log().ifError()
                 .statusCode(200)
-                .extract().body().as(VerifiableCredentialDto[].class);
+                .extract().body().as(VerifiableCredentialResourceDto[].class);
 
-        assertThat(credentials).hasSize(2);
+        assertThat(credentials).hasSize(2).allMatch(it -> it.id() != null);
     }
-
 
     @Test
     void queryCredentials_whenNoResult() {
@@ -98,7 +97,7 @@ class IssuerCredentialsAdminApiControllerTest extends RestControllerTestBase {
                 .post("/query")
                 .then()
                 .statusCode(200)
-                .extract().body().as(VerifiableCredentialDto[].class);
+                .extract().body().as(VerifiableCredentialResourceDto[].class);
 
         assertThat(credentials).isEmpty();
     }

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-10-24T09:30:00Z",
+    "lastUpdated": "2025-11-06T09:30:00Z",
     "maturity": null
   }
 ]


### PR DESCRIPTION
## What this PR changes/adds

Adds `id` to `VerifiableCredentialResourceDto`

## Why it does that

permit revocation

## Further notes

- renamed `VerifiableCredentialDto` to `VerifiableCredentialResourceDto` as it is more related to the resource entity than the actual credential


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #852 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
