### PR TITLE
fix: store (vault) config in private properties

### DIFF
--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextServiceImpl.java
@@ -188,7 +188,7 @@ public class ParticipantContextServiceImpl implements ParticipantContextService 
 
         var cfg = ParticipantContextConfiguration.Builder.newInstance()
                 .participantContextId(context.getParticipantContextId())
-                .entries(config)
+                .privateEntries(config)
                 .build();
         var configResult = configService.save(cfg);
         return configResult.compose(u -> ServiceResult.from(result).map(it -> context));


### PR DESCRIPTION
## What this PR changes/adds

Store participant configuration in private properties. This includes the vault config.

## Why it does that

security

## Further notes

At some point in the future, a `ParticipantManifest`, and by extension a `ParticipantContext` should distinguish between normal and sensitive properties.

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
