### PR TITLE
fix: merge credential contexts into VP @context to preserve custom claims

### DIFF
--- a/core/identity-hub-core/src/test/resources/custom.v1.json
+++ b/core/identity-hub-core/src/test/resources/custom.v1.json
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "customField": {
+      "@id": "https://example.com/custom/v1/customField",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    }
+  }
+}

--- a/core/identity-hub-core/src/test/resources/tractusx.v08.json
+++ b/core/identity-hub-core/src/test/resources/tractusx.v08.json
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "holderIdentifier": {
+      "@id": "https://w3id.org/tractusx-trust/v0.8/holderIdentifier",
+      "@type": "@id"
+    },
+    "bpn": {
+      "@id": "https://w3id.org/tractusx-trust/v0.8/bpn",
+      "@type": "@id"
+    }
+  }
+}


### PR DESCRIPTION
## Description

**Fixes #893**

### Problem

When generating Verifiable Presentations (VPs), custom claims from embedded credentials (e.g., `holderIdentifier` from Tractus-X contexts) were being dropped during JSON-LD compaction. This occurred because:

1. The VP's `@context` array only included hardcoded base contexts:
   - `https://www.w3.org/2018/credentials/v1`
   - `https://identity.foundation/presentation-exchange/submission/v1`
2. Custom contexts from embedded credentials were not propagated to the VP
3. When the VP was compacted in `PresentationApiController.createPresentation()` (line 140), the JSON-LD processor dropped terms undefined in the available contexts

### Solution

This PR implements context merging in `LdpPresentationGenerator` to extract and merge `@context` values from all embedded credentials with the VP's base contexts.

**Key Changes:**
- Added `extractContextsFromCredentials()` method to extract contexts from all credentials
- Added `mergeContexts()` method to combine base and credential contexts without duplicates
- Modified `generatePresentation()` to use merged contexts when building the VP
- Handles both string and array context formats gracefully
- Ensures proper ordering: W3C_CREDENTIALS_URL first, then PRESENTATION_EXCHANGE_URL, then credential contexts

**Example:**

*Before:*
```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://identity.foundation/presentation-exchange/submission/v1"
  ],
  "verifiableCredential": [...]
}
```

*After:*
```json
{
  "@context": [
    "https://www.w3.org/2018/credentials/v1",
    "https://identity.foundation/presentation-exchange/submission/v1",
    "https://w3id.org/tractusx-trust/v0.8"  // ✅ Merged from credential
  ],
  "verifiableCredential": [...]
}
```

### Testing

- Added 5 comprehensive test cases covering:
  - Custom context merging
  - Single context strings vs arrays
  - Multiple credentials with different contexts
  - Duplicate context avoidance
  - Missing contexts handling
- Added test JSON-LD context files (`tractusx.v08.json`, `custom.v1.json`)
- All 98 tests in `identity-hub-core` pass ✅
- Full project build successful ✅
- Checkstyle passed ✅

### Files Changed

- `core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java`
- `core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGeneratorTest.java`
- `core/identity-hub-core/src/test/resources/tractusx.v08.json` (new)
- `core/identity-hub-core/src/test/resources/custom.v1.json` (new)

### Checklist

- [x] Code follows the project's style guidelines
- [x] Tests added for new functionality
- [x] All tests pass
- [x] Documentation updated where necessary
- [x] Commit message follows conventional commits format
- [x] Issue reference included in commit message

---

**Branch:** `fix/893-merge-credential-contexts-vp`  
**Commit:** `39833797`  
**Ready for review** 🚀
