### PR TITLE
fix: use proper query to get status list credential in the BitstringStatusListFactory

### DIFF
--- a/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/statuslist/bitstring/BitstringStatusListManager.java
+++ b/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/statuslist/bitstring/BitstringStatusListManager.java
@@ -145,7 +145,7 @@ public class BitstringStatusListManager implements StatusListManager {
                 .issuanceDate(now)
                 .expirationDate(now.plus(365, ChronoUnit.DAYS)) //todo: make configurable
                 .issuer(new Issuer(participantDid))
-                .type(BITSTRING_STATUS_LIST)
+                .type("BitstringStatusListCredential")
                 .build();
 
         // sign and package in resource

--- a/core/issuerservice/issuerservice-credentials/src/test/java/org/eclipse/edc/issuerservice/credentials/CredentialStatusServiceImplTest.java
+++ b/core/issuerservice/issuerservice-credentials/src/test/java/org/eclipse/edc/issuerservice/credentials/CredentialStatusServiceImplTest.java
@@ -35,10 +35,12 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCre
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.issuerservice.credentials.statuslist.StatusListInfoFactoryRegistryImpl;
 import org.eclipse.edc.issuerservice.credentials.statuslist.bitstring.BitstringStatusListFactory;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListInfo;
 import org.eclipse.edc.json.JacksonTypeManager;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.token.spi.TokenGenerationService;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.jetbrains.annotations.Nullable;
@@ -47,7 +49,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,7 +62,6 @@ import static org.eclipse.edc.issuerservice.credentials.statuslist.TestData.EXAM
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.BAD_REQUEST;
 import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
-import static org.eclipse.edc.spi.result.ServiceFailure.Reason.UNEXPECTED;
 import static org.eclipse.edc.spi.result.StoreResult.notFound;
 import static org.eclipse.edc.spi.result.StoreResult.success;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,12 +69,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("unchecked")
 class CredentialStatusServiceImplTest {
 
     public static final TypeReference<Map<String, Object>> MAP_REF = new TypeReference<>() {
@@ -85,10 +85,12 @@ class CredentialStatusServiceImplTest {
             .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     private final CredentialStore credentialStore = mock();
+    private final BitstringStatusListFactory bitstringStatusListFactory = mock();
     private CredentialStatusServiceImpl revocationService;
     private TokenGenerationService tokenGenerationService;
     private Monitor monitor;
     private ECKey signingKey;
+    private final TestStatusListInfo statusListInfo = spy(new TestStatusListInfo());
 
     @BeforeEach
     void setUp() throws JOSEException {
@@ -97,43 +99,10 @@ class CredentialStatusServiceImplTest {
         when(tokenGenerationService.generate(anyString(), any(), any())).thenReturn(Result.success(TokenRepresentation.Builder.newInstance().token("new-token").build()));
         monitor = mock();
         var reg = new StatusListInfoFactoryRegistryImpl();
-        reg.register("BitstringStatusListEntry", new BitstringStatusListFactory(credentialStore));
+        reg.register("BitstringStatusListEntry", bitstringStatusListFactory);
         revocationService = new CredentialStatusServiceImpl(credentialStore, new NoopTransactionContext(), objectMapper,
                 monitor, tokenGenerationService, () -> "some-private-key", reg, mock());
-    }
-
-    private SignedJWT sign(Map<String, Object> claims) {
-
-
-        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
-        var claimsSet = new JWTClaimsSet.Builder();
-        claims.forEach(claimsSet::claim);
-        var signedJwt = new SignedJWT(jwsHeader, claimsSet.build());
-        try {
-            signedJwt.sign(new ECDSASigner(signingKey));
-            return signedJwt;
-        } catch (JOSEException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private VerifiableCredentialResource createCredential(String credentialJson, @Nullable String rawVc) {
-        return createCredentialBuilder(credentialJson, rawVc)
-                .build();
-    }
-
-    private VerifiableCredentialResource.Builder createCredentialBuilder(String credentialJson, @Nullable String rawVc) {
-        try {
-            var credential = objectMapper.readValue(credentialJson, VerifiableCredential.class);
-            return VerifiableCredentialResource.Builder.newStatusList()
-                    .participantContextId("test-participant")
-                    .state(VcStatus.ISSUED)
-                    .credential(new VerifiableCredentialContainer(rawVc, CredentialFormat.VC1_0_JWT, credential))
-                    .issuerId(credential.getIssuer().id())
-                    .holderId("did:web:testholder");
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        when(bitstringStatusListFactory.create(any())).thenReturn(ServiceResult.success(statusListInfo));
     }
 
     @Nested
@@ -141,11 +110,13 @@ class CredentialStatusServiceImplTest {
 
         @Test
         void revokeCredential() {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID))).thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
+            when(statusListInfo.getStatus()).thenReturn(Result.success("any"));
+            when(statusListInfo.statusListCredential()).thenReturn(createCredential(EXAMPLE_CREDENTIAL, EXAMPLE_CREDENTIAL_JWT.replace("\n", "")));
             when(credentialStore.findById(eq(CREDENTIAL_ID))).thenReturn(success(createCredential(EXAMPLE_CREDENTIAL, EXAMPLE_CREDENTIAL_JWT.replace("\n", ""))));
             when(credentialStore.update(any())).thenReturn(success());
 
             var result = revocationService.revokeCredential(CREDENTIAL_ID);
+
             assertThat(result).isSucceeded();
             verify(tokenGenerationService).generate(anyString(), any(), any());
             verify(credentialStore, times(2)).update(any());
@@ -158,9 +129,9 @@ class CredentialStatusServiceImplTest {
             when(credentialStore.update(any())).thenReturn(success());
 
             var result = revocationService.revokeCredential(CREDENTIAL_ID);
+
             assertThat(result).isFailed().detail().isEqualTo("foo");
             assertThat(result.getFailure().getReason()).isEqualTo(NOT_FOUND);
-
             verifyNoInteractions(tokenGenerationService);
             verify(credentialStore, never()).update(any());
         }
@@ -172,6 +143,7 @@ class CredentialStatusServiceImplTest {
             when(credentialStore.update(any())).thenReturn(success());
 
             var result = revocationService.revokeCredential(CREDENTIAL_ID);
+
             assertThat(result).isSucceeded();
             verifyNoInteractions(tokenGenerationService);
             verify(credentialStore, never()).update(any());
@@ -183,17 +155,15 @@ class CredentialStatusServiceImplTest {
             when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
                     .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
 
-
             var claims = objectMapper.readValue(EXAMPLE_CREDENTIAL, MAP_REF);
             claims.remove("credentialStatus");
             var jwt = sign(claims);
 
-
             when(credentialStore.findById(eq(CREDENTIAL_ID)))
                     .thenReturn(success(createCredential(objectMapper.writeValueAsString(jwt.getJWTClaimsSet().getClaims()), jwt.serialize())));
 
-
             var result = revocationService.revokeCredential(CREDENTIAL_ID);
+
             assertThat(result).isFailed();
             assertThat(result.getFailure().getReason()).isEqualTo(BAD_REQUEST);
             verifyNoInteractions(tokenGenerationService);
@@ -201,58 +171,13 @@ class CredentialStatusServiceImplTest {
         }
 
         @Test
-        void revokeCredential_noRevocationCredentialUrl() throws JsonProcessingException, ParseException {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
-
-
-            var claims = objectMapper.readValue(EXAMPLE_CREDENTIAL, MAP_REF);
-            // remove statusListCredential, which is the revocation credential URL
-            ((List<Map<String, Object>>) claims.get("credentialStatus")).get(0).remove("statusListCredential");
-            var jwt = sign(claims);
-
-
-            when(credentialStore.findById(eq(CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(objectMapper.writeValueAsString(jwt.getJWTClaimsSet().getClaims()), jwt.serialize())));
-
-            var result = revocationService.revokeCredential(CREDENTIAL_ID);
-            assertThat(result).isFailed()
-                    .detail().containsSequence("is invalid, the 'statusListCredential' field is missing");
-            assertThat(result.getFailure().getReason()).isEqualTo(UNEXPECTED);
-            verifyNoInteractions(tokenGenerationService);
-            verify(credentialStore, never()).update(any());
-        }
-
-        @Test
-        void revokeCredential_noStatusIndex() throws ParseException, JsonProcessingException {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
-
-
-            var claims = objectMapper.readValue(EXAMPLE_CREDENTIAL, MAP_REF);
-
-            ((List<Map<String, Object>>) claims.get("credentialStatus")).get(0).remove("statusListIndex");
-            var jwt = sign(claims);
-
-
-            when(credentialStore.findById(eq(CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(objectMapper.writeValueAsString(jwt.getJWTClaimsSet().getClaims()), jwt.serialize())));
-
-            var result = revocationService.revokeCredential(CREDENTIAL_ID);
-            assertThat(result).isFailed()
-                    .detail().containsSequence("is invalid, the 'statusListIndex' field is missing");
-            assertThat(result.getFailure().getReason()).isEqualTo(UNEXPECTED);
-            verifyNoInteractions(tokenGenerationService);
-            verify(credentialStore, never()).update(any());
-        }
-
-        @Test
         void revokeCredential_noRevocationCredentialFound() {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID))).thenReturn(notFound("foo"));
+            when(bitstringStatusListFactory.create(any())).thenReturn(ServiceResult.notFound("foo"));
             when(credentialStore.findById(eq(CREDENTIAL_ID))).thenReturn(success(createCredential(EXAMPLE_CREDENTIAL, EXAMPLE_CREDENTIAL_JWT.replace("\n", ""))));
             when(credentialStore.update(any())).thenReturn(success());
 
             var result = revocationService.revokeCredential(CREDENTIAL_ID);
+
             assertThat(result).isFailed().detail().isEqualTo("foo");
             assertThat(result.getFailure().getReason()).isEqualTo(NOT_FOUND);
 
@@ -284,118 +209,88 @@ class CredentialStatusServiceImplTest {
     class GetCredentialStatus {
         @Test
         void getCredentialStatus() {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
             when(credentialStore.findById(eq(CREDENTIAL_ID)))
                     .thenReturn(success(createCredential(EXAMPLE_CREDENTIAL, EXAMPLE_CREDENTIAL_JWT.replace("\n", ""))));
 
             var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
-            assertThat(result).isSucceeded().isNull();
-            verifyNoInteractions(tokenGenerationService);
-        }
 
-        @Test
-        void getCredentialStatus_whenRevoked() {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL_WITH_STATUS_BIT_SET, EXAMPLE_REVOCATION_CREDENTIAL_JWT_WITH_STATUS_BIT_SET.replace("\n", ""))));
-            when(credentialStore.findById(eq(CREDENTIAL_ID)))
-                    .thenReturn(success(createCredentialBuilder(EXAMPLE_CREDENTIAL, EXAMPLE_CREDENTIAL_JWT.replace("\n", ""))
-                            .state(VcStatus.REVOKED)
-                            .build()));
-
-            var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
             assertThat(result).isSucceeded().isEqualTo("revocation");
             verifyNoInteractions(tokenGenerationService);
         }
 
         @Test
         void getCredentialStatus_credentialNotFound() {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID))).thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
             when(credentialStore.findById(eq(CREDENTIAL_ID))).thenReturn(notFound("foo"));
 
             var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
+
             assertThat(result).isFailed().detail().isEqualTo("foo");
             assertThat(result.getFailure().getReason()).isEqualTo(NOT_FOUND);
-
             verifyNoInteractions(tokenGenerationService);
         }
 
         @Test
         void getCredentialStatus_noRevocationCredentialFound() {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID))).thenReturn(notFound("foo"));
+            when(bitstringStatusListFactory.create(any())).thenReturn(ServiceResult.notFound("foo"));
             when(credentialStore.findById(eq(CREDENTIAL_ID))).thenReturn(success(createCredential(EXAMPLE_CREDENTIAL, EXAMPLE_CREDENTIAL_JWT.replace("\n", ""))));
 
             var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
+
             assertThat(result).isFailed().detail().isEqualTo("foo");
             assertThat(result.getFailure().getReason()).isEqualTo(NOT_FOUND);
-
             verifyNoInteractions(tokenGenerationService);
         }
 
-        @Test
-        void getCredentialStatus_noCredentialStatus() throws ParseException, JsonProcessingException {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
+    }
 
+    private SignedJWT sign(Map<String, Object> claims) {
+        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
+        var claimsSet = new JWTClaimsSet.Builder();
+        claims.forEach(claimsSet::claim);
+        var signedJwt = new SignedJWT(jwsHeader, claimsSet.build());
+        try {
+            signedJwt.sign(new ECDSASigner(signingKey));
+            return signedJwt;
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-            var claims = objectMapper.readValue(EXAMPLE_CREDENTIAL, MAP_REF);
-            claims.remove("credentialStatus");
-            var jwt = sign(claims);
+    private VerifiableCredentialResource createCredential(String credentialJson, @Nullable String rawVc) {
+        return createCredentialBuilder(credentialJson, rawVc)
+                .build();
+    }
 
-            when(credentialStore.findById(eq(CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(objectMapper.writeValueAsString(jwt.getJWTClaimsSet().getClaims()), jwt.serialize())));
+    private VerifiableCredentialResource.Builder createCredentialBuilder(String credentialJson, @Nullable String rawVc) {
+        try {
+            var credential = objectMapper.readValue(credentialJson, VerifiableCredential.class);
+            return VerifiableCredentialResource.Builder.newStatusList()
+                    .participantContextId("test-participant")
+                    .state(VcStatus.ISSUED)
+                    .credential(new VerifiableCredentialContainer(rawVc, CredentialFormat.VC1_0_JWT, credential))
+                    .issuerId(credential.getIssuer().id())
+                    .holderId("did:web:testholder");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
+    private static class TestStatusListInfo implements StatusListInfo {
 
-            var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
-            assertThat(result).isFailed();
-            assertThat(result.getFailure().getReason()).isEqualTo(BAD_REQUEST);
-            verifyNoInteractions(tokenGenerationService);
+        @Override
+        public Result<String> getStatus() {
+            return Result.success("revocation");
         }
 
-        @Test
-        void getCredentialStatus_noCredentialUrl() throws ParseException, JsonProcessingException {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
-
-
-            var claims = objectMapper.readValue(EXAMPLE_CREDENTIAL, MAP_REF);
-            // remove statusListCredential, which is the revocation credential URL
-            ((List<Map<String, Object>>) claims.get("credentialStatus")).get(0).remove("statusListCredential");
-            var jwt = sign(claims);
-
-
-            when(credentialStore.findById(eq(CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(objectMapper.writeValueAsString(jwt.getJWTClaimsSet().getClaims()), jwt.serialize())));
-
-            var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
-            assertThat(result).isFailed()
-                    .detail().containsSequence("is invalid, the 'statusListCredential' field is missing");
-            assertThat(result.getFailure().getReason()).isEqualTo(UNEXPECTED);
-            verifyNoInteractions(tokenGenerationService);
+        @Override
+        public Result<Void> setStatus(boolean status) {
+            return Result.success();
         }
 
-        @Test
-        void getCredentialStatus_noStatusIndex() throws ParseException, JsonProcessingException {
-            when(credentialStore.findById(eq(REVOCATION_CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(EXAMPLE_REVOCATION_CREDENTIAL, EXAMPLE_REVOCATION_CREDENTIAL_JWT.replace("\n", ""))));
-
-
-            var claims = objectMapper.readValue(EXAMPLE_CREDENTIAL, MAP_REF);
-
-            ((List<Map<String, Object>>) claims.get("credentialStatus")).get(0).remove("statusListIndex");
-            var jwt = sign(claims);
-
-
-            when(credentialStore.findById(eq(CREDENTIAL_ID)))
-                    .thenReturn(success(createCredential(objectMapper.writeValueAsString(jwt.getJWTClaimsSet().getClaims()), jwt.serialize())));
-
-            var result = revocationService.getCredentialStatus(CREDENTIAL_ID);
-            assertThat(result).isFailed()
-                    .detail().containsSequence("is invalid, the 'statusListIndex' field is missing");
-            assertThat(result.getFailure().getReason()).isEqualTo(UNEXPECTED);
-            verifyNoInteractions(tokenGenerationService);
+        @Override
+        public VerifiableCredentialResource statusListCredential() {
+            return null;
         }
-
     }
 
 }

--- a/core/issuerservice/issuerservice-credentials/src/test/java/org/eclipse/edc/issuerservice/credentials/statuslist/bitstring/BitstringStatusListFactoryTest.java
+++ b/core/issuerservice/issuerservice-credentials/src/test/java/org/eclipse/edc/issuerservice/credentials/statuslist/bitstring/BitstringStatusListFactoryTest.java
@@ -15,16 +15,24 @@
 package org.eclipse.edc.issuerservice.credentials.statuslist.bitstring;
 
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialStatus;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.eclipse.edc.spi.query.Criterion.criterion;
+import static org.eclipse.edc.spi.result.ServiceFailure.Reason.NOT_FOUND;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class BitstringStatusListFactoryTest {
@@ -32,51 +40,68 @@ class BitstringStatusListFactoryTest {
     private final CredentialStore credentialStore = mock();
     private final BitstringStatusListFactory factory = new BitstringStatusListFactory(credentialStore);
 
-
     @Test
-    void create_success() {
-        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of("statusPurpose", "revocation",
+    void shouldCreateStatusInfo() {
+        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of(
+                "statusPurpose", "revocation",
                 "statusListIndex", "1234",
-                "statusListCredential", "https://example.com/credentials/status/1234"));
-
-        when(credentialStore.findById(any())).thenReturn(StoreResult.success(null));
+                "statusListCredential", "https://example.com/credentials/status/credentialId"));
+        var statusList = VerifiableCredentialResource.Builder.newStatusList().issuerId("issuer").holderId("holder").build();
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(statusList)));
 
         var result = factory.create(status);
-        assertThat(result).isSucceeded();
-        assertThat(result.getContent()).isInstanceOf(BitstringStatusInfo.class);
+
+        assertThat(result).isSucceeded().isInstanceOfSatisfying(BitstringStatusInfo.class, info -> {
+            assertThat(info.index()).isEqualTo(1234);
+            assertThat(info.statusListCredential()).isSameAs(statusList);
+        });
+        verify(credentialStore).query(argThat(querySpec -> querySpec.getFilterExpression()
+                .contains(criterion("verifiableCredential.credential.id", "=", "credentialId"))));
     }
 
     @Test
-    void create_whenNoIndex_expectFailure() {
-        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of("statusPurpose", "revocation",
+    void shouldFail_whenNoIndex() {
+        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of(
+                "statusPurpose", "revocation",
                 "statusListCredential", "https://example.com/credentials/status/1234"));
 
-        when(credentialStore.findById(any())).thenReturn(StoreResult.success(null));
-
         var result = factory.create(status);
+
         assertThat(result).isFailed().detail().contains("the 'statusListIndex' field is missing");
     }
 
     @Test
-    void create_whenNoCredential_expectFailure() {
-        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of("statusPurpose", "revocation",
+    void shouldFail_whenNoStatusListCredential() {
+        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of(
+                "statusPurpose", "revocation",
                 "statusListIndex", "1234"));
 
-        when(credentialStore.findById(any())).thenReturn(StoreResult.success(null));
-
         var result = factory.create(status);
+
         assertThat(result).isFailed().detail().contains("the 'statusListCredential' field is missing");
     }
 
     @Test
-    void create_whenRevocationCredentialNotFound_expectFailure() {
+    void shouldFail_whenCredentialNotFound() {
         var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of("statusPurpose", "revocation",
                 "statusListIndex", "1234",
                 "statusListCredential", "https://example.com/credentials/status/1234"));
-
-        when(credentialStore.findById(any())).thenReturn(StoreResult.notFound("foo"));
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(emptyList()));
 
         var result = factory.create(status);
-        assertThat(result).isFailed().detail().isEqualTo("foo");
+
+        assertThat(result).isFailed().extracting(ServiceFailure::getReason).isEqualTo(NOT_FOUND);
+    }
+
+    @Test
+    void shouldFail_whenQueryFails() {
+        var status = new CredentialStatus("id", "BitstringStatusListEntry", Map.of("statusPurpose", "revocation",
+                "statusListIndex", "1234",
+                "statusListCredential", "https://example.com/credentials/status/1234"));
+        when(credentialStore.query(any())).thenReturn(StoreResult.generalError("failure"));
+
+        var result = factory.create(status);
+
+        assertThat(result).isFailed().messages().contains("failure");
     }
 }

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/TestData.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/TestData.java
@@ -15,12 +15,14 @@
 package org.eclipse.edc.identityhub.tests;
 
 public class TestData {
-    public static final String EXAMPLE_REVOCATION_CREDENTIAL = """
+
+    public static String exampleRevocationCredential(String credentialId) {
+        return """
             {
               "@context": [
                 "https://www.w3.org/ns/credentials/v2"
               ],
-              "id": "https://example.com/credentials/status/3",
+              "id": "%s",
               "type": ["VerifiableCredential", "BitstringStatusListCredential"],
               "issuer": "did:example:12345",
               "validFrom": "2021-04-05T14:27:40Z",
@@ -31,13 +33,16 @@ public class TestData {
                 "encodedList": "uH4sIAAAAAAAAA-3BMQEAAADCoPVPbQwfoAAAAAAAAAAAAAAAAAAAAIC3AYbSVKsAQAAA"
               }
             }
-            """;
-    public static final String EXAMPLE_REVOCATION_CREDENTIAL_WITH_STATUS_BIT_SET = """
+            """.formatted(credentialId);
+    }
+
+    public static String exampleRevocationCredentialWithStatusBitSet(String credentialId) {
+        return """
             {
               "@context": [
                 "https://www.w3.org/ns/credentials/v2"
               ],
-              "id": "https://example.com/credentials/status/3",
+              "id": "%s",
               "type": ["VerifiableCredential", "BitstringStatusListCredential"],
               "issuer": "did:example:12345",
               "validFrom": "2021-04-05T14:27:40Z",
@@ -48,7 +53,8 @@ public class TestData {
                 "encodedList": "H4sIAAAAAAAA/+3OMQ0AAAgDsOHfNBp2kZBWQRMAAAAAAAAAAAAAAL6Z6wAAAAAAtQVQdb5gAEAAAA=="
               }
             }
-            """;
+            """.formatted(credentialId);
+    }
 
     public static final String EXAMPLE_REVOCATION_CREDENTIAL_JWT = """
             eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJAY29udGV4dCI6W
@@ -73,8 +79,4 @@ public class TestData {
             """;
 
     public static final String ISSUER_RUNTIME_NAME = "issuerservice";
-    public static final String ISSUER_RUNTIME_ID = "issuerservice";
-
-    public static final String[] ISSUER_RUNTIME_SQL_MODULES = new String[]{":dist:bom:issuerservice-bom", ":dist:bom:issuerservice-feature-sql-bom"};
-    public static final String[] ISSUER_RUNTIME_MEM_MODULES = new String[]{":dist:bom:issuerservice-bom"};
 }

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalCredentialPublisher.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/LocalCredentialPublisher.java
@@ -18,17 +18,18 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCre
 import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialPublisher;
 import org.eclipse.edc.spi.result.Result;
 
+import static org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialUrl.createUrl;
+
 public class LocalCredentialPublisher implements StatusListCredentialPublisher {
     private final String baseUrl;
 
     public LocalCredentialPublisher(String baseUrl) {
-        this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+        this.baseUrl = baseUrl;
     }
 
     @Override
     public Result<String> publish(VerifiableCredentialResource verifiableCredentialResource) {
-        var url = baseUrl + verifiableCredentialResource.getVerifiableCredential().credential().getId();
-        return Result.success(url);
+        return Result.success(createUrl(baseUrl, verifiableCredentialResource));
     }
 
 }

--- a/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialController.java
+++ b/extensions/issuance/local-statuslist-publisher/src/main/java/org/eclipse/edc/issuerservice/publisher/api/StatusListCredentialController.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialUsage;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialUrl;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.Criterion;
@@ -55,15 +56,14 @@ public class StatusListCredentialController {
     public Response resolveStatusListCredential(@HeaderParam("Accept") @DefaultValue(MediaType.WILDCARD) String acceptHeader,
                                                 @Context ContainerRequestContext context) {
 
-        var httpUrl = context.getUriInfo().getAbsolutePath();
         if (!SUPPORTED_TYPES.contains(acceptHeader)) {
             return Response.status(Response.Status.UNSUPPORTED_MEDIA_TYPE)
                     .entity("Supported media types are: %s".formatted(SUPPORTED_TYPES))
                     .build();
         }
 
-        var split = httpUrl.getPath().split("/");
-        var credentialId = split[split.length - 1];
+        var httpUrl = context.getUriInfo().getAbsolutePath();
+        var credentialId = StatusListCredentialUrl.extractIdFromUrl(httpUrl);
 
         var query = QuerySpec.Builder.newInstance()
                 .filter(new Criterion("verifiableCredential.credential.id", "=", credentialId))

--- a/spi/issuerservice/issuerservice-credential-spi/src/main/java/org/eclipse/edc/issuerservice/spi/credentials/statuslist/StatusListCredentialUrl.java
+++ b/spi/issuerservice/issuerservice-credential-spi/src/main/java/org/eclipse/edc/issuerservice/spi/credentials/statuslist/StatusListCredentialUrl.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.spi.credentials.statuslist;
+
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
+
+import java.net.URI;
+
+/**
+ * Describe the status list credential url format
+ */
+public interface StatusListCredentialUrl {
+
+    /**
+     * Create the status list credential url given the base url the the VC resource.
+     *
+     * @param baseUrl the baseUrl.
+     * @param verifiableCredentialResource the credentials resource.
+     * @return the status list credential url.
+     */
+    static String createUrl(String baseUrl, VerifiableCredentialResource verifiableCredentialResource) {
+        var base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+        return base + verifiableCredentialResource.getVerifiableCredential().credential().getId();
+    }
+
+    /**
+     * Extract the credential url from the status list
+     *
+     * @param uri the status list url.
+     * @return the credential id.
+     */
+    static String extractIdFromUrl(URI uri) {
+        var split = uri.getPath().split("/");
+        return split[split.length - 1];
+    }
+
+}


### PR DESCRIPTION
## What this PR changes/adds

Make `BitstringStatusListFactory` to extract `credentialId` from the status list url and use it to query the credential in the correct way.

## Why it does that

It was impossible to revoke a credential issued by the `BitstringStatusListManager`

## Further notes
- tests in `CredentialApiEndToEndTest` needed to be adapted to set the status list credential id properly
- shrunk scope in `CredentialStatusServiceImplTest` that was testing also the `BitstringStatusListManager`, but now it mocks it properly

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #898

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
