### PR TITLE
fix: remove revocation service registry registration

### DIFF
--- a/core/common-core/build.gradle.kts
+++ b/core/common-core/build.gradle.kts
@@ -13,9 +13,9 @@ dependencies {
     implementation(project(":core:lib:accesstoken-lib"))
     implementation(project(":core:lib:common-lib"))
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
+    implementation(libs.edc.spi.http)
     implementation(libs.edc.spi.transaction)
     implementation(libs.edc.spi.jwt.signer)
-    implementation(libs.edc.verifiablecredentials)
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)
     implementation(libs.edc.lib.store)

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.spi.persistence.EdcPersistenceException;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,6 +102,7 @@ class CredentialRequestManagerImplTest {
                 .thenReturn(success(Json.createObjectBuilder().build()));
         when(sts.createToken(anyString(), anyMap(), ArgumentMatchers.isNull())).thenReturn(success(TokenRepresentation.Builder.newInstance().build()));
         when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.success(participantContext()));
+        when(store.save(any())).thenReturn(StoreResult.success());
     }
 
     private IdentityHubParticipantContext participantContext() {


### PR DESCRIPTION
## What this PR changes/adds

Remove revocation service registry registration from `common-core`, as it is already registered in the `verifiable-credentials` module in Connector repo (see https://github.com/eclipse-edc/Connector/pull/5502)

## Why it does that

_Briefly state why the change was necessary._

## Further notes
- removed `verifiable-credentials` dependency from `common-core`, as core modules should never depend on extensions anyway.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #916 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
