### PR TITLE
ci: add mimetype setting to fix tests

### DIFF
--- a/e2e-tests/identityhub-test-fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/DefaultRuntimes.java
+++ b/e2e-tests/identityhub-test-fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/DefaultRuntimes.java
@@ -111,6 +111,7 @@ public interface DefaultRuntimes {
                     put("edc.iam.sts.privatekey.alias", "user1-alias"); //this must be "username"-alias
                     put("edc.iam.did.web.use.https", "false");
                     put("edc.encryption.strict", "false");
+                    put("edc.iam.credential.revocation.mimetype", "*/*");
                 }
             });
         }


### PR DESCRIPTION
## What this PR changes/adds

Explicitly set "*/*" mimetype, to fix flaky e2e tests.

## Why it does that

the services are currently registered with simple "*" that's not valid according to `StatusListCredentialController`

## Further notes

at the moment 2 sets of status list revocation services are registered upstream. some tangles need to be untied.


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Part of #916 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
