### PR TITLE
fix: uniform StatusList signature on update

### DIFF
--- a/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/CredentialDefaultServiceExtension.java
+++ b/core/issuerservice/issuerservice-credentials/src/main/java/org/eclipse/edc/issuerservice/credentials/CredentialDefaultServiceExtension.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2026 Think-it GmbH
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Think-it GmbH - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.credentials;
+
+import org.eclipse.edc.identityhub.spi.participantcontext.IdentityHubParticipantContextService;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
+import org.eclipse.edc.issuerservice.credentials.statuslist.StatusListInfoFactoryRegistryImpl;
+import org.eclipse.edc.issuerservice.credentials.statuslist.bitstring.BitstringStatusListManager;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListCredentialPublisher;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListInfoFactoryRegistry;
+import org.eclipse.edc.issuerservice.spi.credentials.statuslist.StatusListManager;
+import org.eclipse.edc.issuerservice.spi.issuance.generator.CredentialGeneratorRegistry;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.spi.system.ServiceExtension;
+import org.eclipse.edc.transaction.spi.TransactionContext;
+
+@Extension(CredentialDefaultServiceExtension.NAME)
+public class CredentialDefaultServiceExtension implements ServiceExtension {
+
+    public static final String NAME = "Issuer Service Credential Default Services";
+
+    @Inject
+    private StatusListCredentialPublisher credentialPublisher;
+    @Inject
+    private TransactionContext transactionContext;
+    @Inject
+    private CredentialStore store;
+    @Inject
+    private CredentialGeneratorRegistry registry;
+    @Inject
+    private IdentityHubParticipantContextService participantContextService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public StatusListInfoFactoryRegistry statusListInfoFactoryRegistry() {
+        return new StatusListInfoFactoryRegistryImpl();
+    }
+
+    @Provider(isDefault = true)
+    public StatusListManager statusListManager() {
+        return new BitstringStatusListManager(store, transactionContext, registry, participantContextService, credentialPublisher);
+    }
+}

--- a/core/issuerservice/issuerservice-credentials/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/issuerservice/issuerservice-credentials/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -11,4 +11,5 @@
 #       Cofinity-X - initial API and implementation
 #
 #
+org.eclipse.edc.issuerservice.credentials.CredentialDefaultServiceExtension
 org.eclipse.edc.issuerservice.credentials.CredentialServiceExtension

--- a/docs/developer/architecture/issuer/credential-revocation/credential-revocation.md
+++ b/docs/developer/architecture/issuer/credential-revocation/credential-revocation.md
@@ -154,13 +154,10 @@ in the next step.
 
 #### 4. re-encode status list credential
 
-After the status bit is updated, the status list credential object is encoded as JWT and signed with the given private
-key.
-> this private key is configured using the `edc.issuer.statuslist.signing.key.alias` config property
+After the status bit is updated, the status list credential object is encoded as JWT and signed.
 
 Technically speaking, this updates the `VerifiableCredentialResource#verifiableCredential#rawVc` value with the signed
-and
-serialized JWT.
+and serialized JWT.
 
 #### 5. update status list credential and holder credential
 

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialApiEndToEndTest.java
@@ -135,6 +135,7 @@ public class CredentialApiEndToEndTest {
                     .issuerId("issuer-id")
                     .holderId("holder-id")
                     .id(UUID.randomUUID().toString())
+                    .participantContextId(USER)
                     .credential(new VerifiableCredentialContainer(credentialJwt, CredentialFormat.VC1_0_JWT, credential))
                     .build();
         } catch (JsonProcessingException e) {
@@ -471,7 +472,6 @@ public class CredentialApiEndToEndTest {
         @Test
         void sendCredentialOffer_holderDidResolutionFailure(IssuerService issuer, HolderStore holderStore) {
 
-            var port = getFreePort();
             when(DID_RESOLVER_REGISTRY.resolve(eq("did:web:holder")))
                     .thenReturn(Result.failure("did not found"));
 

--- a/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
+++ b/e2e-tests/bom-tests/src/test/java/org/eclipse/edc/test/bom/BomSmokeTests.java
@@ -135,7 +135,6 @@ public class BomSmokeTests {
                                 put("web.http.issuance.port", valueOf(getFreePort()));
                                 put("edc.sts.account.api.url", "https://sts.com/accounts");
                                 put("edc.sts.accounts.api.auth.header.value", "password");
-                                put("edc.issuer.statuslist.signing.key.alias", "signing-key");
                                 // interaction with embedded STS
                                 put("edc.iam.sts.publickey.id", "test-public-key");
                                 put("edc.iam.sts.privatekey.alias", "test-private-key");

--- a/e2e-tests/identityhub-test-fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/DefaultRuntimes.java
+++ b/e2e-tests/identityhub-test-fixtures/src/testFixtures/java/org/eclipse/edc/identityhub/tests/fixtures/DefaultRuntimes.java
@@ -14,14 +14,7 @@
 
 package org.eclipse.edc.identityhub.tests.fixtures;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import org.eclipse.edc.junit.utils.Endpoints;
-import org.eclipse.edc.runtime.metamodel.annotation.Inject;
-import org.eclipse.edc.spi.security.Vault;
-import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.spi.system.configuration.Config;
 import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 
@@ -56,39 +49,16 @@ public interface DefaultRuntimes {
                 .endpoint(IH_DID, () -> URI.create("http://localhost:" + getFreePort() + "/"))
                 .endpoint("statuslist", () -> URI.create("http://localhost:" + getFreePort() + "/statuslist"));
 
-        String SIGNING_KEY_ALIAS = "signing-key";
-
         static Config config() {
             return ConfigFactory.fromMap(new HashMap<>() {
                 {
                     put("edc.iam.accesstoken.jti.validation", String.valueOf(true));
-                    put("edc.issuer.statuslist.signing.key.alias", SIGNING_KEY_ALIAS);
                     put("edc.iam.did.web.use.https", "false");
                     put("edc.encryption.strict", "false");
                 }
             });
         }
 
-        static ServiceExtension seedSigningKeyFor(String participantContextId) {
-            return new ServiceExtension() {
-                @Inject
-                private Vault vault;
-
-                @Override
-                public String name() {
-                    return "Seed signing key for participantContextId " + participantContextId;
-                }
-
-                @Override
-                public void initialize(ServiceExtensionContext context) {
-                    try {
-                        vault.storeSecret(participantContextId, SIGNING_KEY_ALIAS, new ECKeyGenerator(Curve.P_256).generate().toJSONString());
-                    } catch (JOSEException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            };
-        }
     }
 
     interface IdentityHub {
@@ -112,6 +82,8 @@ public interface DefaultRuntimes {
                     put("edc.iam.did.web.use.https", "false");
                     put("edc.encryption.strict", "false");
                     put("edc.iam.credential.revocation.mimetype", "*/*");
+                    put("edc.iam.credential.status.check.period", "1");
+                    put("edc.iam.credential.status.check.delay", "0");
                 }
             });
         }

--- a/e2e-tests/launcher-tests/src/test/java/org/eclipse/edc/test/launcher/LauncherTest.java
+++ b/e2e-tests/launcher-tests/src/test/java/org/eclipse/edc/test/launcher/LauncherTest.java
@@ -44,7 +44,6 @@ public class LauncherTest {
 
         var dockerfile = findBuildRoot().toPath().resolve("launcher").resolve(launcherName).resolve("Dockerfile");
         var runtime = new GenericContainer<>(new ImageFromDockerfile().withDockerfile(dockerfile))
-                .withEnv("edc.issuer.statuslist.signing.key.alias", "any")
                 .withEnv("edc.iam.oauth2.jwks.url", "https://example.com/jwks.jsons") // oauth2 launcher uses this
                 .waitingFor(forHealthcheck())
                 .withLogConsumer(f -> System.out.println(f.getUtf8StringWithoutLineEnding()));

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2026-01-27T16:00:00Z",
+    "lastUpdated": "2026-02-17T16:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
+++ b/extensions/api/identity-api/verifiable-credentials-api/src/main/java/org/eclipse/edc/identityhub/api/verifiablecredentials/v1/unstable/VerifiableCredentialsApiController.java
@@ -44,7 +44,6 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCre
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
-import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.eclipse.edc.util.string.StringUtils;
@@ -199,8 +198,4 @@ public class VerifiableCredentialsApiController implements VerifiableCredentials
                 .orElseThrow(() -> new ObjectNotFoundException(HolderCredentialRequest.class, holderPid));
     }
 
-    private Result<Criterion> filterByParticipantContext(String participantContext) {
-        return onEncoded(participantContext)
-                .map(pc -> new Criterion("participantContextId", "=", pc));
-    }
 }

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1alpha",
-    "lastUpdated": "2025-12-02T16:00:00Z",
+    "lastUpdated": "2026-02-17T16:00:00Z",
     "maturity": null
   }
 ]

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/VerifiableCredentialResource.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/VerifiableCredentialResource.java
@@ -120,6 +120,19 @@ public class VerifiableCredentialResource extends IdentityResource {
         return usage;
     }
 
+    @Override
+    public String toString() {
+        return "VerifiableCredentialResource{" +
+                "usage=" + usage +
+                ", state=" + state +
+                ", timeOfLastStatusUpdate=" + timeOfLastStatusUpdate +
+                ", issuancePolicy=" + issuancePolicy +
+                ", reissuancePolicy=" + reissuancePolicy +
+                ", verifiableCredential=" + verifiableCredential +
+                ", metadata=" + metadata +
+                '}';
+    }
+
     public static class Builder extends IdentityResource.Builder<VerifiableCredentialResource, Builder> {
 
         protected Builder(VerifiableCredentialResource resource) {


### PR DESCRIPTION
## What this PR changes/adds

Use `CredentialGeneratorRegistry` to sign the status list also on update after revocation in `CredentialStatusService` like it's done on it's generation

## Why it does that

permit revocation, keep status list JWT structure consistent

## Further notes
- extracted a `CredentialDefaultServiceExtension` to keep `CredentialServiceExtension` tidier
- removed setting `edc.issuer.statuslist.signing.key.alias`: the key used to sign the updated status list is the same that it has been used to sign it on generation, and it's already managed by the `KeyPairService`


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #920 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
