### PR TITLE
fix: add missing sql dependency to sql boms

### DIFF
--- a/dist/bom/identityhub-feature-sql-bom/build.gradle.kts
+++ b/dist/bom/identityhub-feature-sql-bom/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly(libs.edc.sql.jtivdalidation)
     runtimeOnly(libs.edc.sql.lease.core)
     runtimeOnly(libs.edc.sql.participantcontext)
+    runtimeOnly(libs.edc.sql.participantcontext.config)
 
     // third-party deps
     runtimeOnly(libs.postgres)

--- a/dist/bom/issuerservice-feature-sql-bom/build.gradle.kts
+++ b/dist/bom/issuerservice-feature-sql-bom/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     runtimeOnly(libs.edc.sql.jtivdalidation)
     runtimeOnly(libs.edc.sql.lease.core)
     runtimeOnly(libs.edc.sql.participantcontext)
+    runtimeOnly(libs.edc.sql.participantcontext.config)
 
     // third-party deps
     runtimeOnly(libs.postgres)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,15 +85,17 @@ edc-lib-token = { module = "org.eclipse.edc:token-lib", version.ref = "edc" }
 edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
 edc-lib-util = { module = "org.eclipse.edc:util-lib", version.ref = "edc" }
 edc-lib-validator = { module = "org.eclipse.edc:validator-lib", version.ref = "edc" }
+
 # SQL dependencies
 edc-sql-bootstrapper = { module = "org.eclipse.edc:sql-bootstrapper", version.ref = "edc" }
 edc-sql-core = { module = "org.eclipse.edc:sql-core", version.ref = "edc" }
+edc-sql-jtivdalidation = { module = "org.eclipse.edc:jti-validation-store-sql", version.ref = "edc" }
 edc-sql-lease = { module = "org.eclipse.edc:sql-lease", version.ref = "edc" }
 edc-sql-lease-core = { module = "org.eclipse.edc:sql-lease-core", version.ref = "edc" }
-edc-sql-jtivdalidation = { module = "org.eclipse.edc:jti-validation-store-sql", version.ref = "edc" }
+edc-sql-participantcontext = { module = "org.eclipse.edc:participantcontext-store-sql", version.ref = "edc" }
+edc-sql-participantcontext-config = { module = "org.eclipse.edc:participantcontext-config-store-sql", version.ref = "edc" }
 edc-sql-pool = { module = "org.eclipse.edc:sql-pool-apache-commons", version.ref = "edc" }
 edc-sql-test-fixtures = { module = "org.eclipse.edc:sql-test-fixtures", version.ref = "edc" }
-edc-sql-participantcontext = { module = "org.eclipse.edc:participantcontext-store-sql", version.ref = "edc" }
 
 # Third party libs
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }


### PR DESCRIPTION
## What this PR changes/adds

Add missing participantcontext-config sql dependency to sql boms

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #927

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
