### PR TITLE
fix: adopt EDC build 1.4.0

### DIFF
--- a/core/common-core/build.gradle.kts
+++ b/core/common-core/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
     implementation(libs.edc.spi.http)
     implementation(libs.edc.spi.transaction)
-    implementation(libs.edc.spi.jwt.signer)
+    implementation(libs.edc.spi.jwt)
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)
     implementation(libs.edc.lib.store)

--- a/core/common-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
+++ b/core/common-core/src/main/java/org/eclipse/edc/identityhub/DefaultServicesExtension.java
@@ -29,7 +29,7 @@ import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransforme
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialOfferStore;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.jsonld.spi.JsonLd;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;

--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(project(":core:lib:common-lib"))
     implementation(libs.edc.spi.dcp) //SignatureSuiteRegistry
     implementation(libs.edc.spi.transaction)
-    implementation(libs.edc.spi.jwt.signer)
+    implementation(libs.edc.spi.jwt)
     implementation(libs.edc.verifiablecredentials)
     implementation(libs.edc.jsonld) // for the JSON-LD mapper
     implementation(libs.edc.lib.util)

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/CoreServicesExtension.java
@@ -55,7 +55,7 @@ import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialSto
 import org.eclipse.edc.identityhub.spi.verification.SelfIssuedTokenVerifier;
 import org.eclipse.edc.jsonld.spi.JsonLd;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.keys.spi.LocalPublicKeyService;
 import org.eclipse.edc.keys.spi.PrivateKeyResolver;

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtEnvelopedPresentationGeneratorTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtEnvelopedPresentationGeneratorTest.java
@@ -25,7 +25,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.JwtGenerationService;

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtPresentationGeneratorTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtPresentationGeneratorTest.java
@@ -22,7 +22,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.JwtGenerationService;

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verification/SelfIssuedTokenVerifierImplComponentTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verification/SelfIssuedTokenVerifierImplComponentTest.java
@@ -107,7 +107,7 @@ class SelfIssuedTokenVerifierImplComponentTest {
 
         var selfIssuedIdToken = createSignedJwt(spoofedKey, new JWTClaimsSet.Builder().claim("foo", "bar").jwtID(UUID.randomUUID().toString()).build());
         assertThat(verifier.verify(selfIssuedIdToken, PARTICIPANT_CONTEXT_ID)).isFailed()
-                .detail().isEqualTo("Token verification failed");
+                .detail().isEqualTo("JWT signature not valid");
 
     }
 
@@ -246,7 +246,7 @@ class SelfIssuedTokenVerifierImplComponentTest {
                 .build());
 
         assertThat(verifier.verify(siToken, PARTICIPANT_CONTEXT_ID)).isFailed()
-                .detail().isEqualTo("Token verification failed");
+                .detail().isEqualTo("JWT signature not valid");
     }
 
     @Test

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/IssuanceServicesExtension.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/IssuanceServicesExtension.java
@@ -41,7 +41,7 @@ import org.eclipse.edc.issuerservice.spi.issuance.mapping.IssuanceClaimsMapper;
 import org.eclipse.edc.issuerservice.spi.issuance.rule.CredentialRuleDefinitionEvaluator;
 import org.eclipse.edc.issuerservice.spi.issuance.rule.CredentialRuleDefinitionValidatorRegistry;
 import org.eclipse.edc.issuerservice.spi.issuance.rule.CredentialRuleFactoryRegistry;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JoseVcdm20CredentialGeneratorTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JoseVcdm20CredentialGeneratorTest.java
@@ -28,7 +28,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.token.spi.TokenGenerationService;

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGeneratorTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JwtCredentialGeneratorTest.java
@@ -28,7 +28,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.token.spi.TokenGenerationService;

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialOfferApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialOfferApiEndToEndTest.java
@@ -178,7 +178,7 @@ public class CredentialOfferApiEndToEndTest {
                     .then()
                     .log().ifValidationFails()
                     .statusCode(403)
-                    .body(containsString("Token verification failed"));
+                    .body(containsString("ID token verification failed: JWT signature not valid"));
         }
 
         @DisplayName("CredentialMessage contains an illegal format, expect HTTP 400")

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
@@ -251,7 +251,7 @@ public class PresentationApiEndToEndTest {
                     .statusCode(401)
                     .log().ifValidationFails()
                     .body("[0].type", equalTo("AuthenticationFailed"))
-                    .body("[0].message", equalTo("ID token verification failed: Token verification failed"));
+                    .body("[0].message", equalTo("ID token verification failed: JWT signature not valid"));
         }
 
         @Test

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/StorageApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/StorageApiEndToEndTest.java
@@ -177,7 +177,7 @@ public class StorageApiEndToEndTest {
                     .then()
                     .log().ifValidationFails()
                     .statusCode(401)
-                    .body(containsString("Token verification failed"));
+                    .body(containsString("ID token verification failed: JWT signature not valid"));
         }
 
         @DisplayName("CredentialMessage contains an illegal format, expect HTTP 400")

--- a/extensions/sts/sts-core/build.gradle.kts
+++ b/extensions/sts/sts-core/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     api(libs.edc.spi.transaction)
     api(libs.edc.spi.dcp)
     api(project(":spi:sts-spi"))
-    api(libs.edc.spi.jwt.signer)
+    api(libs.edc.spi.jwt)
 
     implementation(libs.edc.spi.keys)
     implementation(project(":extensions:sts:sts-account-service-local"))

--- a/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/EmbeddedStsServiceExtension.java
+++ b/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/EmbeddedStsServiceExtension.java
@@ -20,7 +20,7 @@ import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsAccountService
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsClientTokenGeneratorService;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
-import org.eclipse.edc.jwt.signer.spi.JwsSignerProvider;
+import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,6 @@ edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-config-fs = { module = "org.eclipse.edc:configuration-filesystem", version.ref = "edc" }
 edc-spi-core = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-spi-jwt = { module = "org.eclipse.edc:jwt-spi", version.ref = "edc" }
-edc-spi-jwt-signer = { module = "org.eclipse.edc:jwt-signer-spi", version.ref = "edc" }
 edc-spi-http = { module = "org.eclipse.edc:http-spi", version.ref = "edc" }
 edc-spi-keys = { module = "org.eclipse.edc:keys-spi", version.ref = "edc" }
 edc-spi-participantcontext-config = { module = "org.eclipse.edc:participant-context-config-spi", version.ref = "edc" }
@@ -139,5 +138,5 @@ connector = [
 ]
 
 [plugins]
-edc-build = { id = "org.eclipse.edc.edc-build", version = "1.3.0" }
+edc-build = { id = "org.eclipse.edc.edc-build", version = "1.4.0" }
 shadow = { id = "com.gradleup.shadow", version = "9.4.1" }


### PR DESCRIPTION
## What this PR changes/adds

this adopts the EDC build plugin 1.4.0 and fixes some compilation errors due to recent changes in EDC as well

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
