### PR TITLE
feat: add OpenTelemetry traces

### DIFF
--- a/core/identity-hub-core/build.gradle.kts
+++ b/core/identity-hub-core/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation(libs.edc.spi.identity.did)
     implementation(libs.edc.vc.ldp)
     implementation(libs.edc.vc.jwt) // JtiValidationRule
-
+    implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(project(":core:common-core"))
     testImplementation(libs.junit.jupiter.api)

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImpl.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.core.services.query;
 
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.decentralizedclaims.spi.model.PresentationQueryMessage;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.RevocationServiceRegistry;
 import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
@@ -55,6 +57,7 @@ public class CredentialQueryResolverImpl implements CredentialQueryResolver {
     }
 
     @Override
+    @WithSpan(value = "presentation.credential-query", kind = SpanKind.INTERNAL)
     public QueryResult query(String participantContextId, PresentationQueryMessage query, List<String> accessTokenScopes) {
         if (query.getPresentationDefinition() != null) {
             throw new UnsupportedOperationException("Querying with a DIF Presentation Exchange definition is not yet supported.");

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.edc.identityhub.core.services.verifiablecredential;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.json.JsonObject;
 import okhttp3.MediaType;
 import okhttp3.Request;
@@ -39,6 +42,7 @@ import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.statemachine.AbstractStateEntityManager;
 import org.eclipse.edc.statemachine.Processor;
 import org.eclipse.edc.statemachine.ProcessorImpl;
@@ -83,8 +87,11 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
 
     }
 
+    @WithSpan(value = "credential-request.initiate", kind = SpanKind.INTERNAL)
     @Override
     public ServiceResult<String> initiateRequest(String participantContextId, String issuerDid, String holderPid, List<RequestedCredential> requestedCredentials) {
+
+        var traceContext = new Telemetry(GlobalOpenTelemetry.get()).getCurrentTraceContext();
 
         var newRequest = HolderCredentialRequest.Builder.newInstance()
                 .id(holderPid)
@@ -92,6 +99,7 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
                 .requestedCredentials(requestedCredentials)
                 .participantContextId(participantContextId)
                 .state(CREATED.code())
+                .traceContext(traceContext)
                 .build();
 
         try {
@@ -170,13 +178,16 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
     private CompletableFuture<StatusResult<Void>> processInitial(HolderCredentialRequest holderCredentialRequest) {
         monitor.debug("Processing '%s' request '%s'".formatted(holderCredentialRequest.stateAsString(), holderCredentialRequest.getHolderPid()));
 
-        var result = getCredentialRequestEndpoint(holderCredentialRequest)
-                .compose(endpoint -> sendCredentialRequest(holderCredentialRequest, endpoint))
-                .compose(issuerPid -> handleCredentialResponse(issuerPid, holderCredentialRequest))
-                .onFailure(failure -> transactionContext.execute(() -> transitionError(holderCredentialRequest, failure.getFailureDetail())));
+        return new Telemetry(GlobalOpenTelemetry.get()).contextPropagationMiddleware(() -> {
+            var result = getCredentialRequestEndpoint(holderCredentialRequest)
+                    .compose(endpoint -> sendCredentialRequest(holderCredentialRequest, endpoint))
+                    .compose(issuerPid -> handleCredentialResponse(issuerPid, holderCredentialRequest))
+                    .onFailure(failure -> transactionContext.execute(() -> transitionError(holderCredentialRequest, failure.getFailureDetail())));
 
-        StatusResult<Void> statusResult = result.succeeded() ? StatusResult.success() : StatusResult.failure(ResponseStatus.FATAL_ERROR, result.getFailureDetail());
-        return CompletableFuture.completedFuture(statusResult);
+            StatusResult<Void> statusResult = result.succeeded() ? StatusResult.success() : StatusResult.failure(ResponseStatus.FATAL_ERROR, result.getFailureDetail());
+            return CompletableFuture.completedFuture(statusResult);
+        }, holderCredentialRequest).get();
+
     }
 
     /**

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtEnvelopedPresentationGenerator.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtEnvelopedPresentationGenerator.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.core.services.verifiablepresentation.generators;
 
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.PresentationGenerator;
@@ -62,6 +64,7 @@ public class JwtEnvelopedPresentationGenerator implements PresentationGenerator<
     }
 
     @Override
+    @WithSpan(value = "presentation.create", kind = SpanKind.INTERNAL)
     public String generatePresentation(String participantContextId, List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, String issuerId, Map<String, Object> additionalData) {
         var violatingCredentials = credentials.stream().filter(vc -> vc.format() != CredentialFormat.VC2_0_JOSE).toList();
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtPresentationGenerator.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/JwtPresentationGenerator.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.core.services.verifiablepresentation.generators;
 
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.verifiablecredentials.spi.VcConstants;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.PresentationGenerator;
@@ -81,6 +83,7 @@ public class JwtPresentationGenerator implements PresentationGenerator<String> {
      * @throws EdcException                  If signing the JWT fails.
      */
     @Override
+    @WithSpan(value = "presentation.create", kind = SpanKind.INTERNAL)
     public String generatePresentation(String participantContextId, List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, String issuerId, Map<String, Object> additionalData) {
 
         // check if expected data is there

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablepresentation/generators/LdpPresentationGenerator.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.identityhub.core.services.verifiablepresentation.generat
 
 import com.apicatalog.vc.suite.SignatureSuite;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonArrayBuilder;
@@ -108,6 +110,7 @@ public class LdpPresentationGenerator implements PresentationGenerator<JsonObjec
      *                                  or if one or more VerifiableCredentials cannot be represented in the JSON-LD format.
      */
     @Override
+    @WithSpan(value = "presentation.create", kind = SpanKind.INTERNAL)
     public JsonObject generatePresentation(String participantContextId, List<VerifiableCredentialContainer> credentials, String privateKeyAlias, String publicKeyId, String issuerId, Map<String, Object> additionalData) {
         if (!additionalData.containsKey(TYPE_ADDITIONAL_DATA)) {
             throw new IllegalArgumentException("Must provide additional data: '%s'".formatted(TYPE_ADDITIONAL_DATA));

--- a/core/identity-hub-did/build.gradle.kts
+++ b/core/identity-hub-did/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     implementation(libs.edc.spi.transaction)
     implementation(libs.edc.lib.common.crypto)
     implementation(libs.edc.lib.store)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(libs.edc.lib.query)
     testImplementation(libs.edc.junit)

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -14,6 +14,9 @@
 
 package org.eclipse.edc.identityhub.did;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.document.Service;
 import org.eclipse.edc.iam.did.spi.document.VerificationMethod;
@@ -24,6 +27,7 @@ import org.eclipse.edc.identityhub.spi.did.model.DidState;
 import org.eclipse.edc.identityhub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
+import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextEvent;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.participantcontext.spi.store.ParticipantContextStore;
@@ -72,6 +76,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     }
 
     @Override
+    @WithSpan(value = "did-document.store", kind = SpanKind.INTERNAL)
     public ServiceResult<Void> store(DidDocument document, String participantContextId) {
         return transactionContext.execute(() -> {
             var res = DidResource.Builder.newInstance()
@@ -244,17 +249,25 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     @Override
     public <E extends Event> void on(EventEnvelope<E> eventEnvelope) {
         var payload = eventEnvelope.getPayload();
-        if (payload instanceof ParticipantContextUpdated event) {
-            updated(event);
-        } else if (payload instanceof KeyPairRevoked event) {
-            keypairRevoked(event);
-        } else if (payload instanceof KeyPairActivated event) {
-            keyPairActivated(event);
-        } else {
-            monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
+        var spanCtx = Span.current().getSpanContext();
+        if (payload instanceof ParticipantContextEvent event) {
+            spanCtx = event.getSpanContext();
+        }
+
+        try (var scope = Span.wrap(spanCtx).makeCurrent()) {
+            if (payload instanceof ParticipantContextUpdated event) {
+                updated(event);
+            } else if (payload instanceof KeyPairRevoked event) {
+                keypairRevoked(event);
+            } else if (payload instanceof KeyPairActivated event) {
+                keyPairActivated(event);
+            } else {
+                monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
+            }
         }
     }
 
+    @WithSpan(value = "did-document.keypair-activated", kind = SpanKind.INTERNAL)
     private void keyPairActivated(KeyPairActivated event) {
         transactionContext.execute(() -> {
             var didResources = findByParticipantContextId(event.getParticipantContextId());
@@ -294,6 +307,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
         });
     }
 
+    @WithSpan(value = "did-document.keypair-revoked", kind = SpanKind.INTERNAL)
     private void keypairRevoked(KeyPairRevoked event) {
         var didResources = findByParticipantContextId(event.getParticipantContextId());
         var keyId = event.getKeyId();
@@ -310,6 +324,7 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
         }
     }
 
+    @WithSpan(value = "did-document.updated", kind = SpanKind.INTERNAL)
     private void updated(ParticipantContextUpdated event) {
         var newState = event.getNewState();
         var forParticipant = findByParticipantContextId(event.getParticipantContextId());

--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.did;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
@@ -27,7 +27,6 @@ import org.eclipse.edc.identityhub.spi.did.model.DidState;
 import org.eclipse.edc.identityhub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairActivated;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairRevoked;
-import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextEvent;
 import org.eclipse.edc.identityhub.spi.participantcontext.events.ParticipantContextUpdated;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
 import org.eclipse.edc.participantcontext.spi.store.ParticipantContextStore;
@@ -42,11 +41,14 @@ import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.AbstractResult;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+import org.eclipse.edc.spi.telemetry.TraceCarrier;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.util.Collection;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
@@ -249,12 +251,9 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
     @Override
     public <E extends Event> void on(EventEnvelope<E> eventEnvelope) {
         var payload = eventEnvelope.getPayload();
-        var spanCtx = Span.current().getSpanContext();
-        if (payload instanceof ParticipantContextEvent event) {
-            spanCtx = event.getSpanContext();
-        }
 
-        try (var scope = Span.wrap(spanCtx).makeCurrent()) {
+
+        var s = (Supplier<Void>) () -> {
             if (payload instanceof ParticipantContextUpdated event) {
                 updated(event);
             } else if (payload instanceof KeyPairRevoked event) {
@@ -264,7 +263,15 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
             } else {
                 monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
             }
+            return null;
+        };
+
+        if (payload instanceof TraceCarrier carrier) {
+            new Telemetry(GlobalOpenTelemetry.get()).contextPropagationMiddleware(s, carrier).get();
+        } else {
+            s.get();
         }
+
     }
 
     @WithSpan(value = "did-document.keypair-activated", kind = SpanKind.INTERNAL)

--- a/core/identity-hub-keypairs/build.gradle.kts
+++ b/core/identity-hub-keypairs/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     api(libs.edc.spi.transaction)
     implementation(project(":core:lib:keypair-lib"))
     implementation(libs.edc.lib.common.crypto)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.instrumentation.annotations)
     runtimeOnly(libs.edc.core.connector)
     testImplementation(libs.edc.junit)
 }

--- a/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
+++ b/core/identity-hub-keypairs/src/main/java/org/eclipse/edc/identityhub/keypairs/KeyPairServiceImpl.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.keypairs;
 
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.events.KeyPairObservable;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
@@ -72,6 +74,7 @@ public class KeyPairServiceImpl implements KeyPairService, EventSubscriber {
     }
 
     @Override
+    @WithSpan(value = "keypairs.add", kind = SpanKind.INTERNAL)
     public ServiceResult<Void> addKeyPair(String participantContextId, KeyDescriptor keyDescriptor, boolean makeDefault) {
 
         return transactionContext.execute(() -> {

--- a/core/identity-hub-participants/build.gradle.kts
+++ b/core/identity-hub-participants/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(libs.edc.spi.transaction)
     runtimeOnly(libs.bouncyCastle.bcprovJdk18on)
     implementation(libs.edc.spi.participantcontext.config)
+    implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(libs.edc.lib.keys)
     testImplementation(libs.edc.junit)

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubParticipantContextServiceImpl.java
@@ -16,6 +16,8 @@ package org.eclipse.edc.identityhub.participantcontext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.api.auth.spi.ParticipantPrincipal;
 import org.eclipse.edc.identityhub.spi.did.store.DidResourceStore;
 import org.eclipse.edc.identityhub.spi.participantcontext.IdentityHubParticipantContextService;
@@ -84,6 +86,7 @@ public class IdentityHubParticipantContextServiceImpl implements IdentityHubPart
         this.tokenGenerator = new ApiTokenGenerator();
     }
 
+    @WithSpan(value = "participant-context.create", kind = SpanKind.INTERNAL)
     @Override
     public ServiceResult<CreateParticipantContextResponse> createParticipantContext(ParticipantManifest manifest) {
         return transactionContext.execute(() -> {
@@ -148,6 +151,7 @@ public class IdentityHubParticipantContextServiceImpl implements IdentityHubPart
     }
 
     @Override
+    @WithSpan(value = "participant-context.update", kind = SpanKind.INTERNAL)
     public ServiceResult<Void> updateParticipant(String participantContextId, Consumer<IdentityHubParticipantContext> modificationFunction) {
         return transactionContext.execute(() -> {
             var participant = findByIdInternal(participantContextId);

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.participantcontext;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.identityhub.spi.did.DidDocumentService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
@@ -30,6 +32,7 @@ import org.eclipse.edc.spi.result.ServiceResult;
 
 import java.util.stream.Stream;
 
+import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
 import static org.eclipse.edc.spi.result.ServiceResult.success;
 
@@ -64,24 +67,30 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
         var payload = event.getPayload();
         if (payload instanceof ParticipantContextCreated createdEvent) {
             var manifest = createdEvent.getManifest();
-            var doc = DidDocument.Builder.newInstance()
-                    .id(manifest.getDid())
-                    .service(manifest.getServiceEndpoints().stream().toList())
-                    // updating and adding a verification method happens as a result of the KeyPairAddedEvent
-                    .build();
+            var spanCtx = ofNullable(createdEvent.getSpanContext()).orElse(Span.current().getSpanContext());
 
-            if (manifest.isActive() && manifest.getKeys().stream().noneMatch(KeyDescriptor::isActive)) {
-                monitor.warning("The ParticipantContext is 'active', but its (only) KeyPair is 'inActive'. " +
-                        "This will result in a DID Document without Verification Methods, and thus, an unusable ParticipantContext.");
+            try (Scope scope = Span.wrap(spanCtx).makeCurrent()) {
+                // spanContext is now current
+                var doc = DidDocument.Builder.newInstance()
+                        .id(manifest.getDid())
+                        .service(manifest.getServiceEndpoints().stream().toList())
+                        // updating and adding a verification method happens as a result of the KeyPairAddedEvent
+                        .build();
+
+                if (manifest.isActive() && manifest.getKeys().stream().noneMatch(KeyDescriptor::isActive)) {
+                    monitor.warning("The ParticipantContext is 'active', but its (only) KeyPair is 'inActive'. " +
+                            "This will result in a DID Document without Verification Methods, and thus, an unusable ParticipantContext.");
+                }
+
+                didDocumentService.store(doc, manifest.getParticipantContextId())
+                        // adding the keypair event will cause the DidDocumentService to update the DID
+                        .compose(u -> storeKeyPairs(createdEvent))
+                        .compose(u -> manifest.isActive()
+                                ? participantContextService.updateParticipant(manifest.getParticipantContextId(), IdentityHubParticipantContext::activate) //implicitly publishes the did document
+                                : success())
+                        .onFailure(f -> monitor.warning("%s".formatted(f.getFailureDetail())));
             }
 
-            didDocumentService.store(doc, manifest.getParticipantContextId())
-                    // adding the keypair event will cause the DidDocumentService to update the DID
-                    .compose(u -> storeKeyPairs(createdEvent))
-                    .compose(u -> manifest.isActive()
-                            ? participantContextService.updateParticipant(manifest.getParticipantContextId(), IdentityHubParticipantContext::activate) //implicitly publishes the did document
-                            : success())
-                    .onFailure(f -> monitor.warning("%s".formatted(f.getFailureDetail())));
 
         } else if (payload instanceof ParticipantContextDeleting deletionEvent) {
             var participantContext = deletionEvent.getParticipantContext();

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -14,8 +14,7 @@
 
 package org.eclipse.edc.identityhub.participantcontext;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.identityhub.spi.did.DidDocumentService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
@@ -29,10 +28,10 @@ import org.eclipse.edc.spi.event.EventEnvelope;
 import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 
 import java.util.stream.Stream;
 
-import static java.util.Optional.ofNullable;
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
 import static org.eclipse.edc.spi.result.ServiceResult.success;
 
@@ -67,10 +66,8 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
         var payload = event.getPayload();
         if (payload instanceof ParticipantContextCreated createdEvent) {
             var manifest = createdEvent.getManifest();
-            var spanCtx = ofNullable(createdEvent.getSpanContext()).orElse(Span.current().getSpanContext());
 
-            try (Scope scope = Span.wrap(spanCtx).makeCurrent()) {
-                // spanContext is now current
+            new Telemetry(GlobalOpenTelemetry.get()).contextPropagationMiddleware(() -> {
                 var doc = DidDocument.Builder.newInstance()
                         .id(manifest.getDid())
                         .service(manifest.getServiceEndpoints().stream().toList())
@@ -89,21 +86,25 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
                                 ? participantContextService.updateParticipant(manifest.getParticipantContextId(), IdentityHubParticipantContext::activate) //implicitly publishes the did document
                                 : success())
                         .onFailure(f -> monitor.warning("%s".formatted(f.getFailureDetail())));
-            }
+                return null;
+            }, createdEvent).get();
 
 
         } else if (payload instanceof ParticipantContextDeleting deletionEvent) {
             var participantContext = deletionEvent.getParticipantContext();
 
             // unpublish and delete did document, remove keypairs
-            didDocumentService.unpublish(participantContext.getDid())
-                    .compose(u -> didDocumentService.deleteById(participantContext.getDid()))
-                    .compose(u -> keyPairService.query(queryByParticipantContextId(participantContext.getParticipantContextId()).build()))
-                    .compose(keyPairs -> keyPairs.stream()
-                            .map(r -> keyPairService.revokeKey(r.getId(), null))
-                            .reduce(this::merge)
-                            .orElse(success()))
-                    .onFailure(f -> monitor.warning("Removing key pairs from a deleted ParticipantContext failed: %s".formatted(f.getFailureDetail())));
+            new Telemetry(GlobalOpenTelemetry.get()).contextPropagationMiddleware(() -> {
+                didDocumentService.unpublish(participantContext.getDid())
+                        .compose(u -> didDocumentService.deleteById(participantContext.getDid()))
+                        .compose(u -> keyPairService.query(queryByParticipantContextId(participantContext.getParticipantContextId()).build()))
+                        .compose(keyPairs -> keyPairs.stream()
+                                .map(r -> keyPairService.revokeKey(r.getId(), null))
+                                .reduce(this::merge)
+                                .orElse(success()))
+                        .onFailure(f -> monitor.warning("Removing key pairs from a deleted ParticipantContext failed: %s".formatted(f.getFailureDetail())));
+                return null;
+            }, deletionEvent);
         } else {
             monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
         }

--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/ParticipantContextEventCoordinator.java
@@ -104,7 +104,7 @@ class ParticipantContextEventCoordinator implements EventSubscriber {
                                 .orElse(success()))
                         .onFailure(f -> monitor.warning("Removing key pairs from a deleted ParticipantContext failed: %s".formatted(f.getFailureDetail())));
                 return null;
-            }, deletionEvent);
+            }, deletionEvent).get();
         } else {
             monitor.warning("Received event with unexpected payload type: %s".formatted(payload.getClass()));
         }

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/process/IssuanceProcessManagerImpl.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/process/IssuanceProcessManagerImpl.java
@@ -71,7 +71,7 @@ public class IssuanceProcessManagerImpl extends AbstractStateEntityManager<Issua
     /**
      * Process APPROVED issuance process
      */
-    @WithSpan
+    @WithSpan(value = "issuance.approved")
     private CompletableFuture<StatusResult<Void>> processApproved(IssuanceProcess process) {
         return entityRetryProcessFactory.retryProcessor(process)
                 .doProcess(result("Generate Credentials", (p, result) -> generateCredential(p)))
@@ -84,6 +84,7 @@ public class IssuanceProcessManagerImpl extends AbstractStateEntityManager<Issua
                 .execute();
     }
 
+    @WithSpan(value = "issuance.add-credentials-to-status-list")
     private StatusResult<Collection<VerifiableCredentialContainer>> addCredentialsToStatusList(IssuanceProcess issuanceProcess, Collection<VerifiableCredentialContainer> newCredentials) {
 
         var updatedCredentials = new ArrayList<VerifiableCredentialContainer>();
@@ -155,6 +156,7 @@ public class IssuanceProcessManagerImpl extends AbstractStateEntityManager<Issua
         return credential.getCredentialSubject().stream().findFirst().map(CredentialSubject::getId).orElse(null);
     }
 
+    @WithSpan(value = "issuance.deliver-credential")
     private StatusResult<Collection<VerifiableCredentialContainer>> deliverCredentials(IssuanceProcess process, Collection<VerifiableCredentialContainer> credentials) {
         var result = credentialStorageClient.deliverCredentials(process, credentials);
         if (result.succeeded()) {

--- a/extensions/did/local-did-publisher/build.gradle.kts
+++ b/extensions/did/local-did-publisher/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":spi:identity-hub-spi"))
     implementation(libs.jakarta.rsApi)
     implementation(libs.edc.spi.web)
+    implementation(libs.opentelemetry.instrumentation.annotations)
 
     testImplementation(libs.edc.junit)
     testImplementation(libs.restAssured)

--- a/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/DidWebController.java
+++ b/extensions/did/local-did-publisher/src/main/java/org/eclipse/edc/identityhub/publisher/did/local/DidWebController.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.publisher.did.local;
 
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -53,6 +55,7 @@ public class DidWebController {
         this.didWebParser = didWebParser;
     }
 
+    @WithSpan(value = "did-document.resolve", kind = SpanKind.SERVER)
     @GET
     public DidDocument getDidDocument(@Context ContainerRequestContext context) {
 

--- a/extensions/sts/sts-account-provisioner/build.gradle.kts
+++ b/extensions/sts/sts-account-provisioner/build.gradle.kts
@@ -24,5 +24,6 @@ dependencies {
     implementation(project(":spi:participant-context-spi"))
     implementation(project(":spi:keypair-spi"))
     implementation(project(":spi:did-spi"))
+    implementation(libs.opentelemetry.api)
     testImplementation(libs.edc.junit)
 }

--- a/extensions/sts/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerImpl.java
+++ b/extensions/sts/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.common.provisioner;
 
+import io.opentelemetry.api.trace.Span;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.model.StsAccount;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsAccountService;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsClientSecretGenerator;
@@ -28,6 +29,8 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.Vault;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * AccountProvisioner, that synchronizes the {@link IdentityHubParticipantContext} object
@@ -57,7 +60,10 @@ public class StsAccountProvisionerImpl implements EventSubscriber, StsAccountPro
         var payload = event.getPayload();
         ServiceResult<Void> result;
         if (payload instanceof ParticipantContextDeleted deletedEvent) {
-            result = stsAccountService.deleteAccount(deletedEvent.getParticipantContextId());
+            var spanCtx = ofNullable(deletedEvent.getSpanContext()).orElse(Span.current().getSpanContext());
+            try (var scope = Span.wrap(spanCtx).makeCurrent()) {
+                result = stsAccountService.deleteAccount(deletedEvent.getParticipantContextId());
+            }
         } else {
             result = ServiceResult.badRequest("Received event with unexpected payload type: %s".formatted(payload.getClass()));
         }

--- a/extensions/sts/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerImpl.java
+++ b/extensions/sts/sts-account-provisioner/src/main/java/org/eclipse/edc/identityhub/common/provisioner/StsAccountProvisionerImpl.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.common.provisioner;
 
-import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.model.StsAccount;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsAccountService;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsClientSecretGenerator;
@@ -29,8 +29,7 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.security.Vault;
-
-import static java.util.Optional.ofNullable;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 
 /**
  * AccountProvisioner, that synchronizes the {@link IdentityHubParticipantContext} object
@@ -60,10 +59,9 @@ public class StsAccountProvisionerImpl implements EventSubscriber, StsAccountPro
         var payload = event.getPayload();
         ServiceResult<Void> result;
         if (payload instanceof ParticipantContextDeleted deletedEvent) {
-            var spanCtx = ofNullable(deletedEvent.getSpanContext()).orElse(Span.current().getSpanContext());
-            try (var scope = Span.wrap(spanCtx).makeCurrent()) {
-                result = stsAccountService.deleteAccount(deletedEvent.getParticipantContextId());
-            }
+            result = new Telemetry(GlobalOpenTelemetry.get()).contextPropagationMiddleware(() -> {
+                return stsAccountService.deleteAccount(deletedEvent.getParticipantContextId());
+            }, deletedEvent).get();
         } else {
             result = ServiceResult.badRequest("Received event with unexpected payload type: %s".formatted(payload.getClass()));
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,8 @@ jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api", ver
 jersey-common = { module = "org.glassfish.jersey.core:jersey-common", version.ref = "jersey" }
 tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
 opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry" }
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version = "1.61.0" }
+opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry" }
 
 # DCP-TCK libraries
 dcp-testcases = { module = "org.eclipse.dataspacetck.dcp:dcp-testcases", version.ref = "dcp-tck" }

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/build.gradle.kts
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     implementation(libs.edc.vc.jwt)
     implementation(libs.edc.lib.token)
     implementation(libs.nimbus.jwt)
+    implementation(libs.opentelemetry.instrumentation.annotations)
+    implementation(libs.opentelemetry.api)
     testImplementation(libs.edc.junit)
     testImplementation(testFixtures(project(":spi:verifiable-credential-spi")))
 }

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImpl.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImpl.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.protocols.dcp.issuer;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.identityhub.protocols.dcp.issuer.spi.DcpIssuerService;
 import org.eclipse.edc.identityhub.protocols.dcp.spi.DcpProfileRegistry;
@@ -30,6 +32,7 @@ import org.eclipse.edc.issuerservice.spi.issuance.rule.CredentialRuleDefinitionE
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.telemetry.Telemetry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.util.Collection;
@@ -60,6 +63,7 @@ public class DcpIssuerServiceImpl implements DcpIssuerService {
         this.profileRegistry = profileRegistry;
     }
 
+    @WithSpan(value = "issuance.initiate")
     @Override
     public ServiceResult<CredentialRequestMessage.Response> initiateCredentialsIssuance(String participantContextId, CredentialRequestMessage message, DcpRequestContext context) {
         if (message.getCredentials().isEmpty()) {
@@ -143,6 +147,7 @@ public class DcpIssuerServiceImpl implements DcpIssuerService {
 
     private ServiceResult<IssuanceProcess> createIssuanceProcess(String participantContextId, String holderPid, Map<String, CredentialFormat> credentialFormats, DcpRequestContext context, AttestationEvaluationResponse evaluationResponse) {
 
+
         var credentialDefinitionIds = evaluationResponse.credentialDefinitions().stream()
                 .map(CredentialDefinition::getId)
                 .collect(Collectors.toSet());
@@ -153,6 +158,7 @@ public class DcpIssuerServiceImpl implements DcpIssuerService {
                 .claims(evaluationResponse.claims())
                 .participantContextId(participantContextId)
                 .holderPid(holderPid)
+                .traceContext(new Telemetry(GlobalOpenTelemetry.get()).getCurrentTraceContext())
                 .credentialFormats(credentialFormats)
                 .build();
 

--- a/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderCredentialRequest.java
+++ b/spi/holder-credential-request-spi/src/main/java/org/eclipse/edc/identityhub/spi/credential/request/model/HolderCredentialRequest.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.identityhub.spi.credential.request.model;
 
 import org.eclipse.edc.spi.entity.Entity;
 import org.eclipse.edc.spi.entity.StatefulEntity;
+import org.eclipse.edc.spi.telemetry.TraceCarrier;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,7 @@ import static org.eclipse.edc.identityhub.spi.credential.request.model.HolderReq
  * <p>
  * Note: This is the holder-side equivalent of the issuer's {@code IssuanceProcess}
  */
-public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequest> {
+public class HolderCredentialRequest extends StatefulEntity<HolderCredentialRequest> implements TraceCarrier {
 
     private String participantContextId;
     private String issuerDid;

--- a/spi/participant-context-spi/build.gradle.kts
+++ b/spi/participant-context-spi/build.gradle.kts
@@ -22,5 +22,6 @@ val swagger: String by project
 dependencies {
     api(libs.edc.spi.participantcontext)
     implementation(libs.edc.spi.identity.did) // ParticipantManifest#serviceEndpoint
+    implementation(libs.opentelemetry.api)
     testImplementation(libs.edc.lib.json)
 }

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextEvent.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextEvent.java
@@ -34,6 +34,7 @@ public abstract class ParticipantContextEvent extends Event implements TraceCarr
         return participantContextId;
     }
 
+    @Override
     public Map<String, String> getTraceContext() {
         return traceContext;
     }

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextEvent.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextEvent.java
@@ -14,6 +14,8 @@
 
 package org.eclipse.edc.identityhub.spi.participantcontext.events;
 
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.IdentityHubParticipantContext;
 import org.eclipse.edc.spi.event.Event;
 
@@ -24,9 +26,14 @@ import java.util.Objects;
  */
 public abstract class ParticipantContextEvent extends Event {
     protected String participantContextId;
+    protected SpanContext spanContext;
 
     public String getParticipantContextId() {
         return participantContextId;
+    }
+
+    public SpanContext getSpanContext() {
+        return spanContext;
     }
 
     public abstract static class Builder<T extends ParticipantContextEvent, B extends ParticipantContextEvent.Builder<T, B>> {
@@ -46,6 +53,7 @@ public abstract class ParticipantContextEvent extends Event {
 
         public T build() {
             Objects.requireNonNull((event.participantContextId));
+            event.spanContext = Span.current().getSpanContext();
             return event;
         }
     }

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextEvent.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/events/ParticipantContextEvent.java
@@ -14,26 +14,28 @@
 
 package org.eclipse.edc.identityhub.spi.participantcontext.events;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.IdentityHubParticipantContext;
 import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.telemetry.Telemetry;
+import org.eclipse.edc.spi.telemetry.TraceCarrier;
 
+import java.util.Map;
 import java.util.Objects;
 
 /**
  * Base class for all events related to state changes and actions of {@link IdentityHubParticipantContext}s
  */
-public abstract class ParticipantContextEvent extends Event {
+public abstract class ParticipantContextEvent extends Event implements TraceCarrier {
     protected String participantContextId;
-    protected SpanContext spanContext;
+    protected Map<String, String> traceContext;
 
     public String getParticipantContextId() {
         return participantContextId;
     }
 
-    public SpanContext getSpanContext() {
-        return spanContext;
+    public Map<String, String> getTraceContext() {
+        return traceContext;
     }
 
     public abstract static class Builder<T extends ParticipantContextEvent, B extends ParticipantContextEvent.Builder<T, B>> {
@@ -53,7 +55,7 @@ public abstract class ParticipantContextEvent extends Event {
 
         public T build() {
             Objects.requireNonNull((event.participantContextId));
-            event.spanContext = Span.current().getSpanContext();
+            event.traceContext = new Telemetry(GlobalOpenTelemetry.get()).getCurrentTraceContext();
             return event;
         }
     }


### PR DESCRIPTION
## What this PR changes/adds

This PR introduces more OpenTelemetry tracing points so that they can be linked to parent traces of other components.

Request hand-offs between components (e.g. IdentityHub makes a Credential Request to IssuerService) automatically propagage the trace and are continued on the downstream component.

## Solution

this is achieved by two fundamental actions:
- put `@WithSpan` annotations on all relevant methods
- save and restore the trace context on state machines and events

## Why it does that

distributed traces, observability

## Further notes

The following features are currently **missing**:
- metrics
- structured logs
- trace exclusions on critical API borders: e.g. IdentityHub talking to a non-EDC Issuer should **not** propagate the trace parent. 

## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
