### PR TITLE
fix: prevent `null Holder properties` map

### DIFF
--- a/extensions/issuance/issuerservice-holder-attestations/src/test/java/org/eclipse/edc/issuerservice/issuance/attestation/holder/HolderAttestationFactoryTest.java
+++ b/extensions/issuance/issuerservice-holder-attestations/src/test/java/org/eclipse/edc/issuerservice/issuance/attestation/holder/HolderAttestationFactoryTest.java
@@ -41,7 +41,22 @@ class HolderAttestationFactoryTest {
 
         var result = source.execute(new TestHolderAttestationContext(holder));
 
-        assertThat(result).isSucceeded().isSameAs(properties);
+        assertThat(result).isSucceeded().isEqualTo(properties);
+    }
+
+    @Test
+    void shouldReturnEmptyMapWhenHolderPropertiesAreNull() {
+        var factory = new HolderAttestationFactory();
+        var participantContextId = UUID.randomUUID().toString();
+        var attestationDefinition = AttestationDefinition.Builder.newInstance().id(UUID.randomUUID().toString())
+                .attestationType("holder").participantContextId(participantContextId).build();
+        var source = factory.createSource(attestationDefinition);
+        var holder = Holder.Builder.newInstance().holderId(UUID.randomUUID().toString()).did(UUID.randomUUID().toString())
+                .participantContextId(participantContextId).properties(null).build();
+
+        var result = source.execute(new TestHolderAttestationContext(holder));
+
+        assertThat(result).isSucceeded().isEqualTo(Map.of());
     }
 
     private record TestHolderAttestationContext(Holder holder) implements AttestationContext {

--- a/spi/issuerservice/issuerservice-holder-spi/src/main/java/org/eclipse/edc/issuerservice/spi/holder/model/Holder.java
+++ b/spi/issuerservice/issuerservice-holder-spi/src/main/java/org/eclipse/edc/issuerservice/spi/holder/model/Holder.java
@@ -98,7 +98,9 @@ public class Holder extends AbstractParticipantResource {
         }
 
         public Builder properties(Map<String, Object> properties) {
-            entity.properties = properties;
+            if (properties != null) {
+                entity.properties = new HashMap<>(properties);
+            }
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

This PR adds a guard to the `properties` field builder of `Holder` such that the `properties` field of a `Holder` can never be `null`. Since the `properties` field of the `HolderDto` is not required and would just be unconditionally passed to the `Holder`, this could previously result in a `properties` field evaluating to `null`.

## Why it does that
A `null` properties field could result in a potential `NullPointerException` when issuing a credential using the `HolderAttestationFactory`. 

## Further notes

Slightly changed an existing test and also added an additional test for the `null` case.


## Who will sponsor this feature?
@ndr-brt 


## Linked Issue(s)

Closes #973
