### PR TITLE
fix: return only permitted credentials instead of rejecting out-of-scope requests

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImpl.java
@@ -106,16 +106,18 @@ public class CredentialQueryResolverImpl implements CredentialQueryResolver {
             }
             var requestedCredentials = requestedCredentialResult.getContent();
 
-            // clients can never request more credentials than they are permitted to, i.e. their scope list can not exceed the scopes taken
-            // from the access token
-            var isValidQuery = new HashSet<>(allowedCredentials.stream().map(VerifiableCredentialResource::getId).toList())
-                    .containsAll(requestedCredentials.stream().map(VerifiableCredentialResource::getId).toList());
+            // the DCP spec requires that only those credentials are returned that the client is eligible for. This check
+            // checks whether the client has requested credentials outside their permitted scopes
+            var allowedIds = new HashSet<>(allowedCredentials.stream().map(VerifiableCredentialResource::getId).toList());
+            var hasRequestedMore = !allowedIds.containsAll(requestedCredentials.stream().map(VerifiableCredentialResource::getId).toList());
 
-            if (!isValidQuery) {
-                return QueryResult.unauthorized("Invalid query: requested Credentials outside of scope.");
+            if (hasRequestedMore) {
+                var allowedTypes = allowedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential).map(vc -> vc.credential().getType()).flatMap(List::stream).distinct().toList();
+                var requestedTypes = requestedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential).map(vc -> vc.credential().getType()).flatMap(List::stream).distinct().toList();
+                monitor.warning("Client has requested more credentials than allowed. Allowed credentials: %s. Requested credentials: %s".formatted(allowedTypes, requestedTypes));
             }
 
-            credentialResult = requestedCredentials.stream();
+            credentialResult = requestedCredentials.stream().filter(c -> allowedIds.contains(c.getId()));
         }
         // filter out any expired, revoked or suspended credentials
         return QueryResult.success(credentialResult

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImpl.java
@@ -114,7 +114,7 @@ public class CredentialQueryResolverImpl implements CredentialQueryResolver {
             if (hasRequestedMore) {
                 var allowedTypes = allowedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential).map(vc -> vc.credential().getType()).flatMap(List::stream).distinct().toList();
                 var requestedTypes = requestedCredentials.stream().map(VerifiableCredentialResource::getVerifiableCredential).map(vc -> vc.credential().getType()).flatMap(List::stream).distinct().toList();
-                monitor.warning("Client has requested more credentials than allowed. Allowed credentials: %s. Requested credentials: %s".formatted(allowedTypes, requestedTypes));
+                monitor.debug("Client has requested more credentials than allowed. Allowed credentials: %s. Requested credentials: %s".formatted(allowedTypes, requestedTypes));
             }
 
             credentialResult = requestedCredentials.stream().filter(c -> allowedIds.contains(c.getId()));

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.identityhub.core.services.verifiablecredential;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.JsonObject;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
@@ -24,6 +23,7 @@ import org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestSta
 import org.eclipse.edc.identityhub.spi.credential.request.store.HolderCredentialRequestStore;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriteRequest;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriter;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialProfile;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +46,7 @@ import static org.eclipse.edc.spi.result.ServiceResult.success;
 
 
 public class CredentialWriterImpl implements CredentialWriter {
-    private static final List<String> VALID_CREDENTIAL_FORMATS = Arrays.stream(CredentialFormat.values()).map(Object::toString).toList();
+
     private static final List<HolderRequestState> ALLOWED_STATES = List.of(REQUESTED, ISSUED);
     private final CredentialStore credentialStore;
     private final TypeTransformerRegistry credentialTransformerRegistry;
@@ -120,11 +119,11 @@ public class CredentialWriterImpl implements CredentialWriter {
 
     private ServiceResult<VerifiableCredentialResource> convertToResource(CredentialWriteRequest credentialWriteRequest, String participantContextId) {
 
-        CredentialFormat credentialFormat;
-        try {
-            credentialFormat = CredentialFormat.valueOf(credentialWriteRequest.credentialFormat().toUpperCase());
-        } catch (IllegalArgumentException e) {
-            return ServiceResult.badRequest(String.format("Invalid format: '%s', expected one of %s".formatted(credentialWriteRequest.credentialFormat(), VALID_CREDENTIAL_FORMATS)));
+        var profile = credentialWriteRequest.credentialFormat();
+        var mappedFormat = CredentialProfile.formatForProfile(profile);
+
+        if (mappedFormat.failed()) {
+            return mappedFormat.mapFailure();
         }
 
         //attempt to convert the raw credential to JSON -> would mean LD, or JWT otherwise
@@ -137,7 +136,7 @@ public class CredentialWriterImpl implements CredentialWriter {
         }
         var credential = transformationResult.getContent();
 
-        var container = new VerifiableCredentialContainer(credentialWriteRequest.rawCredential(), credentialFormat, credential);
+        var container = new VerifiableCredentialContainer(credentialWriteRequest.rawCredential(), mappedFormat.getContent(), credential);
 
         var resource = VerifiableCredentialResource.Builder.newHolder()
                 .credential(container)
@@ -151,6 +150,7 @@ public class CredentialWriterImpl implements CredentialWriter {
 
         return ServiceResult.success(resource);
     }
+
 
     private Optional<JsonObject> tryConvertToJson(@NotNull String rawCredential) {
         try {

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/query/CredentialQueryResolverImplTest.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 import static org.eclipse.edc.spi.result.StoreResult.success;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -111,9 +112,8 @@ class CredentialQueryResolverImplTest {
                 .thenReturn(success(List.of(credential)));
 
         var res = resolver.query(TEST_PARTICIPANT_CONTEXT_ID, createPresentationQuery("org.eclipse.dspace.dcp.vc.type:AnotherCredential:read"), List.of());
-        assertThat(res).isFailed();
-        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
-        verify(monitor).warning("Permission was not granted on any credentials (empty access token scope list), but 1 were requested.");
+        assertThat(res).isSucceeded();
+        assertThat(res.getContent()).isEmpty();
     }
 
     @Test
@@ -210,20 +210,27 @@ class CredentialQueryResolverImplTest {
 
     @Test
     void query_requestsTooManyCredentials_shouldReturnFailure() {
-        var credential1 = createCredentialResource("TestCredential");
-        var credential2 = createCredentialResource("AnotherCredential");
-        when(storeMock.query(any()))
-                .thenReturn(success(List.of(credential1)))
-                .thenReturn(success(List.of(credential2)))
+        var credential1 = createCredentialResource("TestCredential_1");
+        var credential2 = createCredentialResource("TestCredential_2");
+        var credential3 = createCredentialResource("TestCredential_3");
+        when(storeMock.query(argThat(q -> q != null && q.getFilterExpression().stream().anyMatch(c -> c.getOperandRight().toString().contains("TestCredential_1")))))
                 .thenReturn(success(List.of(credential1)));
 
-        var res = resolver.query(TEST_PARTICIPANT_CONTEXT_ID,
-                createPresentationQuery("org.eclipse.dspace.dcp.vc.type:TestCredential:read",
-                        "org.eclipse.dspace.dcp.vc.type:AnotherCredential:read"), List.of("org.eclipse.dspace.dcp.vc.type:TestCredential:read"));
+        when(storeMock.query(argThat(q -> q != null && q.getFilterExpression().stream().anyMatch(c -> c.getOperandRight().toString().contains("TestCredential_2")))))
+                .thenReturn(success(List.of(credential2)));
 
-        assertThat(res).isFailed();
-        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
-        assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
+        when(storeMock.query(argThat(q -> q != null && q.getFilterExpression().stream().anyMatch(c -> c.getOperandRight().toString().contains("TestCredential_3")))))
+                .thenReturn(success(List.of(credential3)));
+
+
+        var res = resolver.query(TEST_PARTICIPANT_CONTEXT_ID,
+                createPresentationQuery("org.eclipse.dspace.dcp.vc.type:TestCredential_1:read", "org.eclipse.dspace.dcp.vc.type:TestCredential_2:read", "org.eclipse.dspace.dcp.vc.type:TestCredential_3:read"),
+                List.of("org.eclipse.dspace.dcp.vc.type:TestCredential_1:read", "org.eclipse.dspace.dcp.vc.type:TestCredential_2:read"));
+
+        assertThat(res).isSucceeded();
+        var credentials = res.getContent().toList();
+        assertThat(credentials).hasSize(2)
+                .containsExactlyInAnyOrder(credential1.getVerifiableCredential(), credential2.getVerifiableCredential());
     }
 
     @Test
@@ -260,9 +267,7 @@ class CredentialQueryResolverImplTest {
         var res = resolver.query(TEST_PARTICIPANT_CONTEXT_ID,
                 createPresentationQuery("org.eclipse.dspace.dcp.vc.type:TestCredential:read"), List.of("org.eclipse.dspace.dcp.vc.type:AnotherCredential:read"));
 
-        assertThat(res.failed()).isTrue();
-        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
-        assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
+        assertThat(res).isSucceeded().satisfies(creds -> assertThat(creds).isEmpty());
     }
 
     @Test
@@ -281,9 +286,8 @@ class CredentialQueryResolverImplTest {
                 createPresentationQuery("org.eclipse.dspace.dcp.vc.type:TestCredential:read", "org.eclipse.dspace.dcp.vc.type:AnotherCredential:read"),
                 List.of("org.eclipse.dspace.dcp.vc.type:FooCredential:read", "org.eclipse.dspace.dcp.vc.type:BarCredential:read"));
 
-        assertThat(res).isFailed();
-        assertThat(res.reason()).isEqualTo(QueryFailure.Reason.UNAUTHORIZED_SCOPE);
-        assertThat(res.getFailureDetail()).isEqualTo("Invalid query: requested Credentials outside of scope.");
+        assertThat(res).isSucceeded()
+                .satisfies(creds -> assertThat(creds).isEmpty());
     }
 
     @Test
@@ -348,6 +352,10 @@ class CredentialQueryResolverImplTest {
         assertThat(res).isSucceeded();
         assertThat(res.getContent()).isEmpty();
         verify(monitor).warning(eq("Credential '%s' not valid: revoked".formatted(credential.getId())));
+    }
+
+    private QuerySpec queryingFor(String slug) {
+        return argThat(q -> q.getFilterExpression().stream().anyMatch(c -> c.getOperandRight().toString().contains(slug)));
     }
 
     private VerifiableCredentialResource.Builder createCredentialResource(VerifiableCredential cred) {

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/PresentationApiEndToEndTest.java
@@ -300,7 +300,7 @@ public class PresentationApiEndToEndTest {
         }
 
         @Test
-        void query_credentialQueryResolverFails_shouldReturn403(IdentityHub identityHub, CredentialStore store) throws JOSEException, JsonProcessingException {
+        void query_moreScopesThanAccessToken_shouldOnlyReturnPermittedCreds(IdentityHub identityHub, CredentialStore store) throws JOSEException, JsonProcessingException {
 
             var token = generateSiToken();
 
@@ -313,16 +313,27 @@ public class PresentationApiEndToEndTest {
             storeCredential(VC_EXAMPLE_2, CredentialFormat.VC1_0_JWT, store);
 
 
-            identityHub.getCredentialsEndpoint().baseRequest()
+            var response = identityHub.getCredentialsEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(AUTHORIZATION, "Bearer " + token)
                     .body(VALID_QUERY_WITH_ADDITIONAL_SCOPE)
                     .post("/v1/participants/%s/presentations/query".formatted(TEST_PARTICIPANT_CONTEXT_ID))
                     .then()
                     .log().ifError()
-                    .statusCode(403)
-                    .body("[0].type", equalTo("NotAuthorized"))
-                    .body("[0].message", equalTo("Invalid query: requested Credentials outside of scope."));
+                    .statusCode(200)
+                    .extract().body().as(JsonObject.class);
+
+            assertThat(response)
+                    .hasEntrySatisfying("type", jsonValue -> assertThat(jsonValue.toString()).contains("PresentationResponseMessage"))
+                    .hasEntrySatisfying("@context", jsonValue -> assertThat(jsonValue.asJsonArray()).hasSize(1))
+                    .hasEntrySatisfying("presentation", jsonValue -> {
+                        assertThat(vpTokensExtractor(jsonValue)).hasSize(1)
+                                .first()
+                                .satisfies(vpToken -> {
+                                    assertThat(vpToken).isNotNull();
+                                    assertThat(extractCredentials(vpToken)).hasSize(1).allSatisfy(vc -> assertThat(vc.getType()).contains("VerifiableCredential", "AlumniCredential"));
+                                });
+                    });
         }
 
         @Test
@@ -803,7 +814,19 @@ public class PresentationApiEndToEndTest {
 
                 Map<String, Object> map = (Map<String, Object>) OBJECT_MAPPER.convertValue(vpClaim, Map.class);
 
-                return (List<VerifiableCredential>) map.get("verifiableCredential");
+                var credentials = (List<Object>) map.get("verifiableCredential");
+                return credentials.stream().map(s -> {
+                    if (s instanceof String json) {
+
+                        try {
+                            return OBJECT_MAPPER.readValue(json, VerifiableCredential.class);
+                        } catch (JsonProcessingException e) {
+                            throw new RuntimeException(e);
+                        }
+                    } else {
+                        return OBJECT_MAPPER.convertValue(s, VerifiableCredential.class);
+                    }
+                }).toList();
 
             } catch (ParseException e) {
                 throw new RuntimeException(e);

--- a/e2e-tests/tck-tests/presentation/build.gradle.kts
+++ b/e2e-tests/tck-tests/presentation/build.gradle.kts
@@ -21,9 +21,9 @@ dependencies {
     testImplementation(libs.restAssured)
     testImplementation(libs.junit.jupiter.api)
 
-    testImplementation(libs.dcp.tck.runtime)
+    testImplementation(libs.tck.runtime)
     testImplementation(libs.dcp.system)
-    testImplementation(libs.dsp.core)
+    testImplementation(libs.tck.core)
     testImplementation(testFixtures(project(":e2e-tests:identityhub-test-fixtures")))
     testImplementation(libs.junit.platform.launcher)
 

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuance/DcpIssuanceFlowWithDockerTest.java
@@ -122,7 +122,7 @@ public class DcpIssuanceFlowWithDockerTest {
 
         var response = createParticipant(identityHub, baseCredentialServiceUrl);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC3")
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC7")
                 .withExtraHost("host.docker.internal", "host-gateway")
                 .withExposedPorts(CALLBACK_PORT)
                 .withEnv(Map.of(

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowWithDockerTest.java
@@ -117,7 +117,7 @@ public class DcpIssuerIssuanceFlowWithDockerTest {
         var response = createParticipantContext(issuer, baseIssuerServiceUrl);
         createDefinitions(issuer);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC3")
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC7")
                 .withExtraHost("host.docker.internal", "host-gateway")
                 .withExposedPorts(CALLBACK_PORT)
                 .withEnv(Map.of(

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/presentation/DcpPresentationFlowWithDockerTest.java
@@ -131,7 +131,7 @@ public class DcpPresentationFlowWithDockerTest {
 
         var response = createParticipant(identityHub, baseCredentialServiceUrl);
 
-        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC5")
+        try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC7")
                 .withExtraHost("host.docker.internal", "host-gateway")
                 .withExposedPorts(CALLBACK_PORT)
                 .withEnv(Map.of(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ format.version = "1.1"
 awaitility = "4.3.0"
 bouncyCastle-jdk18on = "1.84"
 edc = "0.18.0-SNAPSHOT"
-dcp-tck = "1.0.0-RC6"
+dcp-tck = "1.0.0-RC7"
 jackson = "2.21"
 jakarta-annotation = "3.0.0"
 jersey = "4.0.2"
@@ -122,8 +122,8 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref
 
 # DCP-TCK libraries
 dcp-testcases = { module = "org.eclipse.dataspacetck.dcp:dcp-testcases", version.ref = "dcp-tck" }
-dcp-tck-runtime = { module = "org.eclipse.dataspacetck.dsp:tck-runtime", version.ref = "dcp-tck" }
-dsp-core = { module = "org.eclipse.dataspacetck.dsp:core", version.ref = "dcp-tck" }
+tck-runtime = { module = "org.eclipse.dataspacetck.common:tck-runtime", version.ref = "dcp-tck" }
+tck-core = { module = "org.eclipse.dataspacetck.common:core", version.ref = "dcp-tck" }
 dcp-system = { module = "org.eclipse.dataspacetck.dcp:dcp-system", version.ref = "dcp-tck" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpCredentialStorageClient.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpCredentialStorageClient.java
@@ -23,6 +23,7 @@ import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.iam.decentralizedclaims.spi.CredentialServiceUrlResolver;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialProfile;
 import org.eclipse.edc.issuerservice.spi.holder.model.Holder;
 import org.eclipse.edc.issuerservice.spi.holder.store.HolderStore;
 import org.eclipse.edc.issuerservice.spi.issuance.delivery.CredentialStorageClient;
@@ -147,7 +148,7 @@ public class DcpCredentialStorageClient implements CredentialStorageClient {
     private JsonObject toJson(VerifiableCredentialContainer credential) {
         return Json.createObjectBuilder()
                 .add("credentialType", credential.credential().getType().stream().filter("VerifiableCredential"::equals).findFirst().orElseThrow())
-                .add("format", credential.format().name())
+                .add("format", CredentialProfile.profileForFormat(credential.format()).orElseThrow(f -> new IllegalArgumentException("Invalid credential format: " + credential.format())))
                 .add("payload", credential.rawVc())
                 .build();
     }

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/CredentialProfile.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/CredentialProfile.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.verifiablecredentials.model;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.spi.result.ServiceResult;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.eclipse.edc.spi.result.ServiceResult.success;
+
+/**
+ * The {@code CredentialProfile} class provides functionality to map DCP credential profiles
+ * to their corresponding credential formats and vice versa. It acts as a utility class
+ * to help validate and translate profile/format pairings.
+ * <p>
+ * It defines constant values for supported DCP credential profiles and includes methods
+ * for format/profile conversions and validation logic for expected inputs.
+ * <p>
+ * All currently defined DCP profiles are listed below:
+ * <ul>
+ *     <li>{@code vc11-sl2021/jwt}</li>
+ *     <li>{@code vc20-bssl/jwt}</li>
+ * </ul>
+ * </p>
+ * <p>
+ * For ore information refer to the <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0.1/#dcp-profile-definitions">DCP Specification</a>
+ */
+public class CredentialProfile {
+    public static final String DCP_PROFILE_VC11 = "vc11-sl2021/jwt";
+    public static final String DCP_PROFILE_VC20 = "vc20-bssl/jwt";
+    private static final List<String> VALID_CREDENTIAL_FORMATS = Arrays.stream(CredentialFormat.values()).map(Object::toString).toList();
+
+    /**
+     * Converts a DCP credential profile to its corresponding credential format. If the profile is not recognized, an attempt
+     * is made to convert it to a {@link CredentialFormat} enum value. If the conversion is unsuccessful, an error is returned.
+     *
+     * @param profile A DCP credential profile string.
+     * @return A {@link ServiceResult} containing the corresponding {@link CredentialFormat} or an error if the conversion fails.
+     */
+    public static ServiceResult<CredentialFormat> formatForProfile(String profile) {
+        switch (profile.toLowerCase()) {
+            case DCP_PROFILE_VC11:
+                return success(CredentialFormat.VC1_0_JWT);
+            case DCP_PROFILE_VC20:
+                return success(CredentialFormat.VC2_0_JOSE);
+            default:
+                try {
+                    return success(CredentialFormat.valueOf(profile));
+                } catch (IllegalArgumentException e) {
+                    return ServiceResult.badRequest(String.format("Invalid format: '%s', expected one of '%s, '%s' or  %s".formatted(profile, DCP_PROFILE_VC11, DCP_PROFILE_VC20, VALID_CREDENTIAL_FORMATS)));
+                }
+        }
+    }
+
+    /**
+     * Returns the DCP profile for a given credential format. If the format falls outside supported DCP profiles, then an error is returned.
+     *
+     * @param format The credential format.
+     * @return A {@link ServiceResult} containing the corresponding DCP profile string or an error if the format is unsupported.
+     */
+    public static ServiceResult<String> profileForFormat(CredentialFormat format) {
+        return switch (format) {
+            case VC1_0_JWT -> success(DCP_PROFILE_VC11);
+            case VC2_0_JOSE -> success(DCP_PROFILE_VC20);
+            default ->
+                    ServiceResult.badRequest(String.format("Unsupported format: '%s', expected one of '%s, '%s' or  %s".formatted(format, DCP_PROFILE_VC11, DCP_PROFILE_VC20, VALID_CREDENTIAL_FORMATS)));
+        };
+    }
+}

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/CredentialProfile.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/CredentialProfile.java
@@ -29,13 +29,11 @@ import static org.eclipse.edc.spi.result.ServiceResult.success;
  * <p>
  * It defines constant values for supported DCP credential profiles and includes methods
  * for format/profile conversions and validation logic for expected inputs.
- * <p>
  * All currently defined DCP profiles are listed below:
  * <ul>
  *     <li>{@code vc11-sl2021/jwt}</li>
  *     <li>{@code vc20-bssl/jwt}</li>
  * </ul>
- * </p>
  * <p>
  * For ore information refer to the <a href="https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0.1/#dcp-profile-definitions">DCP Specification</a>
  */

--- a/spi/verifiable-credential-spi/src/test/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/CredentialProfileTest.java
+++ b/spi/verifiable-credential-spi/src/test/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/CredentialProfileTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.identityhub.spi.verifiablecredentials.model;
+
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
+import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC2_0_JOSE;
+import static org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialProfile.DCP_PROFILE_VC11;
+import static org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialProfile.DCP_PROFILE_VC20;
+
+/**
+ * Test class for {@link CredentialProfile}.
+ * This class validates the behavior of the {@code formatForProfile} method, ensuring that different profiles
+ * are correctly translated into corresponding {@link CredentialFormat} or appropriate error messages.
+ */
+class CredentialProfileTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { DCP_PROFILE_VC11, DCP_PROFILE_VC20 })
+    void formatForProfile_validProfile(String profile) {
+        assertThat(CredentialProfile.formatForProfile(profile).succeeded()).isTrue();
+        assertThat(CredentialProfile.formatForProfile(profile.toUpperCase()).succeeded()).isTrue();
+        assertThat(CredentialProfile.formatForProfile(profile.toLowerCase()).succeeded()).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid-profile", "vc20-sl2021/COSE", "VC2-0-LD/JWT" })
+    void formatForProfile_unrecognizedProfile(String profile) {
+        assertThat(CredentialProfile.formatForProfile(profile).failed()).isTrue();
+        assertThat(CredentialProfile.formatForProfile(profile.toUpperCase()).failed()).isTrue();
+        assertThat(CredentialProfile.formatForProfile(profile.toLowerCase()).failed()).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(CredentialFormat.class)
+    void formatForProfile_profileIsFormatString(CredentialFormat format) {
+        var r = CredentialProfile.formatForProfile(format.name());
+        assertThat(r.succeeded()).isTrue();
+        assertThat(r.getContent()).isEqualTo(format);
+    }
+
+    @Test
+    void profileForFormat_withSupportedCredentialFormat() {
+        var r = CredentialProfile.profileForFormat(VC1_0_JWT);
+        assertThat(r.succeeded()).isTrue();
+        assertThat(r.getContent()).isEqualTo(DCP_PROFILE_VC11);
+
+        var r2 = CredentialProfile.profileForFormat(VC2_0_JOSE);
+        assertThat(r2.succeeded()).isTrue();
+        assertThat(r2.getContent()).isEqualTo(DCP_PROFILE_VC20);
+    }
+
+    @ParameterizedTest
+    @EnumSource(mode = EnumSource.Mode.EXCLUDE, value = CredentialFormat.class, names = { "VC1_0_JWT", "VC2_0_JOSE" })
+    void profileForFormat_withUnsupportedProfileString(CredentialFormat unsupportedFormat) {
+        var r = CredentialProfile.profileForFormat(unsupportedFormat);
+        assertThat(r.failed()).isTrue();
+    }
+}


### PR DESCRIPTION

## What this PR changes/adds

When a client requests credentials outside their permitted scope, filter them
out and return only the allowed ones, logging a warning instead of failing the
entire request.


## Why it does that

dcp spec mandates that

## Further notes

**TCK tests will fail until this is also updated in the TCKs!**


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #990

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
