### PR TITLE
fix: use profile strings instead of CredentialFormat enum for format matching

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
@@ -88,15 +88,29 @@ public class CredentialWriterImpl implements CredentialWriter {
                 // verify that the received credentials correspond to the credential request that was made prior
                 var receivedCredential = resource.getVerifiableCredential();
                 var receivedTypes = receivedCredential.credential().getType();
-                var receivedFormat = receivedCredential.format().toString();
+
+                // convert received format to a CredentialFormat
+                var receivedFormat = CredentialProfile.formatForProfile(writeRequest.credentialFormat());
+                if (receivedFormat.failed()) {
+                    return receivedFormat.mapFailure();
+                }
 
                 // check if the list of originally requested credentials contains the received credential
                 var requestedCredential = holderRequest.getIdsAndFormats().stream()
-                        .filter(rqc -> receivedTypes.contains(rqc.credentialType()) && receivedFormat.equalsIgnoreCase(rqc.format()))
+                        .filter(rqc -> receivedTypes.contains(rqc.credentialType()))
+                        // rqc.format() may be a profile string, but receivedFormat is a CredentialFormat, so we need to compare
+                        // raw values
+                        .filter(rqc -> {
+                            var requestedFormat = CredentialProfile.formatForProfile(rqc.format());
+                            if (requestedFormat.failed()) {
+                                return false;
+                            }
+                            return requestedFormat.getContent().equals(receivedFormat.getContent());
+                        })
                         .findFirst();
 
                 if (requestedCredential.isEmpty()) {
-                    return ServiceResult.unauthorized("No credential request was made for Credentials of type '%s' serialized as '%s'".formatted(receivedTypes, receivedFormat));
+                    return ServiceResult.unauthorized("No credential request was made for Credentials of type '%s' serialized as '%s'".formatted(receivedTypes, receivedFormat.getContent()));
                 }
 
                 // store the credential object ID for later use, e.g. automatic re-issuance

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
@@ -98,8 +98,7 @@ public class CredentialWriterImpl implements CredentialWriter {
                 // check if the list of originally requested credentials contains the received credential
                 var requestedCredential = holderRequest.getIdsAndFormats().stream()
                         .filter(rqc -> receivedTypes.contains(rqc.credentialType()))
-                        // rqc.format() may be a profile string, but receivedFormat is a CredentialFormat, so we need to compare
-                        // raw values
+                        // for compatibility, we need to convert both to a CredentialFormat and compare that:
                         .filter(rqc -> {
                             var requestedFormat = CredentialProfile.formatForProfile(rqc.format());
                             if (requestedFormat.failed()) {

--- a/extensions/api/issuer-admin-api/credential-definition-api/build.gradle.kts
+++ b/extensions/api/issuer-admin-api/credential-definition-api/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 
 dependencies {
     api(project(":spi:issuerservice:issuerservice-issuance-spi"))
+    api(project(":spi:verifiable-credential-spi"))
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-configuration"))
     implementation(libs.edc.spi.auth)
     implementation(libs.edc.spi.web)

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/model/CredentialDefinitionDto.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/model/CredentialDefinitionDto.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialProfile;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialRuleDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
@@ -92,7 +92,7 @@ public class CredentialDefinitionDto {
                 .jsonSchema(jsonSchema)
                 .jsonSchemaUrl(jsonSchemaUrl)
                 .validity(validity)
-                .formatFrom(CredentialFormat.valueOf(format.toUpperCase()))
+                .formatFrom(CredentialProfile.formatForProfile(format).orElseThrow(f -> new IllegalArgumentException(f.getFailureDetail())))
                 .attestations(attestations)
                 .rules(rules)
                 .mappings(mappings)


### PR DESCRIPTION

## What this PR changes/adds

Replace CredentialFormat enum comparison with raw profile string comparison in
CredentialWriterImpl and switch CredentialDefinitionDto to resolve formats via
CredentialProfile, which supports profile-based format strings.


## Why it does that

amend previous changes

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
