### PR TITLE
fix: preserve JWK fields when adding key pair to DID document

### DIFF
--- a/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
+++ b/core/identity-hub-did/src/main/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.did;
 
+import com.nimbusds.jose.jwk.JWK;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
@@ -38,6 +39,7 @@ import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.AbstractResult;
+import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.spi.telemetry.Telemetry;
@@ -46,11 +48,13 @@ import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.security.KeyPair;
 import java.security.PublicKey;
+import java.text.ParseException;
 import java.util.Collection;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.eclipse.edc.participantcontext.spi.types.ParticipantResource.queryByParticipantContextId;
+import static org.eclipse.edc.spi.result.Result.failure;
 import static org.eclipse.edc.spi.result.ServiceResult.success;
 
 /**
@@ -285,20 +289,23 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
 
             // add the public key as verification method to all did resources
             var serialized = event.getPublicKeySerialized();
-            var publicKey = keyParserRegistry.parse(serialized);
+            
+            // only convert if not already in JWK format
+            var jwkResult = tryParseJwk(serialized)
+                    .onFailure(f -> monitor.debug("Serialized key is not JWK (message: %s), attempting to convert".formatted(f.getFailureDetail())))
+                    .recover(f -> keyParserRegistry.parse(serialized)
+                            .map(pk -> CryptoConverter.createJwk(new KeyPair((PublicKey) pk, null))));
 
-            if (publicKey.failed()) {
-                monitor.warning("Error adding KeyPair '%s' to DID Document of participant '%s': %s".formatted(event.getKeyPairResource().getId(), event.getParticipantContextId(), publicKey.getFailureDetail()));
+            if (jwkResult.failed()) {
+                monitor.warning("Error adding KeyPair '%s' to DID Document of participant '%s': %s".formatted(event.getKeyPairResource().getId(), event.getParticipantContextId(), jwkResult.getFailureDetail()));
                 return;
             }
-
-            var jwk = CryptoConverter.createJwk(new KeyPair((PublicKey) publicKey.getContent(), null));
 
             var errors = didResources.stream()
                     .map(dd -> {
                         dd.getDocument().getVerificationMethod().add(VerificationMethod.Builder.newInstance()
                                 .id(event.getKeyId())
-                                .publicKeyJwk(jwk.toJSONObject())
+                                .publicKeyJwk(jwkResult.getContent().toJSONObject())
                                 .controller(dd.getDocument().getId())
                                 .type(event.getKeyType())
                                 .build());
@@ -313,6 +320,14 @@ public class DidDocumentServiceImpl implements DidDocumentService, EventSubscrib
                 monitor.warning("Updating DID documents after activating a KeyPair failed: %s".formatted(errors));
             }
         });
+    }
+
+    private Result<JWK> tryParseJwk(String serialized) {
+        try {
+            return Result.success(JWK.parse(serialized));
+        } catch (ParseException e) {
+            return failure("Failed to parse JWK from string: %s".formatted(e));
+        }
     }
 
     @WithSpan(value = "did-document.keypair-revoked", kind = SpanKind.INTERNAL)

--- a/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
+++ b/core/identity-hub-did/src/test/java/org/eclipse/edc/identityhub/did/DidDocumentServiceImplTest.java
@@ -16,7 +16,9 @@ package org.eclipse.edc.identityhub.did;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import org.eclipse.edc.iam.did.spi.document.DidDocument;
 import org.eclipse.edc.iam.did.spi.document.Service;
@@ -47,6 +49,12 @@ import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
@@ -568,6 +576,117 @@ class DidDocumentServiceImplTest {
         verify(didResourceStoreMock).findById(did); // happens during the publishing
         verifyNoMoreInteractions(didResourceStoreMock);
         verify(publisherMock).publish(eq(did));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onKeyPairActivated_withRsaKey() throws NoSuchAlgorithmException {
+        var keyId = "key-id";
+        var keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        var keyPair = keyPairGenerator.generateKeyPair();
+        var key = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                .keyID(keyId)
+                .algorithm(JWSAlgorithm.RS256)
+                .x509CertURL(URI.create("https://example.com/cert"))
+                .build();
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+
+        when(didResourceStoreMock.query(any(QuerySpec.class))).thenReturn(List.of(didResource));
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(publisherMock.publish(did)).thenReturn(Result.success());
+
+        var event = EventEnvelope.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .payload(KeyPairActivated.Builder.newInstance()
+                        .keyId(keyId)
+                        .keyPairResource(KeyPairResource.Builder.newPresentationSigning().id(UUID.randomUUID().toString()).build())
+                        .participantContextId("test-participant")
+                        .publicKey(key.toPublicJWK().toJSONString(), JSON_WEB_KEY_2020)
+                        .build())
+                .build();
+
+        service.on(event);
+
+        verify(didResourceStoreMock).query(any(QuerySpec.class));
+        verify(didResourceStoreMock).update(argThat(dr ->
+                dr.getDocument().getVerificationMethod().stream().anyMatch(vm -> vm.getId().equals(keyId) &&
+                        vm.getPublicKeyJwk().containsKey("x5u") &&
+                        vm.getPublicKeyJwk().containsKey("alg"))));
+        verify(didResourceStoreMock).findById(did); // happens during the publishing
+        verifyNoMoreInteractions(didResourceStoreMock);
+        verify(publisherMock).publish(eq(did));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onKeyPairActivated_withPemKey() throws JOSEException {
+        var keyId = "key-id";
+        var key = new ECKeyGenerator(Curve.P_256).keyID(keyId).generate();
+        var encoded = Base64.getMimeEncoder(64, new byte[]{ '\n' }).encodeToString(key.toPublicJWK().toECPublicKey().getEncoded());
+        var pem = "-----BEGIN PUBLIC KEY-----\n" + encoded + "\n-----END PUBLIC KEY-----";
+
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+
+        when(didResourceStoreMock.query(any(QuerySpec.class))).thenReturn(List.of(didResource));
+        when(didResourceStoreMock.update(any())).thenReturn(StoreResult.success());
+        when(didResourceStoreMock.findById(eq(did))).thenReturn(didResource);
+        when(publisherMock.publish(did)).thenReturn(Result.success());
+
+        var event = EventEnvelope.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .payload(KeyPairActivated.Builder.newInstance()
+                        .keyId(keyId)
+                        .keyPairResource(KeyPairResource.Builder.newPresentationSigning().id(UUID.randomUUID().toString()).build())
+                        .participantContextId("test-participant")
+                        .publicKey(pem, JSON_WEB_KEY_2020)
+                        .build())
+                .build();
+
+        service.on(event);
+
+        verify(didResourceStoreMock).query(any(QuerySpec.class));
+        verify(didResourceStoreMock).update(argThat(dr -> dr.getDocument().getVerificationMethod().stream().anyMatch(vm -> vm.getId().equals(keyId))));
+        verify(didResourceStoreMock).findById(did);
+        verifyNoMoreInteractions(didResourceStoreMock);
+        verify(publisherMock).publish(eq(did));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void onKeyPairActivated_withInvalidKey_shouldLogWarning() {
+        var keyId = "key-id";
+        var doc = createDidDocument().build();
+        var did = doc.getId();
+        var didResource = DidResource.Builder.newInstance().did(did).state(DidState.GENERATED).document(doc).build();
+
+        when(didResourceStoreMock.query(any(QuerySpec.class))).thenReturn(List.of(didResource));
+
+        var event = EventEnvelope.Builder.newInstance()
+                .at(System.currentTimeMillis())
+                .id(UUID.randomUUID().toString())
+                .payload(KeyPairActivated.Builder.newInstance()
+                        .keyId(keyId)
+                        .keyPairResource(KeyPairResource.Builder.newPresentationSigning().id(UUID.randomUUID().toString()).build())
+                        .participantContextId("test-participant")
+                        .publicKey("not-a-valid-key", JSON_WEB_KEY_2020)
+                        .build())
+                .build();
+
+        service.on(event);
+
+        verify(monitorMock).warning(anyString());
+        verify(didResourceStoreMock).query(any(QuerySpec.class));
+        verifyNoMoreInteractions(didResourceStoreMock);
+        verifyNoInteractions(publisherMock);
     }
 
     @SuppressWarnings("unchecked")

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-18T11:00:00Z",
+    "lastUpdated": "2026-05-27T11:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-03-10T15:00:00Z",
+    "lastUpdated": "2026-05-27T15:00:00Z",
     "maturity": null
   }
 ]

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/resources/issuer-api-version.json
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/resources/issuer-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1beta",
-    "lastUpdated": "2025-11-12T16:00:00Z",
+    "lastUpdated": "2026-05-27T16:00:00Z",
     "maturity": null
   }
 ]


### PR DESCRIPTION
## Summary

- When the serialized public key is already in JWK format, use it directly as the verification method's `publicKeyJwk` instead of round-tripping through `PublicKey`, which silently drops extra JWK fields (`alg`, `x5u`, etc.)
- Falls back to `KeyParserRegistry` for non-JWK formats (e.g. PEM), converting the resulting `PublicKey` to a JWK
- Refactored the nested `if`/`else` into a `Result.recover()` chain for clarity

Closes #774 