### PR TITLE
fix: reject duplicate credential issuance requests by holderPid

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -101,6 +101,9 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
                 .build();
 
         try {
+            if (findById(holderPid) != null) {
+                return ServiceResult.conflict("Holder Credential Request with holderPid '%s' already exists".formatted(holderPid));
+            }
             updateRequest(newRequest);
         } catch (EdcPersistenceException e) {
             return ServiceResult.badRequest(e.getMessage());

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -41,6 +41,7 @@ import org.eclipse.edc.spi.response.ResponseStatus;
 import org.eclipse.edc.spi.response.StatusResult;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
+import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.statemachine.AbstractStateEntityManager;
 import org.eclipse.edc.statemachine.Processor;
 import org.eclipse.edc.statemachine.ProcessorImpl;
@@ -100,12 +101,16 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
                 .traceContext(traceContext)
                 .build();
 
-        try {
-            updateRequest(newRequest);
-        } catch (EdcPersistenceException e) {
-            return ServiceResult.badRequest(e.getMessage());
-        }
-        return ServiceResult.success(holderPid);
+        return transactionContext.execute(() -> {
+            if (findById(holderPid) != null) {
+                return ServiceResult.conflict("Holder Credential Request with holderPid '%s' already exists".formatted(holderPid));
+            }
+            try {
+                return ServiceResult.from(updateRequest(newRequest)).map(u -> holderPid);
+            } catch (EdcPersistenceException e) {
+                return ServiceResult.badRequest(e.getMessage());
+            }
+        });
     }
 
     @Override
@@ -150,13 +155,8 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
         monitor.warning("A Holder Credential Request has been transitioned to '%s': %s".formatted(ERROR, failureDetail));
     }
 
-    private void updateRequest(HolderCredentialRequest request) {
-        transactionContext.execute(() -> {
-            if (findById(request.getHolderPid()) != null) {
-                return ServiceResult.conflict("Holder Credential Request with holderPid '%s' already exists".formatted(request.getHolderPid()));
-            }
-            return update(request);
-        });
+    private StoreResult<?> updateRequest(HolderCredentialRequest request) {
+        return transactionContext.execute(() -> update(request));
     }
 
     private Processor processRequestsInState(HolderRequestState state, Function<HolderCredentialRequest, CompletableFuture<StatusResult<Void>>> function) {

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImpl.java
@@ -101,9 +101,6 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
                 .build();
 
         try {
-            if (findById(holderPid) != null) {
-                return ServiceResult.conflict("Holder Credential Request with holderPid '%s' already exists".formatted(holderPid));
-            }
             updateRequest(newRequest);
         } catch (EdcPersistenceException e) {
             return ServiceResult.badRequest(e.getMessage());
@@ -154,7 +151,12 @@ public class CredentialRequestManagerImpl extends AbstractStateEntityManager<Hol
     }
 
     private void updateRequest(HolderCredentialRequest request) {
-        transactionContext.execute(() -> update(request));
+        transactionContext.execute(() -> {
+            if (findById(request.getHolderPid()) != null) {
+                return ServiceResult.conflict("Holder Credential Request with holderPid '%s' already exists".formatted(request.getHolderPid()));
+            }
+            return update(request);
+        });
     }
 
     private Processor processRequestsInState(HolderRequestState state, Function<HolderCredentialRequest, CompletableFuture<StatusResult<Void>>> function) {

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
@@ -69,6 +69,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -142,6 +143,23 @@ class CredentialRequestManagerImplTest {
                     .detail().isEqualTo("foo");
 
             verify(store).save(any());
+            verifyNoMoreInteractions(store, resolver, transformerRegistry, httpClient);
+        }
+
+        @Test
+        void initiateRequest_whenAlreadyExists_expectConflict() {
+            var holderPid = "test-holder-request-id";
+            when(store.findById(anyString())).thenReturn(HolderCredentialRequest.Builder.newInstance()
+                    .issuerDid(ISSUER_DID)
+                    .participantContextId("test-participant")
+                    .requestedCredential("test-id", "TestCredential", CredentialFormat.VC1_0_JWT.toString())
+                    .build());
+            var result = credentialRequestService.initiateRequest("test-participant", ISSUER_DID, holderPid, List.of(new RequestedCredential("test-id", "TestCredential", CredentialFormat.VC1_0_JWT.toString())));
+            assertThat(result)
+                    .isFailed();
+
+            verify(store, never()).save(any());
+            verify(store).findById(eq(holderPid));
             verifyNoMoreInteractions(store, resolver, transformerRegistry, httpClient);
         }
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialRequestManagerImplTest.java
@@ -103,6 +103,7 @@ class CredentialRequestManagerImplTest {
                 .thenReturn(success(Json.createObjectBuilder().build()));
         when(sts.createToken(anyString(), anyMap(), ArgumentMatchers.isNull())).thenReturn(success(TokenRepresentation.Builder.newInstance().build()));
         when(participantContextService.getParticipantContext(anyString())).thenReturn(ServiceResult.success(participantContext()));
+        when(store.findById(anyString())).thenReturn(null);
         when(store.save(any())).thenReturn(StoreResult.success());
     }
 
@@ -130,6 +131,7 @@ class CredentialRequestManagerImplTest {
                     .isSucceeded()
                     .isEqualTo("test-holder-request-id");
 
+            verify(store).findById(anyString());
             verify(store).save(any());
             verifyNoMoreInteractions(store, resolver, transformerRegistry, httpClient);
         }
@@ -142,6 +144,7 @@ class CredentialRequestManagerImplTest {
                     .isFailed()
                     .detail().isEqualTo("foo");
 
+            verify(store).findById(anyString());
             verify(store).save(any());
             verifyNoMoreInteractions(store, resolver, transformerRegistry, httpClient);
         }

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/events/IssuanceEventPublisher.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/events/IssuanceEventPublisher.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.issuerservice.issuance.events;
 
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.issuerservice.spi.issuance.events.CredentialDelivered;
 import org.eclipse.edc.issuerservice.spi.issuance.events.CredentialGenerated;
@@ -21,6 +22,7 @@ import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceApproved;
 import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceEvent;
 import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceEventListener;
 import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceProcessErrored;
+import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceReceived;
 import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceRejected;
 import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceRequested;
 import org.eclipse.edc.issuerservice.spi.issuance.model.IssuanceProcess;
@@ -29,6 +31,7 @@ import org.eclipse.edc.spi.event.EventRouter;
 
 import java.time.Clock;
 import java.util.Collection;
+import java.util.Map;
 
 public class IssuanceEventPublisher implements IssuanceEventListener {
     private final Clock clock;
@@ -40,7 +43,17 @@ public class IssuanceEventPublisher implements IssuanceEventListener {
     }
 
     @Override
-    public void received(IssuanceProcess ip) {
+    public void received(String holderPid, String issuerParticipantContextId, Map<String, CredentialFormat> formats) {
+        var event = IssuanceReceived.Builder.newInstance()
+                .issuerParticipantContextId(issuerParticipantContextId)
+                .holderProcessId(holderPid)
+                .requestedFormats(formats)
+                .build();
+        publishEvent(event);
+    }
+
+    @Override
+    public void requested(IssuanceProcess ip) {
         var event = baseBuilder(IssuanceRequested.Builder.newInstance(), ip)
                 .credentialDefinitionIds(ip.getCredentialDefinitions())
                 .credentialFormats(ip.getCredentialFormats())
@@ -52,7 +65,7 @@ public class IssuanceEventPublisher implements IssuanceEventListener {
     @Override
     public void rejected(String holderPid, String issuerParticipantContextId, String failureDetail) {
         var event = IssuanceRejected.Builder.newInstance()
-                .holderId(holderPid)
+                .holderProcessId(holderPid)
                 .issuerParticipantContextId(issuerParticipantContextId)
                 .reason(failureDetail)
                 .build();

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
@@ -51,6 +51,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -217,6 +218,66 @@ public class DcpIssuanceFlowEndToEndTest {
             inOrder.verify(subscriber).on(argThat(env -> env.getPayload() instanceof IssuanceApproved));
             inOrder.verify(subscriber).on(argThat(env -> env.getPayload() instanceof CredentialGenerated));
             inOrder.verify(subscriber).on(argThat(env -> env.getPayload() instanceof CredentialDelivered));
+        }
+
+        @Test
+        void issuanceFlow_rejectExistingProcessByHolderPid(IssuerService issuer, IdentityHub identityHub) {
+            var subscriber = mock(EventSubscriber.class);
+            issuer.registerListener(IssuanceEvent.class, subscriber);
+
+            var nameMapping = new MappingDefinition("participant.name", "credentialSubject.name", true);
+            var idMapping = new MappingDefinition("participant.id", "credentialSubject.id", true);
+            var credentialDefinitionId = UUID.randomUUID().toString();
+            var format = VC2_0_JOSE;
+            var credentialType = "MembershipCredential_20_" + UUID.randomUUID();
+
+            var attestationDefinition = setupIssuer(issuer, Map.of(
+                    "claim", "onboarding.signedDocuments",
+                    "operator", "eq",
+                    "value", true), List.of(nameMapping, idMapping), format, credentialDefinitionId, credentialType);
+
+            var attestationSource = mock(AttestationSource.class);
+            when(ATTESTATION_SOURCE_FACTORY.createSource(refEq(attestationDefinition))).thenReturn(attestationSource);
+            when(attestationSource.execute(any()))
+                    .thenReturn(Result.success(Map.of("onboarding", Map.of("signedDocuments", true), "participant", Map.of("name", "Alice", "id", participantDid))));
+
+            var requestId = UUID.randomUUID().toString();
+            var request = """
+                    {
+                      "issuerDid": "%s",
+                      "holderPid": "%s",
+                      "credentials": [{ "format": "%s", "id": "%s", "type": "%s" }]
+                    }
+                    """.formatted(issuerDid, requestId, format.name(), credentialDefinitionId, credentialType);
+
+            // make first request - expect it to fail
+            identityHub.getIdentityEndpoint().baseRequest()
+                    .contentType(JSON)
+                    .header(new Header("x-api-key", participantToken))
+                    .body(request)
+                    .post("/v1beta/participants/%s/credentials/request".formatted(PARTICIPANT_ID))
+                    .then()
+                    .log().all()
+                    .statusCode(201);
+
+            // wait for the issuance process to be approved on the issuer side
+            await().pollInterval(INTERVAL)
+                    .atMost(TIMEOUT)
+                    .untilAsserted(() -> assertThat(issuer.getIssuanceProcessesForParticipant(ISSUER_ID)).hasSizeGreaterThanOrEqualTo(1)
+                            .anySatisfy(t -> {
+                                assertThat(t.getHolderPid()).isEqualTo(requestId);
+                                assertThat(t.getState()).isGreaterThanOrEqualTo(IssuanceProcessStates.APPROVED.code());
+                            }));
+
+            // make another request with the same holder-PID, expect a 409
+            identityHub.getIdentityEndpoint().baseRequest()
+                    .contentType(JSON)
+                    .header(new Header("x-api-key", participantToken))
+                    .body(request)
+                    .post("/v1beta/participants/%s/credentials/request".formatted(PARTICIPANT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(409);
         }
 
         /**

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
@@ -250,7 +250,7 @@ public class DcpIssuanceFlowEndToEndTest {
                     }
                     """.formatted(issuerDid, requestId, format.name(), credentialDefinitionId, credentialType);
 
-            // make first request - expect it to fail
+            // make first request - expect it to succeed
             identityHub.getIdentityEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(new Header("x-api-key", participantToken))

--- a/e2e-tests/tck-tests/presentation/build.gradle.kts
+++ b/e2e-tests/tck-tests/presentation/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     testRuntimeOnly(libs.dcp.testcases)
     testImplementation(libs.restAssured)
     testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.edc.lib.store)
 
     testImplementation(libs.tck.runtime)
     testImplementation(libs.dcp.system)

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowTest.java
@@ -30,12 +30,21 @@ import org.eclipse.edc.issuerservice.spi.holder.model.Holder;
 import org.eclipse.edc.issuerservice.spi.holder.store.HolderStore;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionService;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.CredentialDefinitionService;
+import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceReceived;
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
+import org.eclipse.edc.issuerservice.spi.issuance.process.store.IssuanceProcessStore;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.event.EventSubscriber;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.store.InMemoryStatefulEntityStore;
 import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -101,6 +110,21 @@ public class DcpIssuerIssuanceFlowTest {
         createHolder(issuer, holderDid);
         var response = createParticipantContext(issuer, baseIssuerServiceUrl);
         createDefinitions(issuer);
+
+        var issuanceProcessStore = issuer.getService(IssuanceProcessStore.class);
+
+        // this block deletes all potentially existing issuance processes with the same holderPID for the holder to avoid unintended 409 errors
+        //noinspection rawtypes
+        if (issuanceProcessStore instanceof InMemoryStatefulEntityStore memStore) {
+            issuer.getService(EventRouter.class).registerSync(IssuanceReceived.class, new EventSubscriber() {
+                @Override
+                public <E extends Event> void on(EventEnvelope<E> event) {
+                    var holderPid = ((IssuanceReceived) event.getPayload()).getHolderProcessId();
+                    var query = QuerySpec.Builder.newInstance().filter(new Criterion("holderPid", "=", holderPid)).build();
+                    issuanceProcessStore.query(query).forEach(ip -> memStore.delete(ip.getId()));
+                }
+            });
+        }
 
         var result = TckRuntime.Builder.newInstance()
                 .properties(Map.of(

--- a/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowWithDockerTest.java
+++ b/e2e-tests/tck-tests/presentation/src/test/java/org/eclipse/edc/test/e2e/tck/issuer/DcpIssuerIssuanceFlowWithDockerTest.java
@@ -27,14 +27,23 @@ import org.eclipse.edc.issuerservice.spi.holder.model.Holder;
 import org.eclipse.edc.issuerservice.spi.holder.store.HolderStore;
 import org.eclipse.edc.issuerservice.spi.issuance.attestation.AttestationDefinitionService;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.CredentialDefinitionService;
+import org.eclipse.edc.issuerservice.spi.issuance.events.IssuanceReceived;
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.MappingDefinition;
+import org.eclipse.edc.issuerservice.spi.issuance.process.store.IssuanceProcessStore;
 import org.eclipse.edc.junit.extensions.ComponentRuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.utils.Endpoints;
+import org.eclipse.edc.spi.event.Event;
+import org.eclipse.edc.spi.event.EventEnvelope;
+import org.eclipse.edc.spi.event.EventRouter;
+import org.eclipse.edc.spi.event.EventSubscriber;
 import org.eclipse.edc.spi.monitor.ConsoleMonitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.store.InMemoryStatefulEntityStore;
 import org.eclipse.edc.test.e2e.tck.TckTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -116,6 +125,21 @@ public class DcpIssuerIssuanceFlowWithDockerTest {
         createHolder(issuer, holderDid);
         var response = createParticipantContext(issuer, baseIssuerServiceUrl);
         createDefinitions(issuer);
+
+        var issuanceProcessStore = issuer.getService(IssuanceProcessStore.class);
+
+        // this block deletes all potentially existing issuance processes with the same holderPID for the holder to avoid unintended 409 errors
+        //noinspection rawtypes
+        if (issuanceProcessStore instanceof InMemoryStatefulEntityStore memStore) {
+            issuer.getService(EventRouter.class).registerSync(IssuanceReceived.class, new EventSubscriber() {
+                @Override
+                public <E extends Event> void on(EventEnvelope<E> event) {
+                    var holderPid = ((IssuanceReceived) event.getPayload()).getHolderProcessId();
+                    var query = QuerySpec.Builder.newInstance().filter(new Criterion("holderPid", "=", holderPid)).build();
+                    issuanceProcessStore.query(query).forEach(ip -> memStore.delete(ip.getId()));
+                }
+            });
+        }
 
         try (var tckContainer = new GenericContainer<>("eclipsedataspacetck/dcp-tck-runtime:1.0.0-RC7")
                 .withExtraHost("host.docker.internal", "host-gateway")

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-27T11:00:00Z",
+    "lastUpdated": "2026-05-28T11:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-27T15:00:00Z",
+    "lastUpdated": "2026-05-28T10:00:00Z",
     "maturity": null
   }
 ]

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1beta/credentialrequest/CredentialRequestApiController.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1beta/credentialrequest/CredentialRequestApiController.java
@@ -92,7 +92,7 @@ public class CredentialRequestApiController implements CredentialRequestApi {
 
         return dcpIssuerService.initiateCredentialsIssuance(participantContext.getParticipantContextId(), credentialMessage, participant)
                 .map(response -> Response.created(URI.create("/v1beta/participants/%s/requests/%s".formatted(participantContextId, response.requestId()))).build())
-                .orElseThrow(exceptionMapper(CredentialRequestMessage.class, null));
+                .orElseThrow(exceptionMapper(CredentialRequestMessage.class));
 
     }
 }

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImpl.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImpl.java
@@ -77,7 +77,6 @@ public class DcpIssuerServiceImpl implements DcpIssuerService {
 
         if (credentialFormats.failed()) {
             return ServiceResult.badRequest(credentialFormats.getFailureMessages());
-
         }
         return transactionContext.execute(() -> getCredentialsDefinitions(message, credentialFormats.getContent())
                 .compose(credentialDefinitions -> evaluateAttestations(context, credentialDefinitions))
@@ -157,6 +156,15 @@ public class DcpIssuerServiceImpl implements DcpIssuerService {
 
     private ServiceResult<IssuanceProcess> createIssuanceProcess(String participantContextId, String holderPid, Map<String, CredentialFormat> credentialFormats, DcpRequestContext context, AttestationEvaluationResponse evaluationResponse) {
 
+        var query = QuerySpec.Builder.newInstance()
+                .filter(Criterion.criterion("holderPid", "=", holderPid))
+                .filter(Criterion.criterion("participantContextId", "=", participantContextId))
+                .build();
+
+        var existing = issuanceProcessStore.query(query).findAny();
+        if (existing.isPresent()) {
+            return ServiceResult.conflict("An issuance process with holderPid '%s' already exists for this participant.".formatted(holderPid));
+        }
 
         var credentialDefinitionIds = evaluationResponse.credentialDefinitions().stream()
                 .map(CredentialDefinition::getId)

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImpl.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImpl.java
@@ -71,19 +71,23 @@ public class DcpIssuerServiceImpl implements DcpIssuerService {
     @Override
     public ServiceResult<CredentialRequestMessage.Response> initiateCredentialsIssuance(String participantContextId, CredentialRequestMessage message, DcpRequestContext context) {
         if (message.getCredentials().isEmpty()) {
+            observable.invokeForEach(l -> l.rejected(message.getHolderPid(), participantContextId, "No credentials requested"));
             return ServiceResult.badRequest("No credentials requested");
         }
         var credentialFormats = parseCredentialFormats(message);
 
         if (credentialFormats.failed()) {
+            observable.invokeForEach(l -> l.rejected(message.getHolderPid(), participantContextId, credentialFormats.getFailureDetail()));
             return ServiceResult.badRequest(credentialFormats.getFailureMessages());
         }
+
+        observable.invokeForEach(l -> l.received(message.getHolderPid(), participantContextId, credentialFormats.getContent()));
         return transactionContext.execute(() -> getCredentialsDefinitions(message, credentialFormats.getContent())
                 .compose(credentialDefinitions -> evaluateAttestations(context, credentialDefinitions))
                 .compose(this::evaluateRules)
                 .compose(evaluation -> createIssuanceProcess(participantContextId, message.getHolderPid(), credentialFormats.getContent(), context, evaluation))
                 .onSuccess(ip -> {
-                    observable.invokeForEach(l -> l.received(ip));
+                    observable.invokeForEach(l -> l.requested(ip));
                 })
                 .onFailure(f -> {
                     observable.invokeForEach(l -> l.rejected(message.getHolderPid(), participantContextId, f.getFailureDetail()));

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
@@ -32,6 +32,7 @@ import org.eclipse.edc.issuerservice.spi.issuance.model.IssuanceProcessStates;
 import org.eclipse.edc.issuerservice.spi.issuance.process.store.IssuanceProcessStore;
 import org.eclipse.edc.issuerservice.spi.issuance.rule.CredentialRuleDefinitionEvaluator;
 import org.eclipse.edc.spi.result.Result;
+import org.eclipse.edc.spi.result.ServiceFailure;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.transaction.spi.NoopTransactionContext;
 import org.eclipse.edc.transaction.spi.TransactionContext;
@@ -43,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat.VC1_0_JWT;
@@ -101,6 +103,7 @@ public class DcpIssuerServiceImplTest {
         when(attestationPipeline.evaluate(eq(attestations), any())).thenReturn(Result.success(claims));
         when(credentialRuleDefinitionEvaluator.evaluate(eq(List.of(credentialRuleDefinition)), any())).thenReturn(Result.success());
         when(dcpProfileRegistry.profilesFor(VC1_0_JWT)).thenReturn(List.of(new DcpProfile("profile", VC1_0_JWT, "statusType")));
+        when(issuanceProcessStore.query(any())).thenReturn(Stream.of());
 
         var result = dcpIssuerService.initiateCredentialsIssuance("participantContextId", message, participant);
 
@@ -127,6 +130,44 @@ public class DcpIssuerServiceImplTest {
         //noinspection unchecked
         listenerCaptor.getValue().accept(listener);
         verify(listener).received(issuanceProcess);
+    }
+
+    @Test
+    void initiateCredentialsIssuance_whenDuplicateHolderPid_returnsConflict() {
+
+        var holderPid = UUID.randomUUID().toString();
+        var message = CredentialRequestMessage.Builder.newInstance()
+                .holderPid(holderPid)
+                .credential(new CredentialRequestSpecifier("credentialDefinitionId1"))
+                .build();
+
+        var attestations = Set.of("attestation1");
+        var credentialDefinition = CredentialDefinition.Builder.newInstance()
+                .id("credentialDefinitionId1")
+                .credentialType("MembershipCredential")
+                .jsonSchema("jsonSchema")
+                .jsonSchemaUrl("jsonSchemaUrl")
+                .attestations(attestations)
+                .participantContextId("participantContextId")
+                .formatFrom(VC1_0_JWT)
+                .build();
+
+        var holder = Holder.Builder.newInstance().holderId("holderId").did("participantDid").holderName("name").participantContextId("participantContextId").build();
+        var participant = new DcpRequestContext(holder, Map.of());
+
+        var existingProcess = IssuanceProcess.Builder.newInstance().holderPid(holderPid).holderId("holderId").participantContextId("participantContextId").state(IssuanceProcessStates.APPROVED.code()).build();
+
+        when(credentialDefinitionService.queryCredentialDefinitions(any())).thenReturn(ServiceResult.success(List.of(credentialDefinition)));
+        when(credentialDefinitionService.findCredentialDefinitionById(anyString())).thenReturn(ServiceResult.success(credentialDefinition));
+        when(attestationPipeline.evaluate(eq(attestations), any())).thenReturn(Result.success(Map.of()));
+        when(credentialRuleDefinitionEvaluator.evaluate(any(), any())).thenReturn(Result.success());
+        when(dcpProfileRegistry.profilesFor(VC1_0_JWT)).thenReturn(List.of(new DcpProfile("profile", VC1_0_JWT, "statusType")));
+        when(issuanceProcessStore.query(any())).thenReturn(Stream.of(existingProcess));
+
+        var result = dcpIssuerService.initiateCredentialsIssuance("participantContextId", message, participant);
+
+        assertThat(result).isFailed().satisfies(f -> assertThat(f.getReason()).isEqualTo(ServiceFailure.Reason.CONFLICT));
+        verify(issuanceProcessStore, never()).save(any());
     }
 
     @Test

--- a/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-core/src/test/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/DcpIssuerServiceImplTest.java
@@ -54,6 +54,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -125,11 +126,11 @@ public class DcpIssuerServiceImplTest {
 
         var listenerCaptor = ArgumentCaptor.forClass(Consumer.class);
         //noinspection unchecked
-        verify(issuanceObservable).invokeForEach(listenerCaptor.capture());
+        verify(issuanceObservable, times(2)).invokeForEach(listenerCaptor.capture());
         var listener = mock(IssuanceEventListener.class);
         //noinspection unchecked
         listenerCaptor.getValue().accept(listener);
-        verify(listener).received(issuanceProcess);
+        verify(listener).requested(issuanceProcess);
     }
 
     @Test
@@ -207,7 +208,7 @@ public class DcpIssuerServiceImplTest {
 
         var listenerCaptor = ArgumentCaptor.forClass(Consumer.class);
         //noinspection unchecked
-        verify(issuanceObservable).invokeForEach(listenerCaptor.capture());
+        verify(issuanceObservable, times(2)).invokeForEach(listenerCaptor.capture());
         var listener = mock(IssuanceEventListener.class);
         //noinspection unchecked
         listenerCaptor.getValue().accept(listener);

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceEvent.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceEvent.java
@@ -80,7 +80,7 @@ public abstract class IssuanceEvent extends Event {
 
         public T build() {
             Objects.requireNonNull(event.issuerParticipantContextId);
-            Objects.requireNonNull(event.holderId);
+            Objects.requireNonNull(event.holderProcessId);
             return event;
         }
     }

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceEventListener.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceEventListener.java
@@ -14,11 +14,13 @@
 
 package org.eclipse.edc.issuerservice.spi.issuance.events;
 
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.issuerservice.spi.issuance.model.IssuanceProcess;
 import org.eclipse.edc.spi.observe.Observable;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Interface implemented by listeners registered to observe credential issuance changes via {@link Observable#registerListener}.
@@ -27,10 +29,18 @@ import java.util.Collection;
 public interface IssuanceEventListener {
 
     /**
+     * A credential issuance request was received. A decision whether it is rejected or will be processed further is not
+     * made yet.
+     */
+    default void received(String holderPid, String participantContextId, Map<String, CredentialFormat> content) {
+
+    }
+
+    /**
      * A credential issuance request was successfully received and will be processed further by the Issuer service.
      * An {@link IssuanceApproved} has been created to represent the request internally.
      */
-    default void received(IssuanceProcess ip) {
+    default void requested(IssuanceProcess ip) {
 
     }
 

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceEventListener.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceEventListener.java
@@ -31,6 +31,7 @@ public interface IssuanceEventListener {
     /**
      * A credential issuance request was received. A decision whether it is rejected or will be processed further is not
      * made yet.
+     * An {@link IssuanceReceived} has been created to represent the request internally.
      */
     default void received(String holderPid, String participantContextId, Map<String, CredentialFormat> content) {
 
@@ -38,7 +39,7 @@ public interface IssuanceEventListener {
 
     /**
      * A credential issuance request was successfully received and will be processed further by the Issuer service.
-     * An {@link IssuanceApproved} has been created to represent the request internally.
+     * An {@link IssuanceRequested} has been created to represent the request internally.
      */
     default void requested(IssuanceProcess ip) {
 

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceReceived.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceReceived.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.spi.issuance.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
+
+import java.util.Map;
+
+public class IssuanceReceived extends IssuanceEvent {
+
+    @Override
+    public String name() {
+        return "issuance.received";
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends IssuanceEvent.Builder<IssuanceReceived, IssuanceReceived.Builder> {
+
+        private Map<String, CredentialFormat> requestedFormats;
+
+        protected Builder() {
+            super(new IssuanceReceived());
+        }
+
+        @JsonCreator
+        public static IssuanceReceived.Builder newInstance() {
+            return new IssuanceReceived.Builder();
+        }
+
+
+        @Override
+        public IssuanceReceived.Builder self() {
+            return this;
+        }
+
+        public Builder requestedFormats(Map<String, CredentialFormat> formats) {
+            this.requestedFormats = formats;
+            return self();
+        }
+
+        public Map<String, CredentialFormat> getRequestedFormats() {
+            return requestedFormats;
+        }
+    }
+}

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceReceived.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/events/IssuanceReceived.java
@@ -22,15 +22,19 @@ import java.util.Map;
 
 public class IssuanceReceived extends IssuanceEvent {
 
+    private Map<String, CredentialFormat> requestedFormats;
+
     @Override
     public String name() {
         return "issuance.received";
     }
 
+    public Map<String, CredentialFormat> getRequestedFormats() {
+        return requestedFormats;
+    }
+
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends IssuanceEvent.Builder<IssuanceReceived, IssuanceReceived.Builder> {
-
-        private Map<String, CredentialFormat> requestedFormats;
 
         protected Builder() {
             super(new IssuanceReceived());
@@ -47,13 +51,14 @@ public class IssuanceReceived extends IssuanceEvent {
             return this;
         }
 
-        public Builder requestedFormats(Map<String, CredentialFormat> formats) {
-            this.requestedFormats = formats;
-            return self();
+        @Override
+        public IssuanceReceived build() {
+            return super.build();
         }
 
-        public Map<String, CredentialFormat> getRequestedFormats() {
-            return requestedFormats;
+        public Builder requestedFormats(Map<String, CredentialFormat> formats) {
+            this.event.requestedFormats = formats;
+            return self();
         }
     }
 }


### PR DESCRIPTION
## Summary

- on the holder side: `CredentialRequestManagerImpl.initiateRequest` checks for an existing holder credential request with the same `holderPid` and returns `CONFLICT` if found.

- on the issuer side: `DcpIssuerServiceImpl.createIssuanceProcess` now queries the issuance process store by `holderPid` + `participantContextId` before creating a new process, returning a `CONFLICT` result if one already exists.


## Further Remarks

- added the `IssuanceRequested` event on the issuer side, because it didn't exist before. 

Closes #749 