### PR TITLE
fix: map name and description claims

### DIFF
--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/Constants.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/Constants.java
@@ -23,5 +23,7 @@ public interface Constants {
     String VALID_FROM = "validFrom";
     String ID = "id";
     String ISSUER = "issuer";
+    String NAME = "name";
+    String DESCRIPTION = "description";
     String W3C_CREDENTIALS_URL_V2 = "https://www.w3.org/ns/credentials/v2";
 }

--- a/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/JoseVcdm20CredentialGenerator.java
+++ b/core/issuerservice/issuerservice-issuance/src/main/java/org/eclipse/edc/issuerservice/issuance/generator/JoseVcdm20CredentialGenerator.java
@@ -42,8 +42,10 @@ import java.util.UUID;
 
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.CREDENTIAL_STATUS;
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.CREDENTIAL_SUBJECT;
+import static org.eclipse.edc.issuerservice.issuance.generator.Constants.DESCRIPTION;
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.ID;
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.ISSUER;
+import static org.eclipse.edc.issuerservice.issuance.generator.Constants.NAME;
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.TYPE;
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.VALID_FROM;
 import static org.eclipse.edc.issuerservice.issuance.generator.Constants.VERIFIABLE_CREDENTIAL;
@@ -90,6 +92,13 @@ public class JoseVcdm20CredentialGenerator implements CredentialGenerator {
                         .build());
 
         statusResult.onSuccess(builder::credentialStatus);
+
+        if (claims.containsKey(NAME)) {
+            builder.name((String) claims.get(NAME));
+        }
+        if (claims.containsKey(DESCRIPTION)) {
+            builder.description((String) claims.get(DESCRIPTION));
+        }
 
         var credential = builder.build();
 
@@ -142,10 +151,10 @@ public class JoseVcdm20CredentialGenerator implements CredentialGenerator {
             claims.put("validUntil", credential.getExpirationDate().toString());
         }
         if (credential.getDescription() != null) {
-            claims.put("description", credential.getDescription());
+            claims.put(DESCRIPTION, credential.getDescription());
         }
         if (credential.getName() != null) {
-            claims.put("name", credential.getName());
+            claims.put(NAME, credential.getName());
         }
 
         var status = credentialStatusClaims(credential);

--- a/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JoseVcdm20CredentialGeneratorTest.java
+++ b/core/issuerservice/issuerservice-issuance/src/test/java/org/eclipse/edc/issuerservice/issuance/generator/JoseVcdm20CredentialGeneratorTest.java
@@ -124,7 +124,7 @@ class JoseVcdm20CredentialGeneratorTest {
     }
 
     @Test
-    void generateCredential_additionalContext() throws ParseException {
+    void generateCredential_additionalContext() {
         var subjectClaims = Map.of("name", "Foo Bar");
         var statusClaims = Map.of("id", UUID.randomUUID().toString(),
                 TYPE, "BitStringStatusListEntry",
@@ -149,9 +149,8 @@ class JoseVcdm20CredentialGeneratorTest {
 
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
-    void generateCredential_whenNoStatus() throws ParseException {
+    void generateCredential_whenNoStatus() {
 
         var subjectClaims = Map.of("name", "Foo Bar");
         Map<String, Object> claims = Map.of(CREDENTIAL_SUBJECT, subjectClaims);
@@ -183,6 +182,23 @@ class JoseVcdm20CredentialGeneratorTest {
         REQUIRED_CLAIMS.forEach(claim -> assertThat(extractedClaims.getClaim(claim)).describedAs("Claim '%s' cannot be null", claim).isNotNull());
         assertThat(extractJwtHeader(container.rawVc()).getKeyID()).isEqualTo("did:example:issuer#%s".formatted(PUBLIC_KEY_ID));
         assertThat(extractedClaims.getClaims()).doesNotContainKey(CREDENTIAL_STATUS);
+    }
+
+    @Test
+    void generateCredential_withNameAndDescription() {
+        var subjectClaims = Map.of("foo", "bar");
+        Map<String, Object> claims = Map.of(CREDENTIAL_SUBJECT, subjectClaims, "name", "Test Credential", "description", "A test credential");
+
+        var result = jwtCredentialGenerator.generateCredential(TEST_PARTICIPANT, createCredentialDefinition(), PRIVATE_KEY_ALIAS, PUBLIC_KEY_ID, "did:example:issuer", "did:example:participant", claims);
+
+        assertThat(result).isSucceeded();
+        assertThat(result.getContent().credential()).satisfies(vc -> {
+            assertThat(vc.getName()).isEqualTo("Test Credential");
+            assertThat(vc.getDescription()).isEqualTo("A test credential");
+        });
+        var extractedClaims = extractJwtClaims(result.getContent().rawVc());
+        assertThat(extractedClaims.getClaim("name")).isEqualTo("Test Credential");
+        assertThat(extractedClaims.getClaim("description")).isEqualTo("A test credential");
     }
 
     @Test

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowEndToEndTest.java
@@ -122,16 +122,22 @@ public class DcpIssuanceFlowEndToEndTest {
 
             var nameMapping = new MappingDefinition("participant.name", "credentialSubject.name", true);
             var idMapping = new MappingDefinition("participant.id", "credentialSubject.id", true);
+            var credentialNameMapping = new MappingDefinition("participant.credentialName", "name", true);
+            var credentialDescMapping = new MappingDefinition("participant.credentialDescription", "description", true);
             var credentialDefinitionId = UUID.randomUUID().toString();
             var attestationDefinition = setupIssuer(issuer, Map.of(
                     "claim", "onboarding.signedDocuments",
                     "operator", "eq",
-                    "value", true), List.of(nameMapping, idMapping), format, credentialDefinitionId, credentialType);
+                    "value", true), List.of(nameMapping, idMapping, credentialNameMapping, credentialDescMapping), format, credentialDefinitionId, credentialType);
 
             var attestationSource = mock(AttestationSource.class);
             when(ATTESTATION_SOURCE_FACTORY.createSource(refEq(attestationDefinition))).thenReturn(attestationSource);
             when(attestationSource.execute(any()))
-                    .thenReturn(Result.success(Map.of("onboarding", Map.of("signedDocuments", true), "participant", Map.of("name", "Alice", "id", participantDid))));
+                    .thenReturn(Result.success(Map.of("onboarding", Map.of("signedDocuments", true),
+                            "participant", Map.of("name", "Alice",
+                                    "id", participantDid,
+                                    "credentialName", "test-credential-name",
+                                    "credentialDescription", "test-credential-description"))));
 
             var requestId = UUID.randomUUID().toString();
             var request = """
@@ -178,6 +184,10 @@ public class DcpIssuanceFlowEndToEndTest {
                         assertThat(vc.getStateAsEnum()).isEqualTo(VcStatus.ISSUED);
                         assertThat(vc.getIssuerId()).isEqualTo(issuerDid);
                         assertThat(vc.getHolderId()).isEqualTo(participantDid);
+                        if (format == VC2_0_JOSE) {
+                            assertThat(vc.getVerifiableCredential().credential().getName()).isEqualTo("test-credential-name");
+                            assertThat(vc.getVerifiableCredential().credential().getDescription()).isEqualTo("test-credential-description");
+                        }
                         assertThat(vc.getVerifiableCredential().credential().getCredentialStatus()).isNotEmpty()
                                 .anySatisfy(t -> {
                                     assertThat(t.getProperty("", "statusPurpose").toString()).isEqualTo("revocation");

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-28T11:00:00Z",
+    "lastUpdated": "2026-05-28T13:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-28T10:00:00Z",
+    "lastUpdated": "2026-05-28T11:00:00Z",
     "maturity": null
   }
 ]

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/resources/issuer-api-version.json
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/resources/issuer-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-27T16:00:00Z",
+    "lastUpdated": "2026-05-28T11:00:00Z",
     "maturity": null
   }
 ]


### PR DESCRIPTION
## What this PR changes/adds

this PR properly maps the `name` and `description` claims from the `MappingDefinition` into the credential if present.

## Why it does that

VCDM2.0 defines those properties, so they should be in the credential if available

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #701

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
