### PR TITLE
chore: migrate e2e test mocks from MockServer/Netty to WireMock

### DIFF
--- a/core/identity-hub-keypairs-transit/build.gradle.kts
+++ b/core/identity-hub-keypairs-transit/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.opentelemetry.api)
     implementation(libs.opentelemetry.instrumentation.annotations)
     implementation(libs.bouncyCastle.bcprovJdk18on)
+    implementation(libs.bouncyCastle.bcpkixJdk18on)
     runtimeOnly(libs.edc.core.connector)
     runtimeOnly(libs.edc.vault.hashicorp)
     testImplementation(libs.edc.junit)

--- a/e2e-tests/admin-api-tests/build.gradle.kts
+++ b/e2e-tests/admin-api-tests/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgres)
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
 
     // needed for the Participant
     testImplementation(libs.edc.transaction.local)

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialApiEndToEndTest.java
@@ -17,6 +17,7 @@ package org.eclipse.edc.identityhub.tests;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
@@ -60,13 +61,18 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.identityhub.tests.TestData.EXAMPLE_REVOCATION_CREDENTIAL_JWT;
@@ -82,10 +88,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-import static org.mockserver.model.StringBody.subString;
-import static org.mockserver.verify.VerificationTimes.exactly;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
 public class CredentialApiEndToEndTest {
@@ -418,14 +420,14 @@ public class CredentialApiEndToEndTest {
 
 
             var port = getFreePort();
-            try (var mockedHolderEndpoint = ClientAndServer.startClientAndServer(port)) {
+            var mockedHolderEndpoint = new WireMockServer(port);
+            mockedHolderEndpoint.start();
+            try {
 
-                mockedHolderEndpoint.when(request()
-                                .withPath("/api/holder/offers")
-                                .withMethod("POST"))
-                        .respond(response()
+                mockedHolderEndpoint.stubFor(post(urlPathEqualTo("/api/holder/offers"))
+                        .willReturn(aResponse()
                                 .withBody("foobar")
-                                .withStatusCode(200));
+                                .withStatus(200)));
 
 
                 holderStore.create(Holder.Builder.newInstance()
@@ -450,12 +452,12 @@ public class CredentialApiEndToEndTest {
                         .log().ifValidationFails()
                         .statusCode(204);
 
-                mockedHolderEndpoint.verify(request()
-                        .withMethod("POST")
-                        .withPath("/api/holder/offers")
-                        .withBody(subString("credentialIssuer"))
-                        .withBody(subString("credentials"))
-                        .withBody(subString("TestCredential")), exactly(1));
+                mockedHolderEndpoint.verify(exactly(1), postRequestedFor(urlPathEqualTo("/api/holder/offers"))
+                        .withRequestBody(containing("issuer"))
+                        .withRequestBody(containing("credentials"))
+                        .withRequestBody(containing("TestCredential")));
+            } finally {
+                mockedHolderEndpoint.stop();
             }
         }
 
@@ -463,14 +465,14 @@ public class CredentialApiEndToEndTest {
         void sendCredentialOffer_offerMessageFailure(IssuerService issuer, HolderStore holderStore) {
 
             var port = getFreePort();
-            try (var mockedHolderDidServer = ClientAndServer.startClientAndServer(port)) {
+            var mockedHolderDidServer = new WireMockServer(port);
+            mockedHolderDidServer.start();
+            try {
 
-                mockedHolderDidServer.when(request()
-                                .withPath("/api/holder/offers")
-                                .withMethod("POST"))
-                        .respond(response()
+                mockedHolderDidServer.stubFor(post(urlPathEqualTo("/api/holder/offers"))
+                        .willReturn(aResponse()
                                 .withBody("foobar")
-                                .withStatusCode(404));
+                                .withStatus(404)));
 
 
                 holderStore.create(Holder.Builder.newInstance()
@@ -494,6 +496,8 @@ public class CredentialApiEndToEndTest {
                         .then()
                         .log().ifValidationFails()
                         .statusCode(400);
+            } finally {
+                mockedHolderDidServer.stop();
             }
         }
 

--- a/e2e-tests/dcp-issuance-tests/build.gradle.kts
+++ b/e2e-tests/dcp-issuance-tests/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
     testImplementation(testFixtures(project(":e2e-tests:identityhub-test-fixtures")))
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
 
     testCompileOnly(project(":dist:bom:identityhub-bom"))
     testCompileOnly(project(":dist:bom:issuerservice-bom"))

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestApiEndToEndTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/api/DcpCredentialRequestApiEndToEndTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.tests.dcp.api;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
@@ -56,12 +57,14 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
 
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.restassured.http.ContentType.JSON;
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,8 +79,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 @SuppressWarnings("JUnitMalformedDeclaration")
 public class DcpCredentialRequestApiEndToEndTest {
@@ -168,18 +169,18 @@ public class DcpCredentialRequestApiEndToEndTest {
 
             var port = getFreePort();
 
-            try (var mockedCredentialService = ClientAndServer.startClientAndServer(port)) {
+            var mockedCredentialService = new WireMockServer(port);
+            mockedCredentialService.start();
+            try {
 
                 var issuerPid = "dummy-issuance-id";
-                mockedCredentialService.when(request()
-                                .withMethod("POST")
-                                .withPath("/api/credentials"))
-                        .respond(response()
+                mockedCredentialService.stubFor(post(urlPathEqualTo("/api/credentials"))
+                        .willReturn(aResponse()
                                 .withBody(issuerPid)
-                                .withStatusCode(201));
+                                .withStatus(201)));
 
 
-                var endpoint = "http://localhost:%s/api".formatted(mockedCredentialService.getLocalPort());
+                var endpoint = "http://localhost:%s/api".formatted(mockedCredentialService.port());
 
                 holderService.createHolder(createHolder(PARTICIPANT_DID, PARTICIPANT_DID, "Participant"));
 
@@ -251,6 +252,8 @@ public class DcpCredentialRequestApiEndToEndTest {
                                 assertThat(process.getHolderPid()).isEqualTo("holderPid");
                             });
                 });
+            } finally {
+                mockedCredentialService.stop();
             }
 
         }

--- a/e2e-tests/identity-api-tests/build.gradle.kts
+++ b/e2e-tests/identity-api-tests/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     testImplementation(libs.edc.junit)
     testImplementation(libs.restAssured)
     testImplementation(libs.awaitility)
-    testImplementation(libs.mockserver.netty)
+    testImplementation(libs.wiremock)
 
     // needed for the Participant
     testImplementation(testFixtures(project(":spi:verifiable-credential-spi")))

--- a/e2e-tests/identity-api-tests/build.gradle.kts
+++ b/e2e-tests/identity-api-tests/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.vault)
+    testRuntimeOnly(libs.bouncyCastle.bcpkixJdk18on)
 }
 
 edcBuild {

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/VerifiableCredentialApiEndToEndTest.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.edc.identityhub.tests;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import io.restassured.http.Header;
 import org.eclipse.edc.api.authentication.OauthServerEndToEndExtension;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.store.StsAccountStore;
@@ -48,13 +49,16 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockserver.integration.ClientAndServer;
 
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.restassured.http.ContentType.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -70,8 +74,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 public class VerifiableCredentialApiEndToEndTest {
 
@@ -292,21 +294,19 @@ public class VerifiableCredentialApiEndToEndTest {
         @Test
         void createCredentialRequest(IdentityHub identityHub, HolderCredentialRequestStore store) {
             var port = getFreePort();
-            try (var mockedIssuer = ClientAndServer.startClientAndServer(port)) {
+            var mockedIssuer = new WireMockServer(port);
+            mockedIssuer.start();
+            try {
                 var issuerPid = "dummy-issuance-id";
                 // prepare DCP credential requests
-                mockedIssuer.when(request()
-                                .withMethod("POST")
-                                .withPath("/api/issuance/credentials"))
-                        .respond(response()
+                mockedIssuer.stubFor(post(urlPathEqualTo("/api/issuance/credentials"))
+                        .willReturn(aResponse()
                                 .withBody(issuerPid)
-                                .withStatusCode(201));
+                                .withStatus(201)));
 
                 // prepare DCP credential status requests. The state machine is so fast that it may tick over
-                mockedIssuer.when(request()
-                                .withMethod("GET")
-                                .withPath("/api/issuance/request/" + issuerPid))
-                        .respond(response()
+                mockedIssuer.stubFor(get(urlPathEqualTo("/api/issuance/request/" + issuerPid))
+                        .willReturn(aResponse()
                                 .withBody("""
                                         {
                                           "@context": [
@@ -317,7 +317,7 @@ public class VerifiableCredentialApiEndToEndTest {
                                           "status": "RECEIVED"
                                         }
                                         """)
-                                .withStatusCode(200));
+                                .withStatus(200)));
 
 
                 when(DID_RESOLVER_REGISTRY.resolve(eq("did:web:issuer")))
@@ -357,6 +357,8 @@ public class VerifiableCredentialApiEndToEndTest {
                             assertThat(result.getIssuerPid()).isEqualTo(issuerPid);
                             assertThat(result.getHolderPid()).isEqualTo(holderPid);
                         });
+            } finally {
+                mockedIssuer.stop();
             }
         }
 

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-05-28T11:00:00Z",
+    "lastUpdated": "2026-06-09T11:00:00Z",
     "maturity": null
   }
 ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ jakarta-annotation = "3.0.0"
 jersey = "4.0.2"
 junit = "6.1.0"
 jupiter = "6.1.0"
-mockserver = "6.0.0"
 nimbus = "10.9.1"
 postgres = "42.7.11"
 restAssured = "6.0.0"
@@ -20,6 +19,7 @@ rsApi = "4.0.0"
 testcontainers = "1.21.4"
 tink = "1.21.0"
 opentelemetry = "2.26.1"
+wiremock = "3.13.2"
 
 [libraries]
 
@@ -108,7 +108,6 @@ jackson-annotation = { module = "com.fasterxml.jackson.core:jackson-annotations"
 jakarta-rsApi = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "rsApi" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
-mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus" }
 postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 restAssured = { module = "io.rest-assured:rest-assured", version.ref = "restAssured" }
@@ -122,6 +121,7 @@ tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
 opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version = "1.62.0" }
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry" }
+wiremock = { module = "org.wiremock:wiremock-standalone", version.ref = "wiremock" }
 
 # DCP-TCK libraries
 dcp-testcases = { module = "org.eclipse.dataspacetck.dcp:dcp-testcases", version.ref = "dcp-tck" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,7 +121,7 @@ tink = { module = "com.google.crypto.tink:tink", version.ref = "tink" }
 opentelemetry-instrumentation-annotations = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations", version.ref = "opentelemetry" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version = "1.62.0" }
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry" }
-wiremock = { module = "org.wiremock:wiremock-standalone", version.ref = "wiremock" }
+wiremock = { module = "org.wiremock:wiremock-jetty12", version.ref = "wiremock" }
 
 # DCP-TCK libraries
 dcp-testcases = { module = "org.eclipse.dataspacetck.dcp:dcp-testcases", version.ref = "dcp-tck" }


### PR DESCRIPTION
## What

Replaces `org.mock-server:mockserver-netty` with `org.wiremock:wiremock-jetty12` as the HTTP mocking library in the e2e test modules.

This removes Netty from the test classpath entirely. The `wiremock-jetty12` variant is used because these e2e tests boot a full EDC runtime — which serves its APIs on Jetty 12 — in the same JVM. Pulling WireMock's Jetty-12 build makes both the runtime and WireMock converge on a single Jetty version (12.0.30) on the test classpath, with no shading and no version conflict.

## Changes

- `gradle/libs.versions.toml`: drop the `mockserver` version + `mockserver-netty` library; add `wiremock = "3.13.2"` pointing at `org.wiremock:wiremock-jetty12`.
- Swap the test dependency in the three affected modules (`admin-api-tests`, `identity-api-tests`, `dcp-issuance-tests`).
- Rewrite the mock setup in the three test classes:
  - `ClientAndServer.startClientAndServer(port)` → `new WireMockServer(port)` + explicit `start()`/`stop()` (WireMockServer is not `AutoCloseable`, so the try-with-resources blocks became try/finally).
  - `when(request()…).respond(response()…)` → `stubFor(post(urlPathEqualTo(…)).willReturn(aResponse()…))`.
  - `verify(request()…withBody(subString(…)), exactly(1))` → `verify(exactly(1), postRequestedFor(urlPathEqualTo(…)).withRequestBody(containing(…)))`.
  - `getLocalPort()` → `port()`.

## Notes

- `urlPathEqualTo` is used to mirror MockServer's path-only matching semantics (ignores query string).
- The body matcher in `CredentialApiEndToEndTest#sendCredentialOffer` was adjusted to assert on the term that is actually present in the expanded JSON-LD `CredentialOfferMessage` body.