### PR TITLE
docs: update revocation documentation

### DIFF
--- a/docs/developer/architecture/issuer/credential-revocation/credential-revocation.md
+++ b/docs/developer/architecture/issuer/credential-revocation/credential-revocation.md
@@ -53,15 +53,18 @@ credential:
 Requests to revoke a holder credential are sent via the IssuerService's REST API:
 
 ```http request
-POST /v1beta/credentials/{credentialId}/revoke
+POST /v1beta/participants/{participantContextId}/credentials/{credentialResourceId}/revoke
 ```
 
 This request is processed by
 the [IssuerCredentialsAdminApiController](../../../../../extensions/api/issuer-admin-api/credentials-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentials/v1/unstable/IssuerCredentialsAdminApiController.java)
 and delegated to the `CredentialServiceImpl`.
 
-The `credentialId` is the only information that is required to perform the necessary actions. The
-`CredentialServiceImpl` performs the following steps:
+Next to the `participantContextId`, the `credentialResourceId` is the only information that is required to perform the
+necessary actions. Note, that this is the ID of the `VerifiableCredentialResource` that represents the holder
+credential, and not the ID of the credential itself.
+
+The `CredentialServiceImpl` performs the following steps:
 
 #### 1. obtain holder credential
 
@@ -177,7 +180,7 @@ IssuerService.
 Execute the following REST request against the IssuerService's Admin API:
 
 ```http request
-GET /v1beta/credentials/{credentialId}/status
+GET /v1beta/participants/{participantContextId}/credentials/{credentialResourceId}/status
 ```
 
 the response will be `HTTP 200` if the status information has been obtained. An empty response body indicates that the

--- a/extensions/store/sql/identity-hub-credentials-store-sql/src/main/resources/credentials-schema.sql
+++ b/extensions/store/sql/identity-hub-credentials-store-sql/src/main/resources/credentials-schema.sql
@@ -15,7 +15,7 @@
 -- only intended for and tested with Postgres!
 CREATE TABLE IF NOT EXISTS credential_resource
 (
-    id                     VARCHAR PRIMARY KEY NOT NULL, -- ID of the VC, duplicated here for indexing purposes
+    id                     VARCHAR PRIMARY KEY NOT NULL,
     create_timestamp       BIGINT              NOT NULL, -- POSIX timestamp of the creation of the VC
     issuer_id              VARCHAR             NOT NULL,
     holder_id              VARCHAR             NOT NULL,


### PR DESCRIPTION
## What this PR changes/adds

Updates the documentation on revocation to explicitely describe which ID to use for revocation requests. Also updates the API paths, as these now are bound to the participant context.

## Why it does that

Previously, it was not clear whether the internal resource ID or VC ID should be used for revocation requests.


## Who will sponsor this feature?

me

