### PR TITLE
refactor: use token-exchange for participant-scoped vault auth 

### DIFF
--- a/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/TransitSecurityExtension.java
+++ b/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/TransitSecurityExtension.java
@@ -24,7 +24,7 @@ import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.types.TypeManager;
-import org.eclipse.edc.vault.hashicorp.spi.auth.HashicorpVaultTokenProvider;
+import org.eclipse.edc.vault.hashicorp.spi.auth.HashicorpVaultTokenProviderFactory;
 
 @Extension(value = TransitSecurityExtension.NAME)
 public class TransitSecurityExtension implements ServiceExtension {
@@ -32,7 +32,7 @@ public class TransitSecurityExtension implements ServiceExtension {
     public static final String NAME = "Hashicorp Transit Security Extension";
 
     @Inject
-    private HashicorpVaultTokenProvider tokenProvider;
+    private HashicorpVaultTokenProviderFactory tokenProviderFactory;
     @Inject
     private EdcHttpClient edcHttpClient;
 
@@ -52,7 +52,9 @@ public class TransitSecurityExtension implements ServiceExtension {
     @Provider
     public TransitEngine transitEngine() {
         if (transitEngine == null) {
-            transitEngine = new TransitEngineImpl(tokenProvider, typeManager.getMapper(), edcHttpClient, vaultUrl);
+            // the engine mints a participant-scoped vault token per key (resource derived from the key name),
+            // so it needs the factory rather than a single provider.
+            transitEngine = new TransitEngineImpl(tokenProviderFactory, typeManager.getMapper(), edcHttpClient, vaultUrl);
         }
 
         return transitEngine;

--- a/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/keypairs/TransitKeyPairService.java
+++ b/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/keypairs/TransitKeyPairService.java
@@ -82,7 +82,7 @@ public class TransitKeyPairService implements KeyPairService, EventSubscriber {
     }
 
     private static @NotNull String generateKeyName(String participantContextId, String keyId) {
-        return "participant_" + participantContextId + "_" + keyId;
+        return TransitEngine.keyName(participantContextId, keyId);
     }
 
     @Override

--- a/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/transit/TransitEngine.java
+++ b/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/transit/TransitEngine.java
@@ -28,6 +28,38 @@ public interface TransitEngine {
     );
 
     /**
+     * Prefix for Transit key names. Key names follow the convention {@code participant_<participantContextId>_<keyId>}.
+     * The {@code participantContextId} segment is also the token-exchange {@code resource} used to obtain a vault token
+     * scoped (via the {@code participant} Vault role) to that participant's transit keys.
+     */
+    String KEY_NAME_PREFIX = "participant_";
+
+    /**
+     * Builds the Transit key name for a participant key: {@code participant_<participantContextId>_<keyId>}.
+     *
+     * @param participantContextId the participant context id (must not contain underscores)
+     * @param keyId                the key id / alias (must not contain underscores)
+     */
+    static String keyName(String participantContextId, String keyId) {
+        return KEY_NAME_PREFIX + participantContextId + "_" + keyId;
+    }
+
+    /**
+     * Extracts the participant context id from a key name produced by {@link #keyName(String, String)}, or
+     * {@code null} if the name does not follow the convention. The participant context id is everything between
+     * the {@link #KEY_NAME_PREFIX} and the last underscore (key ids must not contain underscores).
+     */
+    static String participantContextIdFromKeyName(String keyName) {
+        if (keyName != null && keyName.startsWith(KEY_NAME_PREFIX)) {
+            var lastSeparator = keyName.lastIndexOf('_');
+            if (lastSeparator > KEY_NAME_PREFIX.length()) {
+                return keyName.substring(KEY_NAME_PREFIX.length(), lastSeparator);
+            }
+        }
+        return null;
+    }
+
+    /**
      * Generates a new key with the given name. Note that keys are created with the {@code deletion_allowed} flag set to {@code true}.
      *
      * @param keyName The name of the key. Should not contain spaces or special characters.

--- a/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/transit/TransitEngineImpl.java
+++ b/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/transit/TransitEngineImpl.java
@@ -23,7 +23,7 @@ import okhttp3.Response;
 import org.eclipse.edc.http.spi.EdcHttpClient;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.result.Result;
-import org.eclipse.edc.vault.hashicorp.spi.auth.HashicorpVaultTokenProvider;
+import org.eclipse.edc.vault.hashicorp.spi.auth.HashicorpVaultTokenProviderFactory;
 
 import java.io.IOException;
 import java.util.Base64;
@@ -31,13 +31,13 @@ import java.util.Map;
 
 public class TransitEngineImpl implements TransitEngine {
     private static final String VAULT_TOKEN_HEADER = "X-Vault-Token";
-    private final HashicorpVaultTokenProvider tokenProvider;
+    private final HashicorpVaultTokenProviderFactory tokenProviderFactory;
     private final ObjectMapper objectMapper;
     private final EdcHttpClient edcHttpClient;
     private final String vaultBaseUrl;
 
-    public TransitEngineImpl(HashicorpVaultTokenProvider tokenProvider, ObjectMapper objectMapper, EdcHttpClient edcHttpClient, String vaultBaseUrl) {
-        this.tokenProvider = tokenProvider;
+    public TransitEngineImpl(HashicorpVaultTokenProviderFactory tokenProviderFactory, ObjectMapper objectMapper, EdcHttpClient edcHttpClient, String vaultBaseUrl) {
+        this.tokenProviderFactory = tokenProviderFactory;
         this.objectMapper = objectMapper;
         this.edcHttpClient = edcHttpClient;
         this.vaultBaseUrl = vaultBaseUrl;
@@ -45,7 +45,7 @@ public class TransitEngineImpl implements TransitEngine {
 
     @Override
     public Result<TransitKeyDescriptor> generateKey(String keyName, String keyType) {
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/keys/" + keyName)
                 .post(jsonBody(Map.of("type", keyType,
                         "exportable", false)))
@@ -57,7 +57,7 @@ public class TransitEngineImpl implements TransitEngine {
 
     @Override
     public Result<Void> rotateKey(String keyName) {
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/keys/" + keyName + "/rotate")
                 .post(RequestBody.EMPTY)
                 .build();
@@ -66,7 +66,7 @@ public class TransitEngineImpl implements TransitEngine {
 
     @Override
     public Result<TransitKeyDescriptor> getKey(String keyName) {
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/keys/" + keyName)
                 .get()
                 .build();
@@ -88,7 +88,7 @@ public class TransitEngineImpl implements TransitEngine {
     @Override
     public Result<Void> setMinAvailableVersion(String keyName, int minVersion) {
         requireNonNegative(minVersion);
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/keys/" + keyName + "/trim")
                 .post(jsonBody(Map.of("min_available_version", minVersion)))
                 .build();
@@ -98,7 +98,7 @@ public class TransitEngineImpl implements TransitEngine {
     @Override
     public Result<String> sign(String keyName, String payload) {
         var encoded = Base64.getEncoder().encodeToString(payload.getBytes());
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/sign/" + keyName)
                 .post(jsonBody(Map.of("input", encoded)))
                 .build();
@@ -109,7 +109,7 @@ public class TransitEngineImpl implements TransitEngine {
     @Override
     public Result<Void> verify(String keyName, String payload, String signature) {
         var encoded = Base64.getEncoder().encodeToString(payload.getBytes());
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/verify/" + keyName)
                 .post(jsonBody(Map.of("input", encoded, "signature", signature)))
                 .build();
@@ -119,7 +119,7 @@ public class TransitEngineImpl implements TransitEngine {
 
     @Override
     public Result<Void> deleteKey(String keyName) {
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/keys/" + keyName)
                 .delete()
                 .build();
@@ -127,7 +127,7 @@ public class TransitEngineImpl implements TransitEngine {
     }
 
     private Result<Void> postKeyConfig(String keyName, TransitKeyConfig config) {
-        var request = vaultRequest()
+        var request = vaultRequest(keyName)
                 .url(vaultBaseUrl + "/v1/transit/keys/" + keyName + "/config")
                 .post(jsonBody(config))
                 .build();
@@ -163,9 +163,15 @@ public class TransitEngineImpl implements TransitEngine {
         }
     }
 
-    private Request.Builder vaultRequest() {
+    /**
+     * Builds a vault request authenticated with a token scoped to the participant that owns the given key.
+     * The participant context id is derived from the key name (see {@link TransitEngine#keyName(String, String)})
+     * and used as the token-exchange resource; a {@code null} resource falls back to the default partition.
+     */
+    private Request.Builder vaultRequest(String keyName) {
+        var resource = TransitEngine.participantContextIdFromKeyName(keyName);
         return new Request.Builder()
-                .header(VAULT_TOKEN_HEADER, tokenProvider.vaultToken());
+                .header(VAULT_TOKEN_HEADER, tokenProviderFactory.create(resource).vaultToken());
     }
 
     private RequestBody jsonBody(Object body) {

--- a/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/TransitSignerIntegrationTest.java
+++ b/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/TransitSignerIntegrationTest.java
@@ -64,7 +64,7 @@ class TransitSignerIntegrationTest {
     @BeforeEach
     void setUp() {
         var vaultBaseUrl = "http://%s:%d".formatted(VAULT.getHost(), VAULT.getMappedPort(8200));
-        transitEngine = new TransitEngineImpl(() -> VAULT_TOKEN, new ObjectMapper(), client, vaultBaseUrl);
+        transitEngine = new TransitEngineImpl(resource -> () -> VAULT_TOKEN, new ObjectMapper(), client, vaultBaseUrl);
     }
 
     @Test

--- a/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/transit/TransitEngineImplIntegrationTest.java
+++ b/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/transit/TransitEngineImplIntegrationTest.java
@@ -61,7 +61,7 @@ class TransitEngineImplIntegrationTest {
     @BeforeEach
     void setUp() throws Exception {
         var vaultBaseUrl = "http://%s:%d".formatted(VAULT.getHost(), VAULT.getMappedPort(8200));
-        transitEngine = new TransitEngineImpl(() -> VAULT_TOKEN, new ObjectMapper(), client, vaultBaseUrl);
+        transitEngine = new TransitEngineImpl(resource -> () -> VAULT_TOKEN, new ObjectMapper(), client, vaultBaseUrl);
     }
 
     @Test
@@ -141,7 +141,7 @@ class TransitEngineImplIntegrationTest {
     @Test
     void generateKey_whenInvalidToken_shouldFail() {
         var vaultBaseUrl = "http://%s:%d".formatted(VAULT.getHost(), VAULT.getMappedPort(8200));
-        var engineWithBadToken = new TransitEngineImpl(() -> "wrong-token", new ObjectMapper(), client, vaultBaseUrl);
+        var engineWithBadToken = new TransitEngineImpl(resource -> () -> "wrong-token", new ObjectMapper(), client, vaultBaseUrl);
         assertThat(engineWithBadToken.generateKey("test-key-" + UUID.randomUUID(), "ed25519")).isFailed();
     }
 


### PR DESCRIPTION
## Summary

- Replace `HashicorpVaultTokenProvider` with `HashicorpVaultTokenProviderFactory` in `TransitEngineImpl` and `TransitSecurityExtension` so that each Vault Transit API call obtains a token scoped to the participant that owns the key, rather than using a single global token.
- Derive the participant context id from the key name (via the new `TransitEngine.keyName` / `participantContextIdFromKeyName` static helpers) and pass it as the token-exchange `resource`; a `null` resource falls back to the default partition.
- Consolidate the key-name format (`participant_<participantContextId>_<keyId>`) into `TransitEngine` so `TransitKeyPairService` and the engine share a single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)