### PR TITLE
fix(transit): advertise EdDSA instead of Ed25519 as the JWS algorithm

### DIFF
--- a/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/TransitSigner.java
+++ b/core/identity-hub-keypairs-transit/src/main/java/org/eclipse/edc/identityhub/TransitSigner.java
@@ -72,7 +72,8 @@ public class TransitSigner implements JWSSigner {
         var supportedAlgorithms = new HashSet<JWSAlgorithm>();
         supportedAlgorithms.addAll(JWSAlgorithm.Family.EC.stream().toList());
         supportedAlgorithms.addAll(JWSAlgorithm.Family.RSA.stream().toList());
-        supportedAlgorithms.add(new JWSAlgorithm("Ed25519", Requirement.REQUIRED));
+
+        // do NOT add ED25519, since it is not an accepted alg value (https://www.rfc-editor.org/info/rfc7518/?utm_source=chatgpt.com#section-3.1)
         supportedAlgorithms.add(new JWSAlgorithm("EdDSA", Requirement.REQUIRED));
 
         return Collections.unmodifiableSet(supportedAlgorithms);

--- a/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/TransitSignerIntegrationTest.java
+++ b/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/TransitSignerIntegrationTest.java
@@ -70,7 +70,7 @@ class TransitSignerIntegrationTest {
     @Test
     void sign_withNonExistentKey_throwsException() {
         var signer = new TransitSigner(transitEngine, "nonexistent-key");
-        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.Ed25519).build();
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256).build();
         var claimsSet = new JWTClaimsSet.Builder().issuer("test-issuer").build();
         var signedJwt = new SignedJWT(jwsHeader, claimsSet);
 
@@ -86,7 +86,7 @@ class TransitSignerIntegrationTest {
         var signer = new TransitSigner(transitEngine, keyName);
 
         for (var i = 0; i < 3; i++) {
-            var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.Ed25519).keyID("key-" + i).build();
+            var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.EdDSA).keyID("key-" + i).build();
             var claimsSet = new JWTClaimsSet.Builder().subject("subject-" + i).build();
             var jwt = new SignedJWT(jwsHeader, claimsSet);
             jwt.sign(signer);
@@ -138,13 +138,30 @@ class TransitSignerIntegrationTest {
     }
 
     @Test
-    void sign_withEd25519() throws JOSEException, ParseException {
+    void sign_withEd25519() {
         var keyName = "test-key";
         var keyId = "test-key-id";
         assertThat(transitEngine.generateKey(keyName, "ed25519")).isSucceeded();
         var signer = new TransitSigner(transitEngine, keyName);
 
         var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.Ed25519).keyID(keyId).build();
+        var claimsSet = new JWTClaimsSet.Builder()
+                .issuer("test-issuer")
+                .subject("test-subject")
+                .audience("test-audience")
+                .build();
+        var signedJwt = new SignedJWT(jwsHeader, claimsSet);
+        assertThatThrownBy(() -> signedJwt.sign(signer)).isInstanceOf(JOSEException.class);
+    }
+
+    @Test
+    void sign_withEdDsa() throws JOSEException, ParseException {
+        var keyName = "test-key";
+        var keyId = "test-key-id";
+        assertThat(transitEngine.generateKey(keyName, "ed25519")).isSucceeded();
+        var signer = new TransitSigner(transitEngine, keyName);
+
+        var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.EdDSA).keyID(keyId).build();
         var claimsSet = new JWTClaimsSet.Builder()
                 .issuer("test-issuer")
                 .subject("test-subject")
@@ -165,6 +182,7 @@ class TransitSignerIntegrationTest {
                 .containsEntry("sub", "test-subject")
                 .containsEntry("aud", List.of("test-audience"));
     }
+
 
     @Test
     void verifyJcaContext() {

--- a/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/transit/TransitEngineImplIntegrationTest.java
+++ b/core/identity-hub-keypairs-transit/src/test/java/org/eclipse/edc/identityhub/transit/TransitEngineImplIntegrationTest.java
@@ -23,6 +23,8 @@ import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.vault.VaultContainer;
@@ -73,6 +75,14 @@ class TransitEngineImplIntegrationTest {
             assertThat(desc.getData().getLatestVersion()).isEqualTo(1);
             assertThat(desc.getData().isExportable()).isFalse();
         });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "EdDSA", "eddsa", "EDDSA" })
+    void generateKey_wrongKeyType(String keyType) {
+        var keyName = "test-key-" + UUID.randomUUID();
+        var result = transitEngine.generateKey(keyName, keyType);
+        assertThat(result).isFailed();
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

`TransitSigner#supportedJWSAlgorithms()` no longer advertises `Ed25519` as a supported JWS algorithm. `EdDSA` is now the sole `REQUIRED` algorithm for Edwards keys, so it is selected deterministically and ends up in the JWS `alg` header.

## Why it does that

The signer previously added **both** `new JWSAlgorithm("Ed25519", REQUIRED)` and `new JWSAlgorithm("EdDSA", REQUIRED)` to the supported set. `CryptoConverter#getRecommendedAlgorithm()` (in the Connector's `crypto-common-lib`) selects the first `REQUIRED` algorithm via `.findFirst()` over a `HashSet` stream, so the chosen algorithm was **non-deterministic**: the resulting token could carry `"alg":"Ed25519"`.

`Ed25519` is a curve name, not a registered JWS algorithm identifier — RFC 8037 defines `EdDSA` as the algorithm for Ed25519/Ed448 keys ([RFC 7518 §3.1](https://www.rfc-editor.org/rfc/rfc7518#section-3.1) algorithm registry). Tokens carrying `alg=Ed25519` are rejected by spec-compliant verifiers, including Nimbus' own `Ed25519Verifier` (which advertises only `EdDSA`), so such tokens fail verification even within the EDC stack itself.
