### PR TITLE
docs: remove obsolete “M1/” segment from spec URLs

### DIFF
--- a/docs/developer/architecture/decentralized-claims-protocol/identity-hub-modules.md
+++ b/docs/developer/architecture/decentralized-claims-protocol/identity-hub-modules.md
@@ -75,9 +75,9 @@ all SPIs that are relevant here.
 ## Hub API (`:core:presentation-api`)
 
 This module contains implementations for
-the [Presentation API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/verifiable.presentation.protocol.md#4-resolution-api)
+the [Presentation API](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0.1/#resolution-api)
 and
-the [Storage API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/verifiable.presentation.protocol.md#5-storage-api).
+the [Storage API](https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/v1.0.1/#storage-api).
 Is
 contains model classes, validators and JSON-LD-transformers.
 

--- a/docs/developer/architecture/decentralized-claims-protocol/identity-hub-modules.md
+++ b/docs/developer/architecture/decentralized-claims-protocol/identity-hub-modules.md
@@ -75,9 +75,9 @@ all SPIs that are relevant here.
 ## Hub API (`:core:presentation-api`)
 
 This module contains implementations for
-the [Presentation API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#4-resolution-api)
+the [Presentation API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/verifiable.presentation.protocol.md#4-resolution-api)
 and
-the [Storage API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#5-storage-api).
+the [Storage API](https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/verifiable.presentation.protocol.md#5-storage-api).
 Is
 contains model classes, validators and JSON-LD-transformers.
 

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authentication/ParticipantSecureTokenService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authentication/ParticipantSecureTokenService.java
@@ -31,7 +31,7 @@ public interface ParticipantSecureTokenService {
      *
      * @param participantContextId The ID of the participant context on behalf of whom the token is generated
      * @param claims               a set of claims, that are to be included in the SI token. MUST include {@code iss}, {@code sub} and {@code aud}.
-     * @param bearerAccessScope    if non-null, must be a space-separated list of scopes as per <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/M1/verifiable.presentation.protocol.md#31-access-scopes">DCP specification</a>
+     * @param bearerAccessScope    if non-null, must be a space-separated list of scopes as per <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/verifiable.presentation.protocol.md#31-access-scopes">DCP specification</a>
      *                             if bearerAccessScope != null -> creates a {@code token} claim, which is another JWT containing the scope as claims.
      *                             if bearerAccessScope == null -> creates a normal JWT using all the claims in the map
      * @return A result containing the token representation, or a failure

--- a/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authentication/ParticipantSecureTokenService.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/edc/identityhub/spi/authentication/ParticipantSecureTokenService.java
@@ -31,7 +31,7 @@ public interface ParticipantSecureTokenService {
      *
      * @param participantContextId The ID of the participant context on behalf of whom the token is generated
      * @param claims               a set of claims, that are to be included in the SI token. MUST include {@code iss}, {@code sub} and {@code aud}.
-     * @param bearerAccessScope    if non-null, must be a space-separated list of scopes as per <a href="https://github.com/eclipse-tractusx/identity-trust/blob/main/specifications/verifiable.presentation.protocol.md#31-access-scopes">DCP specification</a>
+     * @param bearerAccessScope    if non-null, must be a space-separated list of scopes as per DCP specification
      *                             if bearerAccessScope != null -> creates a {@code token} claim, which is another JWT containing the scope as claims.
      *                             if bearerAccessScope == null -> creates a normal JWT using all the claims in the map
      * @return A result containing the token representation, or a failure


### PR DESCRIPTION
## What this PR changes/adds
Just a small thing..
While looking through the docs for something else, I noticed, that given links had a `/M1/` in there and this doesn't resolve anymore. 
For that, I searched through the project for `/M1/` instances, fixed it and verified it by checking if new links resolve. 