### PR TITLE
refactor: consolidate authorization extension admin scopes

### DIFF
--- a/dist/bom/issuerservice-oauth2-bom/build.gradle.kts
+++ b/dist/bom/issuerservice-oauth2-bom/build.gradle.kts
@@ -20,9 +20,9 @@ plugins {
 dependencies {
     implementation(project(":dist:bom:issuerservice-base-bom"))
     implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-authentication-oauth2"))
-    implementation(project(":extensions:api:issuer-admin-api:issuer-admin-api-authorization-oauth2"))
+    implementation(project(":extensions:api:identityhub-api-authorization"))
     implementation(project(":extensions:api:identity-api:identity-api-authentication-oauth2"))
-    implementation(project(":extensions:api:identity-api:identity-api-authorization-oauth2"))
+//    implementation(project(":extensions:api:identity-api:identity-api-authorization-oauth2"))
     // needed for interaction with the embedded STS
     implementation(project(":extensions:sts:sts-core"))
     implementation(project(":extensions:sts:sts-account-service-local"))

--- a/extensions/api/identity-api/identity-api-authentication-oauth2/src/main/java/org/eclipse/edc/identityhub/api/Oauth2JwtAuthenticationExtension.java
+++ b/extensions/api/identity-api/identity-api-authentication-oauth2/src/main/java/org/eclipse/edc/identityhub/api/Oauth2JwtAuthenticationExtension.java
@@ -81,12 +81,6 @@ public class Oauth2JwtAuthenticationExtension implements ServiceExtension {
 
         webService.registerResource(alias, new ServicePrincipalAuthenticationFilter(participantContextService, IdentityApiScopes.ADMIN));
 
-        URL url;
-        try {
-            url = new URL(oauthConfiguration.jwksUrl());
-        } catch (MalformedURLException e) {
-            throw new EdcException(e);
-        }
         var resolver = JwksPublicKeyResolver.create(keyParserRegistry, oauthConfiguration.jwksUrl(), monitor, oauthConfiguration.cacheValidityInMillis());
         webService.registerResource(alias, new JwtValidatorFilter(tokenValidationService, resolver, getRules()));
     }


### PR DESCRIPTION
## What

- Point the `issuerservice-oauth2` BOM at the shared `identityhub-api-authorization` extension instead of the per-API `issuer-admin-api-authorization-oauth2` / `identity-api-authorization-oauth2` extensions.


## Why

both `issuer-admin-api:admin` and `identity-api:admin` are needed as admin scopes in the issuer service

## Further notes:
- Remove the redundant JWKS URL parsing in `Oauth2JwtAuthenticationExtension`. The URL is already validated during config checks, so the second parse threw away its result and only duplicated work.