### PR TITLE
feat: flag for skipping the sts account provisioning

### DIFF
--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubParticipantContextServiceImpl.java
@@ -98,14 +98,19 @@ public class IdentityHubParticipantContextServiceImpl implements IdentityHubPart
 
             return createParticipantContext(context)
                     .compose(this::createTokenAndStoreInVault)
-                    .compose((Function<String, ServiceResult<CreateParticipantContextResponse>>) apiKey -> stsAccountProvisioner.create(manifest)
-                            .map(accountInfo -> {
-                                if (accountInfo == null) {
-                                    return new CreateParticipantContextResponse(apiKey, null, null);
-                                } else {
-                                    return new CreateParticipantContextResponse(apiKey, accountInfo.clientId(), accountInfo.clientSecret());
-                                }
-                            }))
+                    .compose((Function<String, ServiceResult<CreateParticipantContextResponse>>) apiKey -> {
+                        if (!manifest.isProvisionStsAccount()) {
+                            return success(new CreateParticipantContextResponse(apiKey, null, null));
+                        }
+                        return stsAccountProvisioner.create(manifest)
+                                .map(accountInfo -> {
+                                    if (accountInfo == null) {
+                                        return new CreateParticipantContextResponse(apiKey, null, null);
+                                    } else {
+                                        return new CreateParticipantContextResponse(apiKey, accountInfo.clientId(), accountInfo.clientSecret());
+                                    }
+                                });
+                    })
                     .onSuccess(apiToken -> observable.invokeForEach(l -> l.created(context, manifest)));
         });
     }

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubIdentityHubParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubIdentityHubParticipantContextServiceImplTest.java
@@ -56,6 +56,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -140,6 +141,25 @@ class IdentityHubIdentityHubParticipantContextServiceImplTest {
             assertThat(response.clientId()).isEqualTo("clientId");
             assertThat(response.clientSecret()).isEqualTo("clientSecret");
         });
+    }
+
+    @Test
+    void shouldSkipStsProvisioning_whenProvisionStsAccountIsFalse() {
+        when(participantContextStore.create(any())).thenReturn(StoreResult.success());
+        when(vault.storeSecret(anyString(), anyString(), anyString())).thenReturn(Result.success());
+
+        var ctx = createManifest()
+                .provisionStsAccount(false)
+                .build();
+
+        var result = participantContextService.createParticipantContext(ctx);
+
+        assertThat(result).isSucceeded().satisfies(response -> {
+            assertThat(response.apiKey()).isNotBlank();
+            assertThat(response.clientId()).isNull();
+            assertThat(response.clientSecret()).isNull();
+        });
+        verify(stsAccountProvisioner, never()).create(any());
     }
 
     @ParameterizedTest(name = "isActive: {0}")

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityHubParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityHubParticipantContextApiEndToEndTest.java
@@ -75,6 +75,7 @@ import static org.eclipse.edc.identityhub.tests.fixtures.common.AbstractIdentity
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -172,6 +173,34 @@ public class IdentityHubParticipantContextApiEndToEndTest {
             assertThat(identityHub.getDidForParticipant(manifest.getParticipantContextId())).hasSize(1)
                     .allSatisfy(dd -> assertThat(dd.getVerificationMethod()).hasSize(1));
         }
+
+
+        @Test
+        void createNewUser_skipStsClientProvisioning(IdentityHub identityHub, EventRouter router) {
+            var subscriber = mock(EventSubscriber.class);
+            router.registerSync(ParticipantContextCreated.class, subscriber);
+
+            var manifest = createNewParticipant().provisionStsAccount(false).build();
+
+            identityHub.getIdentityEndpoint().baseRequest()
+                    .header(authorizeUser(SUPER_USER, identityHub))
+                    .contentType(ContentType.JSON)
+                    .body(manifest)
+                    .post("/v1beta/participants/")
+                    .then()
+                    .log().ifError()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)))
+                    .body("clientId", nullValue())
+                    .body("apiKey", notNullValue())
+                    .body("clientSecret", nullValue());
+
+            verify(subscriber).on(argThat(env -> ((ParticipantContextCreated) env.getPayload()).getParticipantContextId().equals(manifest.getParticipantContextId())));
+
+            assertThat(identityHub.getKeyPairsForParticipant(manifest.getParticipantContextId())).hasSize(1);
+            assertThat(identityHub.getDidForParticipant(manifest.getParticipantContextId())).hasSize(1)
+                    .allSatisfy(dd -> assertThat(dd.getVerificationMethod()).hasSize(1));
+        }
+
 
         @Test
         void createNewUser_whenKeyPairActive(IdentityHub identityHub, EventRouter router) {
@@ -519,7 +548,7 @@ public class IdentityHubParticipantContextApiEndToEndTest {
         }
 
         @ParameterizedTest(name = "Expect 403, role = {0}")
-        @ValueSource(strings = { "some-role", "admin" })
+        @ValueSource(strings = {"some-role", "admin"})
         void updateScopes_whenNotSuperuser(String role, IdentityHub identityHub) {
             var participantContextId = "some-user";
             var userAuth = authorizeUser(participantContextId, identityHub);

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-06-12T13:00:00Z",
+    "lastUpdated": "2026-06-30T13:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/participant-context-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/model/ParticipantManifestTest.java
+++ b/extensions/api/identity-api/participant-context-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/model/ParticipantManifestTest.java
@@ -85,6 +85,7 @@ class ParticipantManifestTest {
         assertThat(manifest.getKeys()).hasSize(1)
                 .allSatisfy(kd -> assertThat(kd.getKeyId()).isEqualTo("key-1"));
         assertThat(manifest.getApiKeyAlias()).isEqualTo("test-alias");
+        assertThat(manifest.isProvisionStsAccount()).isTrue();
     }
 
     @Test

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantManifest.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantManifest.java
@@ -40,6 +40,7 @@ public class ParticipantManifest {
     private List<String> scopes = new ArrayList<>();
     private Set<Service> serviceEndpoints = new HashSet<>();
     private boolean isActive;
+    private boolean provisionStsAccount = true;
     private String participantContextId;
     private String did;
     private String apiKeyAlias;
@@ -68,6 +69,14 @@ public class ParticipantManifest {
      */
     public boolean isActive() {
         return isActive;
+    }
+
+    /**
+     * Indicates whether an STS account should be provisioned for this participant during creation. When {@code false}, the STS account provisioning
+     * phase is skipped entirely. Defaults to {@code true}.
+     */
+    public boolean isProvisionStsAccount() {
+        return provisionStsAccount;
     }
 
     /**
@@ -130,6 +139,11 @@ public class ParticipantManifest {
 
         public Builder active(boolean isActive) {
             manifest.isActive = isActive;
+            return this;
+        }
+
+        public Builder provisionStsAccount(boolean provisionStsAccount) {
+            manifest.provisionStsAccount = provisionStsAccount;
             return this;
         }
 


### PR DESCRIPTION
 flag for skipping the sts account provisioning when creating the participant context

## What this PR changes/adds

_Briefly describe WHAT your pr changes, which features it adds/modifies._

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #1029 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
