### PR TITLE
fix: remove sts account service usage in embedded

### DIFF
--- a/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/EmbeddedStsServiceExtension.java
+++ b/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/EmbeddedStsServiceExtension.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.iam.decentralizedclaims.sts;
 
 import org.eclipse.edc.iam.decentralizedclaims.sts.service.EmbeddedSecureTokenService;
 import org.eclipse.edc.iam.decentralizedclaims.sts.service.StsClientTokenGeneratorServiceImpl;
-import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsAccountService;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsClientTokenGeneratorService;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
@@ -49,8 +48,6 @@ public class EmbeddedStsServiceExtension implements ServiceExtension {
     @Inject
     private TransactionContext transactionContext;
     @Inject
-    private StsAccountService stsAccountService;
-    @Inject
     private KeyPairService keyPairService;
     private EmbeddedSecureTokenService embeddedSts;
 
@@ -62,7 +59,7 @@ public class EmbeddedStsServiceExtension implements ServiceExtension {
     @Provider
     public ParticipantSecureTokenService secureTokenService() {
         if (embeddedSts == null) {
-            embeddedSts = new EmbeddedSecureTokenService(transactionContext, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), new JwtGenerationService(externalSigner), clock, stsAccountService, keyPairService);
+            embeddedSts = new EmbeddedSecureTokenService(transactionContext, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), new JwtGenerationService(externalSigner), clock, keyPairService);
         }
         return embeddedSts;
     }

--- a/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/service/EmbeddedSecureTokenService.java
+++ b/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/service/EmbeddedSecureTokenService.java
@@ -14,12 +14,9 @@
 
 package org.eclipse.edc.iam.decentralizedclaims.sts.service;
 
-import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsAccountService;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
-import org.eclipse.edc.spi.query.Criterion;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.token.spi.KeyIdDecorator;
 import org.eclipse.edc.token.spi.TokenGenerationService;
@@ -53,33 +50,23 @@ public class EmbeddedSecureTokenService implements ParticipantSecureTokenService
     private final long tokenValiditySeconds;
     private final TokenGenerationService tokenGenerationService;
     private final Clock clock;
-    private final StsAccountService stsAccountService;
     private final KeyPairService keyPairService;
 
     public EmbeddedSecureTokenService(TransactionContext transactionContext,
                                       long tokenValiditySeconds,
                                       TokenGenerationService tokenGenerationService,
                                       Clock clock,
-                                      StsAccountService stsAccountService,
                                       KeyPairService keyPairService) {
         this.transactionContext = transactionContext;
         this.tokenValiditySeconds = tokenValiditySeconds;
         this.tokenGenerationService = tokenGenerationService;
         this.clock = clock;
-        this.stsAccountService = stsAccountService;
         this.keyPairService = keyPairService;
     }
 
     @Override
     public Result<TokenRepresentation> createToken(String participantContextId, Map<String, String> claims, @Nullable String bearerAccessScope) {
         return transactionContext.execute(() -> {
-            var result = stsAccountService.queryAccounts(QuerySpec.Builder.newInstance()
-                    .filter(new Criterion("participantContextId", "=", participantContextId))
-                    .build());
-            if (result == null || result.isEmpty()) {
-                return Result.failure("No account found for participantContextId '%s'".formatted(participantContextId));
-            }
-
             var tokenSigningKey = keyPairService.getActiveKeyPairForUsage(participantContextId, TOKEN_SIGNING);
             if (tokenSigningKey.failed()) {
                 return Result.failure(tokenSigningKey.getFailureDetail());

--- a/extensions/sts/sts-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/sts/defaults/StsAccountTokenIssuanceIntegrationTest.java
+++ b/extensions/sts/sts-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/sts/defaults/StsAccountTokenIssuanceIntegrationTest.java
@@ -17,16 +17,11 @@ package org.eclipse.edc.iam.decentralizedclaims.sts.defaults;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.edc.boot.vault.InMemoryVault;
-import org.eclipse.edc.iam.decentralizedclaims.sts.defaults.store.InMemoryStsAccountStore;
 import org.eclipse.edc.iam.decentralizedclaims.sts.service.EmbeddedSecureTokenService;
 import org.eclipse.edc.iam.decentralizedclaims.sts.service.StsClientTokenGeneratorServiceImpl;
 import org.eclipse.edc.iam.decentralizedclaims.sts.spi.model.StsAccountTokenAdditionalParams;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
-import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyDescriptor;
-import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantManifest;
-import org.eclipse.edc.identityhub.sts.accountservice.RandomStringGenerator;
-import org.eclipse.edc.identityhub.sts.accountservice.StsAccountServiceImpl;
 import org.eclipse.edc.junit.annotations.ComponentTest;
 import org.eclipse.edc.jwt.validation.jti.JtiValidationStore;
 import org.eclipse.edc.keys.KeyParserRegistryImpl;
@@ -34,7 +29,6 @@ import org.eclipse.edc.keys.VaultPrivateKeyResolver;
 import org.eclipse.edc.keys.keyparsers.JwkParser;
 import org.eclipse.edc.keys.keyparsers.PemParser;
 import org.eclipse.edc.keys.spi.KeyParserRegistry;
-import org.eclipse.edc.query.CriterionOperatorRegistryImpl;
 import org.eclipse.edc.security.token.jwt.DefaultJwsSignerProvider;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.spi.result.StoreResult;
@@ -71,17 +65,14 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 public class StsAccountTokenIssuanceIntegrationTest {
 
-    private final InMemoryStsAccountStore clientStore = new InMemoryStsAccountStore(CriterionOperatorRegistryImpl.ofDefaults());
     private final Vault vault = new InMemoryVault(mock(), null);
     private final KeyParserRegistry keyParserRegistry = new KeyParserRegistryImpl();
     private final JtiValidationStore jtiValidationStore = mock();
     private final KeyPairService keyPairService = mock();
-    private StsAccountServiceImpl clientService;
     private StsClientTokenGeneratorServiceImpl tokenGeneratorService;
 
     @BeforeEach
     void setup() throws IOException {
-        clientService = new StsAccountServiceImpl(clientStore, new NoopTransactionContext(), vault, new RandomStringGenerator());
 
         keyParserRegistry.register(new PemParser(mock()));
         keyParserRegistry.register(new JwkParser(new ObjectMapper(), mock()));
@@ -99,7 +90,7 @@ public class StsAccountTokenIssuanceIntegrationTest {
                         .build()));
 
         tokenGeneratorService = new StsClientTokenGeneratorServiceImpl(60 * 5, new EmbeddedSecureTokenService(new NoopTransactionContext(), 60 * 5,
-                new JwtGenerationService(new DefaultJwsSignerProvider(privateKeyResolver)), Clock.systemUTC(), clientService, keyPairService));
+                new JwtGenerationService(new DefaultJwsSignerProvider(privateKeyResolver)), Clock.systemUTC(), keyPairService));
     }
 
     @Test
@@ -120,16 +111,6 @@ public class StsAccountTokenIssuanceIntegrationTest {
         var additional = StsAccountTokenAdditionalParams.Builder.newInstance().audience(audience).build();
 
         vault.storeSecret(participantId, privateKeyAlias, loadResourceFile("ec-privatekey.pem"));
-
-        var createResult = clientService.createAccount(ParticipantManifest.Builder.newInstance()
-                .participantContextId(participantId)
-                .did(did)
-                .key(KeyDescriptor.Builder.newInstance()
-                        .keyId("public-key")
-                        .privateKeyAlias(privateKeyAlias)
-                        .build())
-                .build(), secretAlias);
-        assertThat(createResult.succeeded()).isTrue();
 
         var tokenResult = tokenGeneratorService.tokenFor(client, additional);
 
@@ -166,16 +147,6 @@ public class StsAccountTokenIssuanceIntegrationTest {
 
         vault.storeSecret(participantId, privateKeyAlias, loadResourceFile("ec-privatekey.pem"));
 
-        var createResult = clientService.createAccount(ParticipantManifest.Builder.newInstance()
-                .participantContextId(participantId)
-                .did(did)
-                .key(KeyDescriptor.Builder.newInstance()
-                        .keyId("public-key")
-                        .privateKeyAlias(privateKeyAlias)
-                        .build())
-                .build(), secretAlias);
-        assertThat(createResult.succeeded()).isTrue();
-
         var tokenResult = tokenGeneratorService.tokenFor(client, additional);
         var jwt = SignedJWT.parse(tokenResult.getContent().getToken());
 
@@ -208,16 +179,6 @@ public class StsAccountTokenIssuanceIntegrationTest {
         var additional = StsAccountTokenAdditionalParams.Builder.newInstance().audience(audience).accessToken(accessToken).build();
 
         vault.storeSecret(participantId, privateKeyAlias, loadResourceFile("ec-privatekey.pem"));
-
-        var createResult = clientService.createAccount(ParticipantManifest.Builder.newInstance()
-                .participantContextId(participantId)
-                .did(did)
-                .key(KeyDescriptor.Builder.newInstance()
-                        .keyId("public-key")
-                        .privateKeyAlias(privateKeyAlias)
-                        .build())
-                .build(), secretAlias);
-        assertThat(createResult.succeeded()).isTrue();
 
         var tokenResult = tokenGeneratorService.tokenFor(client, additional);
         var jwt = SignedJWT.parse(tokenResult.getContent().getToken());

--- a/extensions/sts/sts-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/sts/service/EmbeddedSecureTokenServiceTest.java
+++ b/extensions/sts/sts-core/src/test/java/org/eclipse/edc/iam/decentralizedclaims/sts/service/EmbeddedSecureTokenServiceTest.java
@@ -14,14 +14,11 @@
 
 package org.eclipse.edc.iam.decentralizedclaims.sts.service;
 
-import org.eclipse.edc.iam.decentralizedclaims.sts.spi.model.StsAccount;
-import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsAccountService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairResource;
 import org.eclipse.edc.identityhub.spi.keypair.model.KeyPairState;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.KeyPairUsage;
 import org.eclipse.edc.spi.iam.TokenRepresentation;
-import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.token.spi.KeyIdDecorator;
@@ -33,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Clock;
-import java.util.List;
 import java.util.Map;
 
 import static com.nimbusds.jwt.JWTClaimNames.AUDIENCE;
@@ -53,22 +49,11 @@ class EmbeddedSecureTokenServiceTest {
     public static final String TEST_PRIVATEKEY_ID = "test-privatekey-id";
     public static final String TEST_PARTICIPANT = "test-participant";
     private final TokenGenerationService tokenGenerationService = mock();
-    private final StsAccountService stsAccountService = mock();
     private final KeyPairService keyPairService = mock();
-    private final EmbeddedSecureTokenService sts = new EmbeddedSecureTokenService(new NoopTransactionContext(), 10 * 60, tokenGenerationService, Clock.systemUTC(), stsAccountService, keyPairService);
+    private final EmbeddedSecureTokenService sts = new EmbeddedSecureTokenService(new NoopTransactionContext(), 10 * 60, tokenGenerationService, Clock.systemUTC(), keyPairService);
 
     @BeforeEach
     void setup() {
-        when(stsAccountService.queryAccounts(any(QuerySpec.class))).thenReturn(
-                List.of(StsAccount.Builder.newInstance()
-                        .id("key-pair-id")
-                        .clientId(TEST_PRIVATEKEY_ID)
-                        .secretAlias(TEST_PARTICIPANT + "-alias")
-                        .name(TEST_PARTICIPANT)
-                        .participantContextId(TEST_PARTICIPANT)
-                        .did("did:web:" + TEST_PARTICIPANT)
-                        .build()));
-
         when(keyPairService.getActiveKeyPairForUsage(eq(TEST_PARTICIPANT), eq(KeyPairUsage.TOKEN_SIGNING)))
                 .thenReturn(success(createKeyPair()));
 
@@ -171,16 +156,6 @@ class EmbeddedSecureTokenServiceTest {
 
         verify(tokenGenerationService, times(2)).generate(eq(TEST_PARTICIPANT), eq(TEST_PRIVATEKEY_ID), any(TokenDecorator[].class));
         verifyNoMoreInteractions(tokenGenerationService);
-    }
-
-    @Test
-    void createToken_whenStsAccountNotfound_expectFailure() {
-        when(stsAccountService.queryAccounts(any(QuerySpec.class))).thenReturn(List.of());
-
-        var result = sts.createToken(TEST_PARTICIPANT, Map.of(), null);
-        assertThat(result).isFailed()
-                .detail()
-                .isEqualTo("No account found for participantContextId 'test-participant'");
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Remove sts account service usage in embedded token generation. It caused the failure when the sts is not provisioned for a participant context. Also it was only a check but the result of the query was not actually used.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
