### PR TITLE
feat: add flag for skipping api key provisioning

### DIFF
--- a/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubParticipantContextServiceImpl.java
+++ b/core/identity-hub-participants/src/main/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubParticipantContextServiceImpl.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
@@ -97,8 +96,10 @@ public class IdentityHubParticipantContextServiceImpl implements IdentityHubPart
             var context = convert(manifest);
 
             return createParticipantContext(context)
-                    .compose(this::createTokenAndStoreInVault)
-                    .compose((Function<String, ServiceResult<CreateParticipantContextResponse>>) apiKey -> {
+                    .compose(ctx -> manifest.isProvisionApiKey()
+                            ? createTokenAndStoreInVault(ctx)
+                            : ServiceResult.success(null))
+                    .compose(apiKey -> {
                         if (!manifest.isProvisionStsAccount()) {
                             return success(new CreateParticipantContextResponse(apiKey, null, null));
                         }

--- a/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubIdentityHubParticipantContextServiceImplTest.java
+++ b/core/identity-hub-participants/src/test/java/org/eclipse/edc/identityhub/participantcontext/IdentityHubIdentityHubParticipantContextServiceImplTest.java
@@ -162,6 +162,22 @@ class IdentityHubIdentityHubParticipantContextServiceImplTest {
         verify(stsAccountProvisioner, never()).create(any());
     }
 
+    @Test
+    void shouldSkipApiKeyProvisioning_whenProvisionApiKeyIsFalse() {
+        when(participantContextStore.create(any())).thenReturn(StoreResult.success());
+
+        var ctx = createManifest()
+                .provisionApiKey(false)
+                .build();
+
+        var result = participantContextService.createParticipantContext(ctx);
+
+        assertThat(result).isSucceeded().satisfies(response -> {
+            assertThat(response.apiKey()).isNull();
+        });
+        verify(vault, never()).storeSecret(anyString(), anyString(), anyString());
+    }
+
     @ParameterizedTest(name = "isActive: {0}")
     @ValueSource(booleans = {true, false})
     void createParticipantContext_withPublicKeyJwk(boolean isActive) {

--- a/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityHubParticipantContextApiEndToEndTest.java
+++ b/e2e-tests/identity-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/IdentityHubParticipantContextApiEndToEndTest.java
@@ -203,6 +203,31 @@ public class IdentityHubParticipantContextApiEndToEndTest {
 
 
         @Test
+        void createNewUser_skipApiKeyProvisioning(IdentityHub identityHub, EventRouter router) {
+            var subscriber = mock(EventSubscriber.class);
+            router.registerSync(ParticipantContextCreated.class, subscriber);
+
+            var manifest = createNewParticipant().provisionApiKey(false).build();
+
+            identityHub.getIdentityEndpoint().baseRequest()
+                    .header(authorizeUser(SUPER_USER, identityHub))
+                    .contentType(ContentType.JSON)
+                    .body(manifest)
+                    .post("/v1beta/participants/")
+                    .then()
+                    .log().ifError()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)))
+                    .body("apiKey", nullValue());
+
+            verify(subscriber).on(argThat(env -> ((ParticipantContextCreated) env.getPayload()).getParticipantContextId().equals(manifest.getParticipantContextId())));
+
+            assertThat(identityHub.getKeyPairsForParticipant(manifest.getParticipantContextId())).hasSize(1);
+            assertThat(identityHub.getDidForParticipant(manifest.getParticipantContextId())).hasSize(1)
+                    .allSatisfy(dd -> assertThat(dd.getVerificationMethod()).hasSize(1));
+        }
+
+
+        @Test
         void createNewUser_whenKeyPairActive(IdentityHub identityHub, EventRouter router) {
             var subscriber = mock(EventSubscriber.class);
             router.registerSync(ParticipantContextCreated.class, subscriber);

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-alpha",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-06-30T13:00:00Z",
+    "lastUpdated": "2026-07-10T13:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/identity-api/participant-context-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/model/ParticipantManifestTest.java
+++ b/extensions/api/identity-api/participant-context-api/src/test/java/org/eclipse/edc/identityhub/api/verifiablecredential/v1/unstable/model/ParticipantManifestTest.java
@@ -86,6 +86,7 @@ class ParticipantManifestTest {
                 .allSatisfy(kd -> assertThat(kd.getKeyId()).isEqualTo("key-1"));
         assertThat(manifest.getApiKeyAlias()).isEqualTo("test-alias");
         assertThat(manifest.isProvisionStsAccount()).isTrue();
+        assertThat(manifest.isProvisionApiKey()).isTrue();
     }
 
     @Test

--- a/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantManifest.java
+++ b/spi/participant-context-spi/src/main/java/org/eclipse/edc/identityhub/spi/participantcontext/model/ParticipantManifest.java
@@ -41,6 +41,7 @@ public class ParticipantManifest {
     private Set<Service> serviceEndpoints = new HashSet<>();
     private boolean isActive;
     private boolean provisionStsAccount = true;
+    private boolean provisionApiKey = true;
     private String participantContextId;
     private String did;
     private String apiKeyAlias;
@@ -77,6 +78,14 @@ public class ParticipantManifest {
      */
     public boolean isProvisionStsAccount() {
         return provisionStsAccount;
+    }
+
+    /**
+     * Indicates whether an API key should be provisioned for this participant during creation. When {@code false}, the API key generation and
+     * vault storage phase is skipped entirely, and the API key is {@code null} in the response. Defaults to {@code true}.
+     */
+    public boolean isProvisionApiKey() {
+        return provisionApiKey;
     }
 
     /**
@@ -144,6 +153,11 @@ public class ParticipantManifest {
 
         public Builder provisionStsAccount(boolean provisionStsAccount) {
             manifest.provisionStsAccount = provisionStsAccount;
+            return this;
+        }
+
+        public Builder provisionApiKey(boolean provisionApiKey) {
+            manifest.provisionApiKey = provisionApiKey;
             return this;
         }
 


### PR DESCRIPTION
## What this PR changes/adds

add flag for skipping api key provisioning

## Why it does that

Avoid bloating the vault if the api key is not used

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #1031 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
