### PR TITLE
feat: remove uniqueness constraint from CredentialDefinition

### DIFF
--- a/core/issuerservice/issuerservice-core/src/main/java/org/eclipse/edc/issuerservice/defaults/store/InMemoryCredentialDefinitionStore.java
+++ b/core/issuerservice/issuerservice-core/src/main/java/org/eclipse/edc/issuerservice/defaults/store/InMemoryCredentialDefinitionStore.java
@@ -21,31 +21,20 @@ import org.eclipse.edc.spi.query.QueryResolver;
 import org.eclipse.edc.spi.result.StoreResult;
 import org.eclipse.edc.store.ReflectionBasedQueryResolver;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
 import static org.eclipse.edc.spi.result.StoreResult.alreadyExists;
 import static org.eclipse.edc.spi.result.StoreResult.notFound;
 import static org.eclipse.edc.spi.result.StoreResult.success;
 
 public class InMemoryCredentialDefinitionStore extends InMemoryEntityStore<CredentialDefinition> implements CredentialDefinitionStore {
 
-
-    private final Map<String, String> credentialTypes = new HashMap<>();
-
     @Override
     public StoreResult<Void> create(CredentialDefinition credentialDefinition) {
         lock.writeLock().lock();
         try {
-            if (credentialTypes.containsKey(credentialDefinition.getCredentialType())) {
-                return alreadyExists(alreadyExistsForTypeErrorMessage(credentialDefinition.getCredentialType()));
-            }
             if (store.containsKey(credentialDefinition.getId())) {
                 return alreadyExists(alreadyExistsErrorMessage(credentialDefinition.getId()));
             }
             store.put(credentialDefinition.getId(), credentialDefinition);
-            credentialTypes.put(credentialDefinition.getCredentialType(), credentialDefinition.getId());
             return success(null);
         } finally {
             lock.writeLock().unlock();
@@ -59,15 +48,7 @@ public class InMemoryCredentialDefinitionStore extends InMemoryEntityStore<Crede
             if (!store.containsKey(credentialDefinition.getId())) {
                 return notFound(notFoundErrorMessage(credentialDefinition.getId()));
             }
-            var credentialId = credentialTypes.get(credentialDefinition.getCredentialType());
-            if (credentialId != null && !credentialId.equals(credentialDefinition.getId())) {
-                return alreadyExists(alreadyExistsForTypeErrorMessage(credentialDefinition.getCredentialType()));
-            }
-            var oldDefinition = store.put(credentialDefinition.getId(), credentialDefinition);
-
-            Optional.ofNullable(oldDefinition)
-                    .map(CredentialDefinition::getCredentialType)
-                    .ifPresent(credentialTypes::remove);
+            store.put(credentialDefinition.getId(), credentialDefinition);
 
             return success();
         } finally {
@@ -82,8 +63,7 @@ public class InMemoryCredentialDefinitionStore extends InMemoryEntityStore<Crede
             if (!store.containsKey(id)) {
                 return notFound(notFoundErrorMessage(id));
             }
-            var credential = store.remove(id);
-            credentialTypes.remove(credential.getCredentialType());
+            store.remove(id);
             return success();
         } finally {
             lock.writeLock().unlock();

--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialDefinitionApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialDefinitionApiEndToEndTest.java
@@ -167,39 +167,6 @@ public class CredentialDefinitionApiEndToEndTest {
         }
 
         @Test
-        void createCredentialDefinition_whenCredentialTypeExists(IssuerService issuer, CredentialDefinitionService service) {
-            issuer.createParticipant(USER);
-
-            var definition = CredentialDefinition.Builder.newInstance()
-                    .id("id")
-                    .jsonSchema("{}")
-                    .jsonSchemaUrl("https://example.org/membership-credential-schema.json")
-                    .credentialType("MembershipCredential")
-                    .participantContextId("participantContextId")
-                    .formatFrom(VC1_0_JWT)
-                    .build();
-
-            service.createCredentialDefinition(definition);
-
-            issuer.getAdminEndpoint().baseRequest()
-                    .contentType(ContentType.JSON)
-                    .header(authorizeUser(USER, issuer))
-                    .body("""
-                            {
-                              "id": "test-definition-id",
-                              "credentialType": "MembershipCredential",
-                              "jsonSchema": "{}",
-                              "jsonSchemaUrl": "https://example.org/membership-credential-schema.json",
-                              "format": "VC1_0_JWT"
-                            }
-                            """)
-                    .post("/v1beta/participants/%s/credentialdefinitions".formatted(USER))
-                    .then()
-                    .log().all()
-                    .statusCode(409);
-        }
-
-        @Test
         void createCredentialDefinition_whenMissingFields(IssuerService issuer) {
             issuer.createParticipant(USER);
 

--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "1.0.0-alpha",
+    "version": "1.0.0-beta",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-07-10T13:00:00Z",
+    "lastUpdated": "2026-07-20T13:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -1,8 +1,8 @@
 [
   {
-    "version": "1.0.0-alpha",
+    "version": "1.0.0-beta",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-06-12T13:00:00Z",
+    "lastUpdated": "2026-07-20T13:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/SqlCredentialDefinitionStore.java
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/java/org/eclipse/edc/issuerservice/store/sql/credentialdefinition/SqlCredentialDefinitionStore.java
@@ -16,7 +16,6 @@ package org.eclipse.edc.issuerservice.store.sql.credentialdefinition;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.issuerservice.spi.issuance.credentialdefinition.store.CredentialDefinitionStore;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialDefinition;
 import org.eclipse.edc.issuerservice.spi.issuance.model.CredentialRuleDefinition;
@@ -56,9 +55,6 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
     private static final TypeReference<List<MappingDefinition>> MAPPINGS_LIST_REF = new TypeReference<>() {
     };
 
-    private static final TypeReference<List<CredentialFormat>> FORMATS_LIST_REF = new TypeReference<>() {
-    };
-
     private final CredentialDefinitionStoreStatements statements;
     private final Clock clock;
 
@@ -96,10 +92,6 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
                     return alreadyExists(alreadyExistsErrorMessage(id));
                 }
 
-                if (findByCredentialType(connection, credentialDefinition.getCredentialType()) != null) {
-                    return alreadyExists(alreadyExistsForTypeErrorMessage(credentialDefinition.getCredentialType()));
-                }
-
                 var stmt = statements.getInsertTemplate();
                 queryExecutor.execute(connection, stmt,
                         credentialDefinition.getId(),
@@ -132,30 +124,26 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
         Objects.requireNonNull(id);
         return transactionContext.execute(() -> {
             try (var connection = getConnection()) {
-                if (findByIdInternal(connection, id) != null) {
-
-
-                    var definitionByCredentialType = findByCredentialType(connection, credentialDefinition.getCredentialType());
-                    if (definitionByCredentialType != null && !definitionByCredentialType.getId().equals(id)) {
-                        return alreadyExists(alreadyExistsForTypeErrorMessage(credentialDefinition.getCredentialType()));
-                    }
-                    queryExecutor.execute(connection,
-                            statements.getUpdateTemplate(),
-                            credentialDefinition.getCredentialType(),
-                            toJson(credentialDefinition.getAttestations()),
-                            toJson(credentialDefinition.getRules()),
-                            toJson(credentialDefinition.getMappings()),
-                            toJson(credentialDefinition.getJsonSchema()),
-                            toJson(credentialDefinition.getAdditionalContext()),
-                            credentialDefinition.getJsonSchemaUrl(),
-                            credentialDefinition.getValidity(),
-                            credentialDefinition.getFormat(),
-                            clock.millis(),
-                            credentialDefinition.getId()
-                    );
-                    return StoreResult.success();
+                if (findByIdInternal(connection, id) == null) {
+                    return StoreResult.notFound(notFoundErrorMessage(id));
                 }
-                return StoreResult.notFound(notFoundErrorMessage(id));
+
+                queryExecutor.execute(connection,
+                        statements.getUpdateTemplate(),
+                        credentialDefinition.getCredentialType(),
+                        toJson(credentialDefinition.getAttestations()),
+                        toJson(credentialDefinition.getRules()),
+                        toJson(credentialDefinition.getMappings()),
+                        toJson(credentialDefinition.getJsonSchema()),
+                        toJson(credentialDefinition.getAdditionalContext()),
+                        credentialDefinition.getJsonSchemaUrl(),
+                        credentialDefinition.getValidity(),
+                        credentialDefinition.getFormat(),
+                        clock.millis(),
+                        credentialDefinition.getId()
+                );
+                return StoreResult.success();
+
             } catch (SQLException e) {
                 throw new EdcPersistenceException(e);
             }
@@ -195,13 +183,6 @@ public class SqlCredentialDefinitionStore extends AbstractSqlStore implements Cr
         return transactionContext.execute(() -> {
             var stmt = statements.getFindByIdTemplate();
             return queryExecutor.single(connection, false, this::mapResultSet, stmt, id);
-        });
-    }
-
-    private CredentialDefinition findByCredentialType(Connection connection, String credentialType) {
-        return transactionContext.execute(() -> {
-            var stmt = statements.getFindCredentialTypeTemplate();
-            return queryExecutor.single(connection, false, this::mapResultSet, stmt, credentialType);
         });
     }
 

--- a/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/resources/credential-definition-schema.sql
+++ b/extensions/store/sql/issuerservice-credential-definition-store-sql/src/main/resources/credential-definition-schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS credential_definitions
 (
     id                     VARCHAR NOT NULL,
     participant_context_id VARCHAR NOT NULL,
-    credential_type        VARCHAR NOT NULL UNIQUE,
+    credential_type        VARCHAR NOT NULL,
     attestations           JSON    NOT NULL DEFAULT '[]',
     rules                  JSON    NOT NULL DEFAULT '[]',
     mappings               JSON    NOT NULL DEFAULT '[]',

--- a/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/credentialdefinition/store/CredentialDefinitionStore.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/main/java/org/eclipse/edc/issuerservice/spi/issuance/credentialdefinition/store/CredentialDefinitionStore.java
@@ -70,10 +70,6 @@ public interface CredentialDefinitionStore {
         return "A Credential definition with ID '%s' already exists.".formatted(id);
     }
 
-    default String alreadyExistsForTypeErrorMessage(String credentialType) {
-        return "A Credential definition with credential type '%s' already exists.".formatted(credentialType);
-    }
-
     default String notFoundErrorMessage(String id) {
         return "A Credential definition ID '%s' does not exist.".formatted(id);
     }

--- a/spi/issuerservice/issuerservice-issuance-spi/src/testFixtures/java/org/eclipse/edc/issuerservice/spi/issuance/credentialdefinition/store/CredentialDefinitionStoreTestBase.java
+++ b/spi/issuerservice/issuerservice-issuance-spi/src/testFixtures/java/org/eclipse/edc/issuerservice/spi/issuance/credentialdefinition/store/CredentialDefinitionStoreTestBase.java
@@ -32,7 +32,6 @@ import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
 
 public abstract class CredentialDefinitionStoreTestBase {
 
-
     @Test
     void create() {
         var credentialDefinition = createCredentialDefinition();
@@ -66,19 +65,6 @@ public abstract class CredentialDefinitionStoreTestBase {
     }
 
     @Test
-    void create_whenTypeExists_shouldReturnFailure() {
-        var credentialDefinition = createCredentialDefinition();
-
-        var result = getStore().create(credentialDefinition);
-
-        var newCredentialDefinition = createCredentialDefinition(UUID.randomUUID().toString(), credentialDefinition.getCredentialType());
-        assertThat(result).isSucceeded();
-        var result2 = getStore().create(newCredentialDefinition);
-
-        assertThat(result2).isFailed().detail().contains("already exists");
-    }
-
-    @Test
     void update() {
         var credentialDefinition = createCredentialDefinition();
         var result = getStore().create(credentialDefinition);
@@ -95,21 +81,6 @@ public abstract class CredentialDefinitionStoreTestBase {
 
         var updateRes = getStore().update(credentialDefinition);
         assertThat(updateRes).isFailed().detail().contains("ID '%s' does not exist.".formatted(credentialDefinition.getId()));
-    }
-
-    @Test
-    void update_whenTypeExists_fails() {
-        var credentialDefinition = createCredentialDefinition();
-        var credentialDefinition1 = createCredentialDefinition(UUID.randomUUID().toString(), "Membership1");
-        var result = getStore().create(credentialDefinition);
-        var result1 = getStore().create(credentialDefinition1);
-        assertThat(result).isSucceeded();
-        assertThat(result1).isSucceeded();
-
-        credentialDefinition = createCredentialDefinition(credentialDefinition.getId(), "Membership1");
-
-        var updateRes = getStore().update(credentialDefinition);
-        assertThat(updateRes).isFailed();
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Removes uniqueness check on `credentialType` in `CredentialDefinition`

## Why it does that

credentials definitions are now accessed by id

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #1045 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
