### PR TITLE
fix: add missing additionalContext binding to cred def api

### DIFF
--- a/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialDefinitionApiEndToEndTest.java
+++ b/e2e-tests/admin-api-tests/src/test/java/org/eclipse/edc/identityhub/tests/CredentialDefinitionApiEndToEndTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,6 +88,7 @@ public class CredentialDefinitionApiEndToEndTest {
                     .attestation("test-attestation")
                     .participantContextId(USER)
                     .formatFrom(VC1_0_JWT)
+                    .additionalContext(List.of("https://www.w3.org/2018/credentials/examples/v1"))
                     .build();
 
             issuer.getAdminEndpoint().baseRequest()

--- a/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/model/CredentialDefinitionDto.java
+++ b/extensions/api/issuer-admin-api/credential-definition-api/src/main/java/org/eclipse/edc/issuerservice/api/admin/credentialdefinition/v1/unstable/model/CredentialDefinitionDto.java
@@ -39,6 +39,7 @@ public class CredentialDefinitionDto {
     private final List<String> attestations = new ArrayList<>();
     private final List<CredentialRuleDefinition> rules = new ArrayList<>();
     private final List<MappingDefinition> mappings = new ArrayList<>();
+    private final List<String> additionalContext = new ArrayList<>();
     private String format;
     private String credentialType;
     private String jsonSchema;
@@ -77,6 +78,10 @@ public class CredentialDefinitionDto {
         return attestations;
     }
 
+    public List<String> getAdditionalContext() {
+        return additionalContext;
+    }
+
     public List<CredentialRuleDefinition> getRules() {
         return rules;
     }
@@ -96,6 +101,7 @@ public class CredentialDefinitionDto {
                 .attestations(attestations)
                 .rules(rules)
                 .mappings(mappings)
+                .additionalContext(additionalContext)
                 .participantContextId(participantContextId)
                 .build();
     }
@@ -174,6 +180,11 @@ public class CredentialDefinitionDto {
         @JsonIgnore
         public Builder mapping(MappingDefinition mapping) {
             this.entity.mappings.add(mapping);
+            return this;
+        }
+
+        public Builder additionalContext(List<String> additionalContexts) {
+            this.entity.additionalContext.addAll(additionalContexts);
             return this;
         }
 

--- a/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
+++ b/extensions/api/issuer-admin-api/issuer-admin-api-configuration/src/main/resources/issuer-admin-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-beta",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-07-20T13:00:00Z",
+    "lastUpdated": "2026-07-21T13:00:00Z",
     "maturity": null
   }
 ]


### PR DESCRIPTION
## What this PR changes/adds

add missing additionalContext binding to cred def api

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
