### PR TITLE
feat: remove authHeader so /metadata becomes public

### DIFF
--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1beta/issuermetadata/IssuerMetadataApi.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1beta/issuermetadata/IssuerMetadataApi.java
@@ -40,5 +40,5 @@ public interface IssuerMetadataApi {
                             content = @Content(schema = @Schema(implementation = ApiSchema.IssuerMetadataSchema.class)))
             }
     )
-    JsonObject getIssuerMetadata(String participantContextId, String token);
+    JsonObject getIssuerMetadata(String participantContextId);
 }

--- a/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1beta/issuermetadata/IssuerMetadataApiController.java
+++ b/protocols/dcp/dcp-issuer/dcp-issuer-api/src/main/java/org/eclipse/edc/identityhub/protocols/dcp/issuer/api/v1beta/issuermetadata/IssuerMetadataApiController.java
@@ -49,7 +49,7 @@ public class IssuerMetadataApiController implements IssuerMetadataApi {
     @GET
     @Path("/")
     @Override
-    public JsonObject getIssuerMetadata(@PathParam("participantContextId") String participantContextId, @HeaderParam(AUTHORIZATION) String authHeader) {
+    public JsonObject getIssuerMetadata(@PathParam("participantContextId") String participantContextId) {
 
         var participantContext = participantContextService.getParticipantContext(participantContextId)
                 .orElseThrow((f) -> new AuthenticationFailedException("Invalid issuer"));


### PR DESCRIPTION
## What this PR changes/adds
It remove the @HeaderParam(AUTHORIZATION) String authHeader parameter.

## Why it does that
As a participant, I wanna to know what are Governance parameters to ask the Credential.

## Who will sponsor this feature?
@wolf4ood 

## Linked Issue(s)
Closes #1050

