### PR TITLE
feat: make ParticipantSecureTokenService a default provider

### DIFF
--- a/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
+++ b/extensions/api/identity-api/identity-api-configuration/src/main/resources/identity-api-version.json
@@ -2,7 +2,7 @@
   {
     "version": "1.0.0-beta",
     "urlPath": "/v1beta",
-    "lastUpdated": "2026-08-12T13:00:00Z",
+    "lastUpdated": "2026-08-14T13:00:00Z",
     "maturity": null
   }
 ]

--- a/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/EmbeddedStsServiceExtension.java
+++ b/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/EmbeddedStsServiceExtension.java
@@ -15,8 +15,6 @@
 package org.eclipse.edc.iam.decentralizedclaims.sts;
 
 import org.eclipse.edc.iam.decentralizedclaims.sts.service.EmbeddedSecureTokenService;
-import org.eclipse.edc.iam.decentralizedclaims.sts.service.StsClientTokenGeneratorServiceImpl;
-import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsClientTokenGeneratorService;
 import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
 import org.eclipse.edc.identityhub.spi.keypair.KeyPairService;
 import org.eclipse.edc.jwt.spi.signer.JwsSignerProvider;
@@ -25,17 +23,14 @@ import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Setting;
 import org.eclipse.edc.spi.system.ServiceExtension;
-import org.eclipse.edc.spi.system.ServiceExtensionContext;
 import org.eclipse.edc.token.JwtGenerationService;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 
-import static org.eclipse.edc.identityhub.sts.accountservice.StsAccountServiceExtension.NAME;
 
-
-@Extension(value = NAME)
+@Extension(value = EmbeddedStsServiceExtension.NAME)
 public class EmbeddedStsServiceExtension implements ServiceExtension {
     public static final String NAME = "Local (embedded) STS Account Service Extension";
     private static final int DEFAULT_STS_TOKEN_EXPIRATION_MIN = 5;
@@ -56,18 +51,11 @@ public class EmbeddedStsServiceExtension implements ServiceExtension {
         return NAME;
     }
 
-    @Provider
+    @Provider(isDefault = true)
     public ParticipantSecureTokenService secureTokenService() {
         if (embeddedSts == null) {
             embeddedSts = new EmbeddedSecureTokenService(transactionContext, TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin), new JwtGenerationService(externalSigner), clock, keyPairService);
         }
         return embeddedSts;
-    }
-
-    @Provider
-    public StsClientTokenGeneratorService clientTokenService(ServiceExtensionContext context) {
-        return new StsClientTokenGeneratorServiceImpl(
-                TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin),
-                secureTokenService());
     }
 }

--- a/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/StsClientTokenGeneratorExtension.java
+++ b/extensions/sts/sts-core/src/main/java/org/eclipse/edc/iam/decentralizedclaims/sts/StsClientTokenGeneratorExtension.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2026 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.iam.decentralizedclaims.sts;
+
+import org.eclipse.edc.iam.decentralizedclaims.sts.service.StsClientTokenGeneratorServiceImpl;
+import org.eclipse.edc.iam.decentralizedclaims.sts.spi.service.StsClientTokenGeneratorService;
+import org.eclipse.edc.identityhub.spi.authentication.ParticipantSecureTokenService;
+import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
+import org.eclipse.edc.runtime.metamodel.annotation.Setting;
+import org.eclipse.edc.spi.system.ServiceExtension;
+
+import java.util.concurrent.TimeUnit;
+
+@Extension(value = StsClientTokenGeneratorExtension.NAME)
+public class StsClientTokenGeneratorExtension implements ServiceExtension {
+    public static final String NAME = "STS Client Token Generator Extension";
+    private static final int DEFAULT_STS_TOKEN_EXPIRATION_MIN = 5;
+    @Setting(description = "Self-issued ID Token expiration in minutes. By default is 5 minutes", defaultValue = "" + DEFAULT_STS_TOKEN_EXPIRATION_MIN, key = "edc.iam.sts.token.expiration")
+    private long stsTokenExpirationMin;
+    @Inject
+    private ParticipantSecureTokenService secureTokenService;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Provider
+    public StsClientTokenGeneratorService clientTokenService() {
+        return new StsClientTokenGeneratorServiceImpl(
+                TimeUnit.MINUTES.toSeconds(stsTokenExpirationMin),
+                secureTokenService);
+    }
+}

--- a/extensions/sts/sts-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/extensions/sts/sts-core/src/main/resources/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -14,3 +14,4 @@
 
 org.eclipse.edc.iam.decentralizedclaims.sts.defaults.StsDefaultServicesExtension
 org.eclipse.edc.iam.decentralizedclaims.sts.EmbeddedStsServiceExtension
+org.eclipse.edc.iam.decentralizedclaims.sts.StsClientTokenGeneratorExtension


### PR DESCRIPTION
## What this PR changes/adds

Marks the `ParticipantSecureTokenService` provider in `EmbeddedStsServiceExtension` as a default provider (`@Provider(isDefault = true)`).

Moves the `StsClientTokenGeneratorService` provider out of `EmbeddedStsServiceExtension` into a new `StsClientTokenGeneratorExtension` (same module), which injects the resolved `ParticipantSecureTokenService` instead of calling the embedded implementation directly.

## Why it does that

The self-issued token claims (e.g. for DCP credential requests to an issuer) are fixed by the callers of `ParticipantSecureTokenService`, and there is no decorator hook in the token generation chain. Previously, customizing the token (e.g. adding a claim) required excluding the entire `sts-core` module from the runtime, because the service was registered via a plain `@Provider`. With a default provider, downstream extensions can simply out-provide `ParticipantSecureTokenService` with their own implementation.

Splitting off the `StsClientTokenGeneratorService` provider ensures consistency: it was previously hard-wired to the embedded STS, so an out-provided `ParticipantSecureTokenService` would have been used by the DCP flows but silently bypassed by the STS API token endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)