### PR TITLE
feat: deactivate superseded credentials holder-side

### DIFF
--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImpl.java
@@ -46,7 +46,13 @@ public class CredentialStatusCheckServiceImpl implements CredentialStatusCheckSe
         try {
             if (isRevoked(credential)) {
                 return success(VcStatus.REVOKED); //irreversible, cannot be overwritten
-            } else if (isSuspended(credential)) {
+            }
+            // a superseded credential was replaced by a re-issued one and stays EXPIRED permanently (unless revoked),
+            // even while its own validity dates would still make it usable
+            if (credential.isSuperseded()) {
+                return success(VcStatus.EXPIRED);
+            }
+            if (isSuspended(credential)) {
                 return success(VcStatus.SUSPENDED);
             }
 

--- a/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
+++ b/core/identity-hub-core/src/main/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImpl.java
@@ -27,10 +27,13 @@ import org.eclipse.edc.identityhub.spi.credential.request.store.HolderCredential
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriteRequest;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriter;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialProfile;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialUsage;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.eclipse.edc.spi.query.Criterion;
+import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.result.ServiceResult;
 import org.eclipse.edc.token.spi.TokenValidationService;
@@ -254,12 +257,17 @@ public class CredentialWriterImpl implements CredentialWriter {
             }
 
             // store the credential object ID for later use, e.g. automatic re-issuance
-            resource.getMetadata().put("credentialObjectId", requestedCredential.get().id());
+            resource.getMetadata().put(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID, requestedCredential.get().id());
 
             var createResult = credentialStore.create(resource);
 
             if (createResult.failed()) {
                 return from(createResult);
+            }
+
+            var supersededResult = expireSupersededCredentials(resource, participantContextId);
+            if (supersededResult.failed()) {
+                return supersededResult;
             }
         }
 
@@ -267,6 +275,43 @@ public class CredentialWriterImpl implements CredentialWriter {
         holderRequest.transitionIssued(issuerPid);
         holderCredentialRequestStore.save(holderRequest);
 
+        return success();
+    }
+
+    /**
+     * A delivered credential replaces any credential that was previously obtained for the same {@code CredentialObject}
+     * in the same format, e.g. on re-issuance after automatic renewal. The Issuer may revoke the replaced credential at
+     * any time, so it must no longer be used in DCP interactions: it is moved to {@link VcStatus#EXPIRED}, which excludes
+     * it from presentations immediately, and marked as superseded so the credential watchdog neither re-activates it nor
+     * requests re-issuance for it. The watchdog may still move it on to {@link VcStatus#REVOKED} once the Issuer revokes it.
+     */
+    private ServiceResult<Void> expireSupersededCredentials(VerifiableCredentialResource newCredential, String participantContextId) {
+        var query = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("participantContextId", "=", participantContextId))
+                .filter(new Criterion("usage", "=", CredentialUsage.Holder.toString()))
+                .filter(new Criterion("metadata.%s".formatted(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID), "=",
+                        newCredential.getMetadata().get(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID)))
+                .filter(new Criterion("verifiableCredential.format", "=", newCredential.getVerifiableCredential().format().ordinal()))
+                .filter(new Criterion("id", "!=", newCredential.getId()))
+                // a revocation is authoritative and must not be masked by the supersession
+                .filter(new Criterion("state", "!=", VcStatus.REVOKED.code()))
+                .build();
+
+        var queryResult = credentialStore.query(query);
+        if (queryResult.failed()) {
+            return from(queryResult).mapEmpty();
+        }
+
+        for (var superseded : queryResult.getContent()) {
+            superseded.getMetadata().put(VerifiableCredentialResource.METADATA_SUPERSEDED_BY, newCredential.getId());
+            superseded.setExpired();
+            var updateResult = credentialStore.update(superseded);
+            if (updateResult.failed()) {
+                return from(updateResult);
+            }
+            monitor.debug("Credential '%s' was superseded by re-issued credential '%s' and is now in state %s"
+                    .formatted(superseded.getId(), newCredential.getId(), VcStatus.EXPIRED));
+        }
         return success();
     }
 

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialStatusCheckServiceImplTest.java
@@ -228,6 +228,37 @@ class CredentialStatusCheckServiceImplTest {
     }
 
     @Test
+    void checkStatus_superseded_staysExpired() {
+        var credential = createVerifiableCredential()
+                .expirationDate(Instant.now(clock).plus(10, ChronoUnit.MINUTES))
+                .build();
+        var resource = createCredentialBuilder(credential)
+                .state(VcStatus.EXPIRED)
+                .metadata(VerifiableCredentialResource.METADATA_SUPERSEDED_BY, "new-credential-id")
+                .build();
+
+        assertThat(service.checkStatus(resource))
+                .isSucceeded()
+                .isEqualTo(VcStatus.EXPIRED);
+    }
+
+    @Test
+    void checkStatus_superseded_becomesRevoked() {
+        when(revocationServiceRegistry.getRevocationStatus(any())).thenReturn(Result.success("revocation"));
+        var credential = createVerifiableCredential()
+                .expirationDate(Instant.now(clock).plus(10, ChronoUnit.MINUTES))
+                .build();
+        var resource = createCredentialBuilder(credential)
+                .state(VcStatus.EXPIRED)
+                .metadata(VerifiableCredentialResource.METADATA_SUPERSEDED_BY, "new-credential-id")
+                .build();
+
+        assertThat(service.checkStatus(resource))
+                .isSucceeded()
+                .isEqualTo(VcStatus.REVOKED);
+    }
+
+    @Test
     void checkStatus_expired_becomesRevoked() {
         when(revocationServiceRegistry.getRevocationStatus(any())).thenReturn(Result.success("revocation"));
         var credential = createVerifiableCredential()

--- a/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImplTest.java
+++ b/core/identity-hub-core/src/test/java/org/eclipse/edc/identityhub/core/services/verifiablecredential/CredentialWriterImplTest.java
@@ -20,10 +20,13 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialFormat;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.CredentialSubject;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.Issuer;
 import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
+import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredentialContainer;
 import org.eclipse.edc.identityhub.spi.credential.request.model.HolderCredentialRequest;
 import org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState;
 import org.eclipse.edc.identityhub.spi.credential.request.store.HolderCredentialRequestStore;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.generator.CredentialWriteRequest;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.jsonld.util.JacksonJsonLd;
 import org.eclipse.edc.keys.spi.PublicKeyResolver;
@@ -37,6 +40,7 @@ import org.eclipse.edc.transform.spi.TypeTransformerRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Instant;
 import java.util.List;
@@ -80,6 +84,7 @@ class CredentialWriterImplTest {
     @BeforeEach
     void setUp() {
         when(tokenValidationService.validate(anyString(), any(PublicKeyResolver.class), anyList())).thenReturn(Result.success(ClaimToken.Builder.newInstance().build()));
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of()));
         when(holderCredentialRequestStore.findByIdAndLease(anyString())).thenReturn(StoreResult.success(HolderCredentialRequest.Builder.newInstance()
                 .issuerDid(ISSUER_DID)
                 .requestedCredential("test-id", TEST_CREDENTIAL_TYPE, TEST_CREDENTIAL_FORMAT)
@@ -131,6 +136,73 @@ class CredentialWriterImplTest {
 
         var result = credentialWriter.write("holderPid", HOLDER_DID, "issuerPid", ISSUER_DID, Set.of(new CredentialWriteRequest("raw-cred", CredentialFormat.VC2_0_COSE.toString())), PARTICIPANT_ID);
         assertThat(result).isFailed().detail().contains("No credential request was made for Credentials ");
+    }
+
+    @Test
+    @DisplayName("a delivered credential expires the credential it supersedes, e.g. on re-issuance after renewal")
+    void write_expiresSupersededCredential() {
+        when(credentialTransformerRegistry.transform(isA(String.class), eq(VerifiableCredential.class)))
+                .thenReturn(Result.success(createCredential().build()));
+        when(credentialStore.create(any())).thenReturn(StoreResult.success());
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(createResource("old-credential-id"))));
+        when(credentialStore.update(any())).thenReturn(StoreResult.success());
+
+        var result = credentialWriter.write("holderPid", HOLDER_DID, "issuerPid", ISSUER_DID, Set.of(new CredentialWriteRequest("raw-cred", TEST_CREDENTIAL_FORMAT)), PARTICIPANT_ID);
+
+        assertThat(result).isSucceeded();
+        var newCredential = ArgumentCaptor.forClass(VerifiableCredentialResource.class);
+        verify(credentialStore).create(newCredential.capture());
+        verify(credentialStore).update(argThat(resource -> resource.getId().equals("old-credential-id") &&
+                resource.getStateAsEnum() == VcStatus.EXPIRED &&
+                newCredential.getValue().getId().equals(resource.getMetadata().get(VerifiableCredentialResource.METADATA_SUPERSEDED_BY))));
+        // the lookup must be scoped to the participant's own holder credentials for the same credential object,
+        // must not return the credential just stored, and must leave revoked credentials alone
+        verify(credentialStore).query(argThat(querySpec -> {
+            var filters = querySpec.getFilterExpression().toString();
+            return filters.contains("participantContextId = " + PARTICIPANT_ID) &&
+                    filters.contains("usage = Holder") &&
+                    filters.contains("metadata.credentialObjectId = test-id") &&
+                    filters.contains("id != " + newCredential.getValue().getId()) &&
+                    filters.contains("state != " + VcStatus.REVOKED.code());
+        }));
+    }
+
+    @Test
+    @DisplayName("a first-time issuance finds nothing to supersede and modifies no other credential")
+    void write_noSupersededCredential_updatesNothing() {
+        when(credentialTransformerRegistry.transform(isA(String.class), eq(VerifiableCredential.class)))
+                .thenReturn(Result.success(createCredential().build()));
+        when(credentialStore.create(any())).thenReturn(StoreResult.success());
+
+        var result = credentialWriter.write("holderPid", HOLDER_DID, "issuerPid", ISSUER_DID, Set.of(new CredentialWriteRequest("raw-cred", TEST_CREDENTIAL_FORMAT)), PARTICIPANT_ID);
+
+        assertThat(result).isSucceeded();
+        verify(credentialStore, never()).update(any());
+    }
+
+    @Test
+    void write_supersededCredentialUpdateFails_expectFailure() {
+        when(credentialTransformerRegistry.transform(isA(String.class), eq(VerifiableCredential.class)))
+                .thenReturn(Result.success(createCredential().build()));
+        when(credentialStore.create(any())).thenReturn(StoreResult.success());
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(createResource("old-credential-id"))));
+        when(credentialStore.update(any())).thenReturn(StoreResult.generalError("update failed"));
+
+        var result = credentialWriter.write("holderPid", HOLDER_DID, "issuerPid", ISSUER_DID, Set.of(new CredentialWriteRequest("raw-cred", TEST_CREDENTIAL_FORMAT)), PARTICIPANT_ID);
+
+        assertThat(result).isFailed().detail().contains("update failed");
+    }
+
+    @Test
+    void write_supersededCredentialLookupFails_expectFailure() {
+        when(credentialTransformerRegistry.transform(isA(String.class), eq(VerifiableCredential.class)))
+                .thenReturn(Result.success(createCredential().build()));
+        when(credentialStore.create(any())).thenReturn(StoreResult.success());
+        when(credentialStore.query(any())).thenReturn(StoreResult.generalError("query failed"));
+
+        var result = credentialWriter.write("holderPid", HOLDER_DID, "issuerPid", ISSUER_DID, Set.of(new CredentialWriteRequest("raw-cred", TEST_CREDENTIAL_FORMAT)), PARTICIPANT_ID);
+
+        assertThat(result).isFailed().detail().contains("query failed");
     }
 
     @Test
@@ -380,6 +452,18 @@ class CredentialWriterImplTest {
         assertThat(result).isFailed();
         Assertions.assertThat(request.stateAsEnum()).isEqualTo(REQUESTED);
         verify(holderCredentialRequestStore).breakLease(request);
+    }
+
+    private VerifiableCredentialResource createResource(String id) {
+        return VerifiableCredentialResource.Builder.newHolder()
+                .id(id)
+                .issuerId(ISSUER_DID)
+                .holderId(HOLDER_DID)
+                .state(VcStatus.REQUESTED)
+                .participantContextId(PARTICIPANT_ID)
+                .metadata(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID, "test-id")
+                .credential(new VerifiableCredentialContainer("raw-cred", CredentialFormat.VC1_0_JWT, createCredential().build()))
+                .build();
     }
 
     private VerifiableCredential.Builder createCredential() {

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowAllInOneTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowAllInOneTest.java
@@ -35,6 +35,7 @@ import org.eclipse.edc.iam.verifiablecredentials.spi.model.VerifiableCredential;
 import org.eclipse.edc.identityhub.spi.credential.request.model.HolderRequestState;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.CredentialUsage;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStatus;
+import org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VerifiableCredentialResource;
 import org.eclipse.edc.identityhub.spi.verifiablecredentials.store.CredentialStore;
 import org.eclipse.edc.identityhub.tests.fixtures.DefaultRuntimes;
 import org.eclipse.edc.identityhub.tests.fixtures.credentialservice.IdentityHub;
@@ -62,6 +63,8 @@ import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.query.QuerySpec;
 import org.eclipse.edc.spi.result.Result;
 import org.eclipse.edc.spi.security.Vault;
+import org.eclipse.edc.spi.system.configuration.Config;
+import org.eclipse.edc.spi.system.configuration.ConfigFactory;
 import org.eclipse.edc.sql.testfixtures.PostgresqlEndToEndExtension;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.hamcrest.Matchers;
@@ -126,6 +129,15 @@ public class DcpIssuanceFlowAllInOneTest {
         private static String participantToken;
         private static String issuerDid;
         private static String participantDid;
+
+        /**
+         * The default renewal grace period (1 week) would put every credential permanently inside the renewal window,
+         * so all of them would be re-issued continuously. With 2 seconds, only the deliberately short-lived
+         * RenewalCredential (5s validity) is ever renewed.
+         */
+        static Config renewalConfig() {
+            return ConfigFactory.fromMap(Map.of("edc.iam.credential.renewal.graceperiod", "2"));
+        }
 
         @BeforeAll
         static void beforeAll(IssuerService issuer, IdentityHub identityHub) {
@@ -192,7 +204,7 @@ public class DcpIssuanceFlowAllInOneTest {
                     .jsonSchemaUrl("https://example.com/schema")
                     .jsonSchema("{}")
                     .attestation(attestationDefinition.getId())
-                    .validity(Duration.ofSeconds(5).toSeconds()) // one second - trigger renewal
+                    .validity(Duration.ofHours(1).toSeconds())
                     .mapping(mappingDefinition)
                     .rule(new CredentialRuleDefinition("expression", ruleConfiguration))
                     .participantContextId("participantContextId")
@@ -200,6 +212,23 @@ public class DcpIssuanceFlowAllInOneTest {
                     .build();
 
             credentialDefinitionService.createCredentialDefinition(credentialDefinition);
+
+            // a separate, short-lived credential type keeps the continuous renewal chain it spawns from interfering
+            // with the tests that expect their MembershipCredential to remain untouched
+            var renewalCredentialDefinition = CredentialDefinition.Builder.newInstance()
+                    .id("renewalCredential-id")
+                    .credentialType("RenewalCredential")
+                    .jsonSchemaUrl("https://example.com/schema")
+                    .jsonSchema("{}")
+                    .attestation(attestationDefinition.getId())
+                    .validity(Duration.ofSeconds(5).toSeconds()) // expires quickly - triggers renewal
+                    .mapping(mappingDefinition)
+                    .rule(new CredentialRuleDefinition("expression", ruleConfiguration))
+                    .participantContextId("participantContextId")
+                    .formatFrom(VC1_0_JWT)
+                    .build();
+
+            credentialDefinitionService.createCredentialDefinition(renewalCredentialDefinition);
             return attestationDefinition;
         }
 
@@ -291,7 +320,7 @@ public class DcpIssuanceFlowAllInOneTest {
             issuer.getIdentityEndpoint().baseRequest()
                     .contentType(JSON)
                     .header(new Header("x-api-key", participantToken))
-                    .body(createIssuanceRequest(holderRequestId))
+                    .body(createIssuanceRequest(holderRequestId, "renewalCredential-id", "RenewalCredential"))
                     .post("/v1/participants/%s/credentials/request".formatted(PARTICIPANT_ID))
                     .then()
                     .log().ifValidationFails()
@@ -321,11 +350,23 @@ public class DcpIssuanceFlowAllInOneTest {
                                 .getContent())
                                 .hasSizeGreaterThanOrEqualTo(2);
 
-                        assertThat(store.query(QuerySpec.Builder.newInstance()
+                        var renewalCredentials = store.query(QuerySpec.Builder.newInstance()
                                         .filter(new Criterion("usage", "=", CredentialUsage.Holder.toString()))
                                         .build())
-                                .getContent())
-                                .hasSizeGreaterThanOrEqualTo(2);
+                                .getContent().stream()
+                                .filter(c -> c.getVerifiableCredential().credential().getType().contains("RenewalCredential"))
+                                .toList();
+                        assertThat(renewalCredentials).hasSizeGreaterThanOrEqualTo(2);
+
+                        // a delivered renewal supersedes the credential it replaces: only the newest credential remains
+                        // usable, previous generations are moved to EXPIRED and marked with their successor
+                        assertThat(renewalCredentials.stream()
+                                .filter(c -> c.getStateAsEnum() != VcStatus.EXPIRED && c.getStateAsEnum() != VcStatus.REVOKED))
+                                .hasSize(1);
+                        assertThat(renewalCredentials).anySatisfy(c -> {
+                            assertThat(c.getStateAsEnum()).isEqualTo(VcStatus.EXPIRED);
+                            assertThat(c.getMetadata()).containsKey(VerifiableCredentialResource.METADATA_SUPERSEDED_BY);
+                        });
 
                         // no issuance process should be in a state _other than_ DELIVERED
                         var query = QuerySpec.Builder.newInstance()
@@ -466,13 +507,17 @@ public class DcpIssuanceFlowAllInOneTest {
         }
 
         private @NonNull Map<String, Object> createIssuanceRequest(String holderRequestId) {
+            return createIssuanceRequest(holderRequestId, "membershipCredential-id", "MembershipCredential");
+        }
+
+        private @NonNull Map<String, Object> createIssuanceRequest(String holderRequestId, String credentialDefinitionId, String credentialType) {
             return Map.of(
                     "issuerDid", issuerDid,
                     "holderPid", holderRequestId,
                     "credentials", List.of(Map.of(
-                            "id", "membershipCredential-id",
+                            "id", credentialDefinitionId,
                             "format", VC1_0_JWT.name(),
-                            "type", "MembershipCredential"
+                            "type", credentialType
                     ))
             );
         }
@@ -518,6 +563,7 @@ public class DcpIssuanceFlowAllInOneTest {
                 .endpoints(ENDPOINTS.build())
                 .configurationProvider(DefaultRuntimes.Issuer::config)
                 .configurationProvider(DefaultRuntimes.IdentityHub::config)
+                .configurationProvider(Tests::renewalConfig)
                 .paramProvider(IdentityHub.class, IdentityHub::forContext)
                 .paramProvider(IssuerService.class, IssuerService::forContext)
                 .build();
@@ -541,6 +587,7 @@ public class DcpIssuanceFlowAllInOneTest {
                 .endpoints(ENDPOINTS.build())
                 .configurationProvider(DefaultRuntimes.Issuer::config)
                 .configurationProvider(DefaultRuntimes.IdentityHub::config)
+                .configurationProvider(Tests::renewalConfig)
                 .configurationProvider(() -> POSTGRESQL_EXTENSION.configFor(ISSUER))
                 .paramProvider(IdentityHub.class, IdentityHub::forContext)
                 .paramProvider(IssuerService.class, IssuerService::forContext)

--- a/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowAllInOneTest.java
+++ b/e2e-tests/dcp-issuance-tests/src/test/java/org/eclipse/edc/identityhub/tests/dcp/flow/DcpIssuanceFlowAllInOneTest.java
@@ -81,6 +81,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -379,6 +380,63 @@ public class DcpIssuanceFlowAllInOneTest {
         }
 
         @Test
+        @DisplayName("a re-issuance requested while the current credential is still valid supersedes it upon delivery")
+        void testReissuanceWithinValidity(IssuerService issuer, IdentityHub identityHub) {
+            var store = issuer.getService(CredentialStore.class);
+            var firstRequestId = UUID.randomUUID().toString();
+
+            identityHub.getIdentityEndpoint().baseRequest()
+                    .contentType(JSON)
+                    .header(new Header("x-api-key", participantToken))
+                    .body(createIssuanceRequest(firstRequestId))
+                    .post("/v1/participants/%s/credentials/request".formatted(PARTICIPANT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(201);
+
+            await().pollInterval(INTERVAL)
+                    .atMost(TIMEOUT)
+                    .untilAsserted(() -> assertThat(identityHub.getCredentialRequestForParticipant(PARTICIPANT_ID, firstRequestId))
+                            .hasSize(1)
+                            .allSatisfy(t -> assertThat(t.getState()).isEqualTo(HolderRequestState.ISSUED.code())));
+
+            var activeCredentials = activeMembershipCredentials(store);
+            assertThat(activeCredentials).hasSize(1);
+            var firstCredential = activeCredentials.get(0);
+            assertThat(firstCredential.getStateAsEnum()).isEqualTo(VcStatus.ISSUED);
+            assertThat(firstCredential.getVerifiableCredential().credential().getExpirationDate()).isAfter(Instant.now());
+
+            // request re-issuance long before the first credential expires - once the fresh credential is delivered,
+            // two technically valid credentials exist on the holder, and only the newer one may remain usable
+            var secondRequestId = UUID.randomUUID().toString();
+            identityHub.getIdentityEndpoint().baseRequest()
+                    .contentType(JSON)
+                    .header(new Header("x-api-key", participantToken))
+                    .body(createIssuanceRequest(secondRequestId))
+                    .post("/v1/participants/%s/credentials/request".formatted(PARTICIPANT_ID))
+                    .then()
+                    .log().ifValidationFails()
+                    .statusCode(201);
+
+            await().pollInterval(INTERVAL)
+                    .atMost(TIMEOUT)
+                    .untilAsserted(() -> {
+                        var active = activeMembershipCredentials(store);
+                        assertThat(active).hasSize(1);
+                        var newCredential = active.get(0);
+                        assertThat(newCredential.getId()).isNotEqualTo(firstCredential.getId());
+                        assertThat(newCredential.getStateAsEnum()).isEqualTo(VcStatus.ISSUED);
+
+                        var supersededResult = store.findById(firstCredential.getId());
+                        assertThat(supersededResult.succeeded()).isTrue();
+                        var superseded = supersededResult.getContent();
+                        assertThat(superseded.getVerifiableCredential().credential().getExpirationDate()).isAfter(Instant.now());
+                        assertThat(superseded.getStateAsEnum()).isEqualTo(VcStatus.EXPIRED);
+                        assertThat(superseded.getMetadata()).containsEntry(VerifiableCredentialResource.METADATA_SUPERSEDED_BY, newCredential.getId());
+                    });
+        }
+
+        @Test
         @DisplayName("RT-05: revoking an issued credential flips its published status list, observable by a verifier")
         void testRevoke(IssuerService issuer, IdentityHub identityHub) throws ParseException {
             var holderRequestId = UUID.randomUUID().toString();
@@ -504,6 +562,19 @@ public class DcpIssuanceFlowAllInOneTest {
                                 });
                     });
 
+        }
+
+        /**
+         * The holder's stored MembershipCredentials that are still usable in DCP interactions, i.e. neither expired nor revoked.
+         */
+        private List<VerifiableCredentialResource> activeMembershipCredentials(CredentialStore store) {
+            return store.query(QuerySpec.Builder.newInstance()
+                            .filter(new Criterion("usage", "=", CredentialUsage.Holder.toString()))
+                            .build())
+                    .getContent().stream()
+                    .filter(c -> c.getVerifiableCredential().credential().getType().contains("MembershipCredential"))
+                    .filter(c -> c.getStateAsEnum() != VcStatus.EXPIRED && c.getStateAsEnum() != VcStatus.REVOKED)
+                    .toList();
         }
 
         private @NonNull Map<String, Object> createIssuanceRequest(String holderRequestId) {

--- a/extensions/common/credential-watchdog/src/main/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdog.java
+++ b/extensions/common/credential-watchdog/src/main/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdog.java
@@ -98,8 +98,12 @@ public class CredentialWatchdog implements Runnable {
                 }
             });
 
-            // check credentials that are nearing expiry
+            // initiate re-issuance for credentials that are nearing (or past) expiry, unless a replacement credential
+            // was already issued: the state alone cannot express that distinction, because EXPIRED covers both a
+            // superseded credential and one that ran out without a replacement. The latter must still be renewed, while
+            // renewing a superseded one would loop forever, as every delivery expires its predecessor.
             allCredentials.stream()
+                    .filter(cred -> !cred.isSuperseded())
                     .filter(cred -> Instant.now().isAfter(cred.getVerifiableCredential().credential().getExpirationDate().minusSeconds(expiryGracePeriod.toSeconds())))
                     .forEach(this::startReissuance);
         });
@@ -113,10 +117,11 @@ public class CredentialWatchdog implements Runnable {
                 .filter(s -> !s.equalsIgnoreCase("VerifiableCredential"))
                 .findAny()
                 .orElse(null);
-        var credentialObjectId = ofNullable(expiringCredential.getMetadata().get("credentialObjectId")).map(Object::toString);
+        var credentialObjectId = ofNullable(expiringCredential.getMetadata().get(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID)).map(Object::toString);
 
         if (credentialObjectId.isEmpty()) {
-            monitor.warning("Attempting to start re-issuance for credential '%s' failed: No CredentialObjectId found (metadata property 'credentialObjectId'). Will abort re-issuance.".formatted(expiringCredential.getId()));
+            monitor.warning("Attempting to start re-issuance for credential '%s' failed: No CredentialObjectId found (metadata property '%s'). Will abort re-issuance."
+                    .formatted(expiringCredential.getId(), VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID));
             return;
         }
 

--- a/extensions/common/credential-watchdog/src/test/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdogTest.java
+++ b/extensions/common/credential-watchdog/src/test/java/org/eclipse/edc/identityhub/common/credentialwatchdog/CredentialWatchdogTest.java
@@ -191,6 +191,45 @@ class CredentialWatchdogTest {
     }
 
     @Test
+    void run_whenCredentialIsSuperseded_shouldNotInitiateRenewal() {
+        var cred = createCredentialBuilder()
+                .state(VcStatus.EXPIRED)
+                .metadata(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID, "cred-object-id")
+                .metadata(VerifiableCredentialResource.METADATA_SUPERSEDED_BY, "new-credential-id")
+                .credential(new VerifiableCredentialContainer("raw-vc-content", VC1_0_JWT, createVerifiableCredential()
+                        .expirationDate(Instant.now().plusSeconds(GRACE_PERIOD / 2))
+                        .build()))
+                .build();
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(cred)));
+        when(credentialStatusCheckService.checkStatus(any())).thenReturn(Result.success(VcStatus.EXPIRED));
+
+        watchdog.run();
+
+        verifyNoInteractions(credentialRequestManager);
+        verify(credentialStore, never()).update(any());
+    }
+
+    @Test
+    void run_whenCredentialExpiredWithoutReplacement_shouldInitiateRenewal() {
+        var cred = createCredentialBuilder()
+                .state(VcStatus.EXPIRED)
+                .metadata(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID, "cred-object-id")
+                .credential(new VerifiableCredentialContainer("raw-vc-content", VC1_0_JWT, createVerifiableCredential()
+                        .expirationDate(Instant.now().minusSeconds(10))
+                        .build()))
+                .build();
+        when(credentialStore.query(any())).thenReturn(StoreResult.success(List.of(cred)));
+        when(credentialStatusCheckService.checkStatus(any())).thenReturn(Result.success(VcStatus.EXPIRED));
+        when(credentialStore.update(any())).thenReturn(StoreResult.success());
+
+        watchdog.run();
+
+        verify(credentialRequestManager).initiateRequest(eq(cred.getParticipantContextId()), eq(cred.getIssuerId()), anyString(), argThat(list ->
+                list.size() == 1 && list.get(0).id().equals("cred-object-id")));
+        verify(credentialStore).update(argThat(vc -> vc.getStateAsEnum() == REQUESTED));
+    }
+
+    @Test
     void run_whenCredentialIsExpiring_noObjectIdPresent() {
         var cred = createCredentialBuilder()
                 // .metadata("credentialObjectId", "cred-object-id") missing!

--- a/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/VerifiableCredentialResource.java
+++ b/spi/verifiable-credential-spi/src/main/java/org/eclipse/edc/identityhub/spi/verifiablecredentials/model/VerifiableCredentialResource.java
@@ -33,6 +33,19 @@ import static org.eclipse.edc.identityhub.spi.verifiablecredentials.model.VcStat
  * specifically the issuance and re-issuance policies as well as a representation of the VC
  */
 public class VerifiableCredentialResource extends IdentityResource {
+
+    /**
+     * Metadata key holding the ID of the {@code CredentialObject} this credential was requested with. Links a stored
+     * credential back to the Issuer's credential offering, e.g. for automatic re-issuance.
+     */
+    public static final String METADATA_CREDENTIAL_OBJECT_ID = "credentialObjectId";
+
+    /**
+     * Metadata key holding the ID of the credential that superseded this one. Set when a re-issued credential is delivered,
+     * marking this resource as permanently out of use regardless of its own validity dates.
+     */
+    public static final String METADATA_SUPERSEDED_BY = "supersededBy";
+
     private Map<String, Object> metadata = new HashMap<>();
     private int state;
     private Instant timeOfLastStatusUpdate;
@@ -84,6 +97,15 @@ public class VerifiableCredentialResource extends IdentityResource {
     @JsonIgnore
     public boolean isSuspended() {
         return SUSPENDED.code() == state;
+    }
+
+    /**
+     * Whether this credential was replaced by a re-issued one. A superseded credential must no longer be used in DCP
+     * interactions, no matter what its own validity dates say.
+     */
+    @JsonIgnore
+    public boolean isSuperseded() {
+        return metadata != null && metadata.containsKey(METADATA_SUPERSEDED_BY);
     }
 
     public void suspend() {

--- a/spi/verifiable-credential-spi/src/testFixtures/java/org/eclipse/edc/identityhub/verifiablecredentials/store/CredentialStoreTestBase.java
+++ b/spi/verifiable-credential-spi/src/testFixtures/java/org/eclipse/edc/identityhub/verifiablecredentials/store/CredentialStoreTestBase.java
@@ -368,6 +368,28 @@ public abstract class CredentialStoreTestBase {
     }
 
     @Test
+    void query_byMetadata_withEqualOperator() {
+        var expectedCred = createCredentialBuilder()
+                .metadata(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID, "credential-object-1")
+                .build();
+        var otherCred = createCredentialBuilder()
+                .metadata(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID, "credential-object-2")
+                .build();
+
+        getStore().create(expectedCred);
+        getStore().create(otherCred);
+
+        var query = QuerySpec.Builder.newInstance()
+                .filter(new Criterion("metadata.%s".formatted(VerifiableCredentialResource.METADATA_CREDENTIAL_OBJECT_ID), "=", "credential-object-1"))
+                .build();
+
+        assertThat(getStore().query(query)).isSucceeded()
+                .satisfies(str -> Assertions.assertThat(str).hasSize(1)
+                        .usingRecursiveFieldByFieldElementComparator()
+                        .containsExactly(expectedCred));
+    }
+
+    @Test
     void query_noQuerySpec() {
         var resources = range(0, 5)
                 .mapToObj(i -> createCredentialBuilder().id("id" + i).build())


### PR DESCRIPTION
## What this PR changes/adds

When a re-issued credential is delivered to the holder, the credential it replaces is now deactivated: `CredentialWriterImpl` looks up earlier holder credentials obtained for the same `CredentialObject` (correlated via the `credentialObjectId` metadata, same format and participant context), moves them to `VcStatus#EXPIRED` and marks them with a `supersededBy` metadata entry pointing at the new credential. This happens inside the existing write transaction.

Two accompanying guards make the deactivation stick:
- `CredentialStatusCheckService` treats a superseded credential as terminally `EXPIRED`, so the watchdog cannot flip it back to `ISSUED` while its validity dates are still in the future (a revocation by the Issuer still wins and moves it to `REVOKED`).
- The `CredentialWatchdog` no longer triggers re-issuance for superseded credentials, which would otherwise loop forever since every delivery expires its predecessor. Credentials that expired *without* a replacement are still renewed, which is why the check inspects the `supersededBy` marker rather than the state field (`EXPIRED` alone cannot distinguish the two cases).

The `"credentialObjectId"` metadata key literal was extracted into a shared constant on `VerifiableCredentialResource`, next to the new `METADATA_SUPERSEDED_BY`.

The all-in-one issuance E2E test was reworked along the way: renewal is now isolated in a dedicated short-lived `RenewalCredential` definition (with a matching renewal grace period), because the previous fixture put every credential of the class permanently inside the renewal window, and the resulting churn started superseding other tests' credentials once this feature was in place. A new E2E test covers pre-emptive re-issuance: a second credential requested well within the validity of the first, asserting that of the two technically valid credentials only the newly delivered one remains usable.

## Why it does that

Upon re-issuance, issuers may revoke the old credential. Deactivating it on the holder side ensures only the freshest credential is used in DCP interactions and prevents presenting a revoked or out-of-date credential.

## Linked Issue(s)

Closes #693