### PR TITLE
chore: add dedicated "Security" section to release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -8,6 +8,11 @@ changelog:
     - title: Breaking changes
       labels:
         - breaking-change
+    # must come before Bugfixes/New Features: PRs land in the first matching
+    # category, and security-relevant PRs usually also carry "bug" or "enhancement"
+    - title: Security
+      labels:
+        - security
     - title: Bugfixes
       labels:
         - bug


### PR DESCRIPTION
## What this PR changes

Adds a dedicated `Security` category to the auto-generated release notes, mapped to the new `security` label (already created in this repo).

The category is placed before `Bugfixes` and `New Features & Improvements` — not just before the catch-all — because GitHub assigns each PR to the *first* category whose labels match, and security-relevant PRs will typically also carry a `bug` or `enhancement` label.

Closes eclipse-edc/Connector#5955

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171VrV7JWP82oQPFQMtwqsJ