### PR TITLE
feat: validate datasource and table in database attestation validator

### DIFF
--- a/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/DatabaseAttestationExtension.java
+++ b/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/DatabaseAttestationExtension.java
@@ -48,6 +48,6 @@ public class DatabaseAttestationExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         registry.registerFactory(DATABASE_ATTESTATION_TYPE, new DatabaseAttestationSourceFactory(transactionContext, queryExecutor, dataSourceRegistry));
-        validatorRegistry.registerValidator(DATABASE_ATTESTATION_TYPE, new DatabaseAttestationSourceValidator());
+        validatorRegistry.registerValidator(DATABASE_ATTESTATION_TYPE, new DatabaseAttestationSourceValidator(dataSourceRegistry, transactionContext, queryExecutor));
     }
 }

--- a/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/database/DatabaseAttestationSource.java
+++ b/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/database/DatabaseAttestationSource.java
@@ -37,6 +37,7 @@ public class DatabaseAttestationSource extends AbstractSqlStore implements Attes
     public static final String TABLE_NAME = "tableName";
     public static final String REQUIRED = "required";
     public static final String ID_COLUMN = "idColumn";
+    public static final String DEFAULT_ID_COLUMN = "holder_id";
     private final boolean required;
     private final TransactionContext transactionContext;
     private final QueryExecutor queryExecutor;

--- a/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/database/DatabaseAttestationSourceFactory.java
+++ b/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/database/DatabaseAttestationSourceFactory.java
@@ -24,6 +24,7 @@ import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
 import org.eclipse.edc.transaction.spi.TransactionContext;
 
 import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.DATASOURCE_NAME;
+import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.DEFAULT_ID_COLUMN;
 import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.ID_COLUMN;
 import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.REQUIRED;
 import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.TABLE_NAME;
@@ -47,7 +48,7 @@ public class DatabaseAttestationSourceFactory implements AttestationSourceFactor
         var required = (Boolean) configuration.getOrDefault(REQUIRED, false);
         var dataSourceName = (String) configuration.get(DATASOURCE_NAME);
         var tableName = (String) configuration.get(TABLE_NAME);
-        var idColumn = (String) configuration.getOrDefault(ID_COLUMN, "holder_id");
+        var idColumn = (String) configuration.getOrDefault(ID_COLUMN, DEFAULT_ID_COLUMN);
 
         return new DatabaseAttestationSource(dataSourceName, required, objectMapper, tableName, dataSourceRegistry, queryExecutor, transactionContext, idColumn);
     }

--- a/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/database/DatabaseAttestationSourceValidator.java
+++ b/extensions/issuance/issuerservice-database-attestations/src/main/java/org/eclipse/edc/issuerservice/issuance/database/DatabaseAttestationSourceValidator.java
@@ -16,21 +16,43 @@ package org.eclipse.edc.issuerservice.issuance.database;
 
 
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.TransactionContext;
 import org.eclipse.edc.validator.spi.ValidationResult;
 import org.eclipse.edc.validator.spi.Validator;
 
+import java.sql.SQLException;
+import javax.sql.DataSource;
+
 import static java.lang.String.format;
 import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.DATASOURCE_NAME;
+import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.DEFAULT_ID_COLUMN;
+import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.ID_COLUMN;
 import static org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSource.TABLE_NAME;
 import static org.eclipse.edc.validator.spi.ValidationResult.failure;
 import static org.eclipse.edc.validator.spi.ValidationResult.success;
 import static org.eclipse.edc.validator.spi.Violation.violation;
 
 /**
- * Validates presentation attestation definitions.
+ * Validates database attestation definitions. In addition to structural checks of the configuration, it verifies that
+ * the configured datasource is registered on the runtime and that the configured table and ID column actually exist,
+ * so that misconfigurations fail at attestation creation time rather than during credential issuance.
  */
 public class DatabaseAttestationSourceValidator implements Validator<AttestationDefinition> {
     private static final String ATTESTATION_TYPE = "database";
+    private static final String PROBE_QUERY_TEMPLATE = "SELECT %s FROM %s WHERE 1 = 0";
+
+    private final DataSourceRegistry dataSourceRegistry;
+    private final TransactionContext transactionContext;
+    private final QueryExecutor queryExecutor;
+
+    public DatabaseAttestationSourceValidator(DataSourceRegistry dataSourceRegistry, TransactionContext transactionContext, QueryExecutor queryExecutor) {
+        this.dataSourceRegistry = dataSourceRegistry;
+        this.transactionContext = transactionContext;
+        this.queryExecutor = queryExecutor;
+    }
 
     @Override
     public ValidationResult validate(AttestationDefinition definition) {
@@ -38,13 +60,35 @@ public class DatabaseAttestationSourceValidator implements Validator<Attestation
             return failure(violation("Expecting attestation type: " + ATTESTATION_TYPE, ATTESTATION_TYPE));
         }
         var config = definition.getConfiguration();
-        if (!config.containsKey(DATASOURCE_NAME)) {
+        if (!(config.get(DATASOURCE_NAME) instanceof String dataSourceName) || dataSourceName.isBlank()) {
             return failure(violation(format("No %s specified", DATASOURCE_NAME), DATASOURCE_NAME));
         }
-        if (!config.containsKey(TABLE_NAME)) {
+        if (!(config.get(TABLE_NAME) instanceof String tableName) || tableName.isBlank()) {
             return failure(violation(format("No %s specified", TABLE_NAME), TABLE_NAME));
         }
+        var idColumn = config.get(ID_COLUMN) instanceof String col && !col.isBlank() ? col : DEFAULT_ID_COLUMN;
 
-        return success();
+        var dataSource = dataSourceRegistry.resolve(dataSourceName);
+        if (dataSource == null) {
+            return failure(violation(format("DataSource '%s' not found. It must be configured on the runtime.", dataSourceName), DATASOURCE_NAME));
+        }
+
+        return verifySchema(dataSource, tableName, idColumn);
+    }
+
+    private ValidationResult verifySchema(DataSource dataSource, String tableName, String idColumn) {
+        try {
+            return transactionContext.execute(() -> {
+                try (var connection = dataSource.getConnection()) {
+                    queryExecutor.single(connection, false, resultSet -> 0, PROBE_QUERY_TEMPLATE.formatted(idColumn, tableName));
+                    return success();
+                } catch (SQLException | EdcPersistenceException e) {
+                    return failure(violation(format("Table '%s' with column '%s' could not be queried on the configured datasource: %s",
+                            tableName, idColumn, e.getMessage()), TABLE_NAME));
+                }
+            });
+        } catch (RuntimeException e) {
+            return failure(violation(format("Could not verify datasource: %s", e.getMessage()), DATASOURCE_NAME));
+        }
     }
 }

--- a/extensions/issuance/issuerservice-database-attestations/src/test/java/org/eclipse/edc/issuerservice/issuance/attestations/database/DatabaseAttestationSourceValidatorPostgresTest.java
+++ b/extensions/issuance/issuerservice-database-attestations/src/test/java/org/eclipse/edc/issuerservice/issuance/attestations/database/DatabaseAttestationSourceValidatorPostgresTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2025 Cofinity-X
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Cofinity-X - initial API and implementation
+ *
+ */
+
+package org.eclipse.edc.issuerservice.issuance.attestations.database;
+
+import org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSourceValidator;
+import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
+import org.eclipse.edc.junit.testfixtures.TestUtils;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.sql.testfixtures.PostgresqlStoreSetupExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+
+@PostgresqlIntegrationTest
+@ExtendWith(PostgresqlStoreSetupExtension.class)
+class DatabaseAttestationSourceValidatorPostgresTest {
+
+    private final String tableName = "membership_attestation";
+    private String dataSourceName;
+    private DatabaseAttestationSourceValidator validator;
+
+    @BeforeEach
+    void setup(PostgresqlStoreSetupExtension extension, QueryExecutor queryExecutor) {
+
+        try (Connection connection = extension.getConnection()) {
+            var sql = TestUtils.getResourceFileContentAsString("test-attestation-table.sql");
+            queryExecutor.execute(connection, sql);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        dataSourceName = extension.getDatasourceName();
+        validator = new DatabaseAttestationSourceValidator(extension.getDataSourceRegistry(),
+                extension.getTransactionContext(),
+                queryExecutor);
+    }
+
+    @AfterEach
+    void tearDown(PostgresqlStoreSetupExtension extension) {
+        extension.runQuery("DROP TABLE %s".formatted(tableName));
+    }
+
+    @Test
+    void validate() {
+        var definition = createDefinition(Map.of("dataSourceName", dataSourceName, "tableName", tableName));
+
+        assertThat(validator.validate(definition)).isSucceeded();
+    }
+
+    @Test
+    void validate_whenTableNotExists() {
+        var definition = createDefinition(Map.of("dataSourceName", dataSourceName, "tableName", "not_exist"));
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("not_exist");
+    }
+
+    @Test
+    void validate_whenIdColumnNotExists() {
+        var definition = createDefinition(Map.of("dataSourceName", dataSourceName,
+                "tableName", tableName,
+                "idColumn", "not_a_column"));
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("not_a_column");
+    }
+
+    @Test
+    void validate_whenDataSourceNotRegistered() {
+        var definition = createDefinition(Map.of("dataSourceName", "unregistered", "tableName", tableName));
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("unregistered");
+    }
+
+    private AttestationDefinition createDefinition(Map<String, Object> configuration) {
+        return AttestationDefinition.Builder.newInstance().id("att1")
+                .attestationType("database")
+                .participantContextId("participantContextId")
+                .configuration(configuration)
+                .build();
+    }
+}

--- a/extensions/issuance/issuerservice-database-attestations/src/test/java/org/eclipse/edc/issuerservice/issuance/attestations/database/DatabaseAttestationSourceValidatorTest.java
+++ b/extensions/issuance/issuerservice-database-attestations/src/test/java/org/eclipse/edc/issuerservice/issuance/attestations/database/DatabaseAttestationSourceValidatorTest.java
@@ -16,58 +16,153 @@ package org.eclipse.edc.issuerservice.issuance.attestations.database;
 
 import org.eclipse.edc.issuerservice.issuance.database.DatabaseAttestationSourceValidator;
 import org.eclipse.edc.issuerservice.spi.issuance.model.AttestationDefinition;
+import org.eclipse.edc.spi.persistence.EdcPersistenceException;
+import org.eclipse.edc.sql.QueryExecutor;
+import org.eclipse.edc.transaction.datasource.spi.DataSourceRegistry;
+import org.eclipse.edc.transaction.spi.NoopTransactionContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
+import javax.sql.DataSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.edc.junit.assertions.AbstractResultAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 class DatabaseAttestationSourceValidatorTest {
 
-    private final DatabaseAttestationSourceValidator validator = new DatabaseAttestationSourceValidator();
+    private final DataSourceRegistry dataSourceRegistry = mock();
+    private final QueryExecutor queryExecutor = mock();
+    private final DataSource dataSource = mock();
+    private final DatabaseAttestationSourceValidator validator =
+            new DatabaseAttestationSourceValidator(dataSourceRegistry, new NoopTransactionContext(), queryExecutor);
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        when(dataSource.getConnection()).thenReturn(mock(Connection.class));
+    }
 
     @Test
     void validate_success() {
-        Map<String, Object> configuration = Map.of("jdbcUrl", "jdbc:postgresql://localhost:5432/postgres",
-                "tableName", "membership_attestations",
-                "dataSourceName", "barbaz");
+        when(dataSourceRegistry.resolve("barbaz")).thenReturn(dataSource);
 
-        var definition = AttestationDefinition.Builder.newInstance().id("att1")
-                .attestationType("database")
-                .participantContextId("participantContextId")
-                .configuration(configuration)
-                .build();
+        var definition = createDefinition(Map.of("jdbcUrl", "jdbc:postgresql://localhost:5432/postgres",
+                "tableName", "membership_attestations",
+                "dataSourceName", "barbaz"));
 
         assertThat(validator.validate(definition)).isSucceeded();
     }
 
+    @Test
+    void validate_wrongAttestationType_shouldFail() {
+        var definition = AttestationDefinition.Builder.newInstance().id("att1")
+                .attestationType("presentation")
+                .participantContextId("participantContextId")
+                .configuration(Map.of("tableName", "membership_attestations", "dataSourceName", "barbaz"))
+                .build();
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("database");
+    }
 
     @Test
     void validate_missingDataSourceName_shouldFail() {
-        Map<String, Object> configuration = Map.of("jdbcUrl", "jdbc:postgresql://localhost:5432/postgres",
-                "tableName", "membership_attestations");
-
-        var definition = AttestationDefinition.Builder.newInstance().id("att1")
-                .attestationType("database")
-                .participantContextId("participantContextId")
-                .configuration(configuration)
-                .build();
+        var definition = createDefinition(Map.of("jdbcUrl", "jdbc:postgresql://localhost:5432/postgres",
+                "tableName", "membership_attestations"));
 
         assertThat(validator.validate(definition)).isFailed().detail().contains("dataSourceName");
     }
 
     @Test
     void validate_missingTableName_shouldFail() {
-        Map<String, Object> configuration = Map.of("jdbcUrl", "jdbc:postgresql://localhost:5432/postgres",
-                "dataSourceName", "foobar");
-        var definition = AttestationDefinition.Builder.newInstance().id("att1")
-                .attestationType("database")
-                .participantContextId("participantContextId")
-                .configuration(configuration)
-                .build();
+        var definition = createDefinition(Map.of("jdbcUrl", "jdbc:postgresql://localhost:5432/postgres",
+                "dataSourceName", "foobar"));
 
         assertThat(validator.validate(definition)).isFailed().detail().contains("tableName");
     }
 
+    @Test
+    void validate_nullTableName_shouldFail() {
+        var configuration = new HashMap<String, Object>();
+        configuration.put("dataSourceName", "foobar");
+        configuration.put("tableName", null);
+
+        assertThat(validator.validate(createDefinition(configuration))).isFailed().detail().contains("tableName");
+    }
+
+    @Test
+    void validate_dataSourceNotRegistered_shouldFail() {
+        when(dataSourceRegistry.resolve(anyString())).thenReturn(null);
+
+        var definition = createDefinition(Map.of("tableName", "membership_attestations", "dataSourceName", "nonexistent"));
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("nonexistent");
+    }
+
+    @Test
+    void validate_tableNotExists_shouldFail() {
+        when(dataSourceRegistry.resolve("barbaz")).thenReturn(dataSource);
+        when(queryExecutor.single(any(), anyBoolean(), any(), anyString()))
+                .thenThrow(new EdcPersistenceException("relation \"not_exist\" does not exist"));
+
+        var definition = createDefinition(Map.of("tableName", "not_exist", "dataSourceName", "barbaz"));
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("not_exist");
+    }
+
+    @Test
+    void validate_connectionFails_shouldFail() throws SQLException {
+        when(dataSourceRegistry.resolve("barbaz")).thenReturn(dataSource);
+        when(dataSource.getConnection()).thenThrow(new SQLException("connection refused"));
+
+        var definition = createDefinition(Map.of("tableName", "membership_attestations", "dataSourceName", "barbaz"));
+
+        assertThat(validator.validate(definition)).isFailed().detail().contains("connection refused");
+    }
+
+    @Test
+    void validate_customIdColumn_isUsedInProbeQuery() {
+        when(dataSourceRegistry.resolve("barbaz")).thenReturn(dataSource);
+
+        var definition = createDefinition(Map.of("tableName", "membership_attestations",
+                "dataSourceName", "barbaz",
+                "idColumn", "custom_id"));
+
+        assertThat(validator.validate(definition)).isSucceeded();
+
+        var queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(queryExecutor).single(any(), anyBoolean(), any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue()).contains("custom_id").contains("membership_attestations");
+    }
+
+    @Test
+    void validate_defaultIdColumn_isUsedInProbeQuery() {
+        when(dataSourceRegistry.resolve("barbaz")).thenReturn(dataSource);
+
+        var definition = createDefinition(Map.of("tableName", "membership_attestations", "dataSourceName", "barbaz"));
+
+        assertThat(validator.validate(definition)).isSucceeded();
+
+        var queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(queryExecutor).single(any(), anyBoolean(), any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue()).contains("holder_id");
+    }
+
+    private AttestationDefinition createDefinition(Map<String, Object> configuration) {
+        return AttestationDefinition.Builder.newInstance().id("att1")
+                .attestationType("database")
+                .participantContextId("participantContextId")
+                .configuration(configuration)
+                .build();
+    }
 }


### PR DESCRIPTION
## What this PR changes/adds

`DatabaseAttestationSourceValidator` now verifies the configured datasource, table and id column when a `database` attestation definition is created, instead of only performing structural checks on the configuration map:

- The datasource name is resolved against the `DataSourceRegistry`; an unregistered datasource produces a validation failure.
- Table and id column existence are verified with a side-effect-free probe query (`SELECT <idColumn> FROM <tableName> WHERE 1 = 0`) on the resolved datasource. The probe deliberately mirrors the identifier semantics of the issuance-time query (lowercase folding, `search_path`, privileges), so validation and issuance cannot disagree. This also covers `idColumn`, which was previously not validated at all.
- The structural checks were tightened from `containsKey` to non-blank-string checks, so a null-valued configuration entry no longer slips through and NPEs later.
- All exceptions from the probe are converted to validation failures, so the Admin API returns HTTP 400, never a 500.

The extension already injected `DataSourceRegistry`, `TransactionContext` and `QueryExecutor` for the source factory; they are now also passed to the validator. The `"holder_id"` default was hoisted into a shared `DEFAULT_ID_COLUMN` constant so validator and factory cannot diverge.

Unit tests were extended accordingly, and a new Postgres integration test (`DatabaseAttestationSourceValidatorPostgresTest`) verifies the behavior against a real database.

Note: a temporarily unreachable database now blocks attestation creation with a 400. This matches the fail-fast intent of the issue, since issuance would fail the same way.

## Why it does that

A misconfigured `database` attestation (nonexistent datasource, table or column) was previously only caught during the credential issuance flow, as a runtime exception. Failing fast at creation time gives the operator immediate, actionable feedback.

## Linked Issue(s)

Closes #850
