### PR TITLE
chore: bump label-checker to v1.6.66

### DIFF
--- a/.github/workflows/scan-pull-request.yaml
+++ b/.github/workflows/scan-pull-request.yaml
@@ -38,7 +38,7 @@ jobs:
     continue-on-error: false
     steps:
       - uses: actions/checkout@v7
-      - uses: agilepathway/label-checker@v1.6.65
+      - uses: agilepathway/label-checker@v1.6.66
         with:
           any_of: api,bug,build,dependencies,documentation,enhancement,no-changelog,refactoring
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What this PR changes/adds

Bumps `agilepathway/label-checker` from v1.6.65 to v1.6.66 in the `scan-pull-request` workflow.

## Why it does that

The action builds its Docker image from source on every run against Debian bullseye. After bullseye LTS ended (2026-08-31), the `bullseye-security` repository's Release file expired and is no longer re-signed, so `apt-get update` inside the image build fails deterministically and the `check-for-assigned-labels` job errors out on every PR event before ever evaluating labels (see e.g. https://github.com/eclipse-edc/IdentityHub/actions/runs/34204179470/job/101991639663). v1.6.66, released today, fixes the image build (agilepathway/label-checker#492).
