### PR TITLE
chore: use reusable scan-pull-request workflow

### DIFF
--- a/.github/workflows/scan-pull-request.yaml
+++ b/.github/workflows/scan-pull-request.yaml
@@ -10,35 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-pull-request-title:
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    steps:
-      - uses: actions/checkout@v7
-      - uses: deepakputhraya/action-pr-title@master
-        with:
-          # Match pull request titles conventional commit syntax (https://www.conventionalcommits.org/en/v1.0.0/)
-          # (online tool for regex quick check: https://regex101.com/r/V5J8kh/1)
-          #
-          # Valid examples would be
-          # - fix: resolve minor issue
-          # - docs(Sample5): update docs for configuration
-          # - feat(management-api)!: change path to access contract agreements
-          #
-          # Invalid examples would be
-          # - Add cool feature
-          # - Feature/some cool improvement
-          # - fix: resolve minor issue.
-          regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(\w+((,|\/|\\)?\s?\w+)+\))?!?: [\S ]{1,80}[^\.]$'
-          allowed_prefixes: 'build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test'
-          prefix_case_sensitive: true
-
-  check-for-assigned-labels:
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    steps:
-      - uses: actions/checkout@v7
-      - uses: agilepathway/label-checker@v1.6.66
-        with:
-          any_of: api,bug,build,dependencies,documentation,enhancement,no-changelog,refactoring
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+  trigger-workflow:
+    uses: eclipse-edc/.github/.github/workflows/scan-pull-request.yml@main
+    secrets:
+      envGH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What this PR changes/adds

Replaces IdentityHub's inline copy of the `scan-pull-request` workflow (PR title check + label check) with a thin wrapper around the reusable workflow from `eclipse-edc/.github`, exactly as Connector already does.

## Why it does that

IdentityHub was one of the few repos carrying its own copy of these checks, so action bumps (such as the recent label-checker fix in #1081 and eclipse-edc/.github#248) had to be applied twice. Delegating to the shared workflow keeps future maintenance in one place. Behavioral note: the shared workflow's accepted label list is a superset of the inline one — it additionally accepts the `security` label.

## Linked Issue(s)

_none_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hZeCWzWwHyt2SwLPGn3zX